### PR TITLE
Move OBS packages

### DIFF
--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -1,13 +1,13 @@
 # Packaging
 
 D-Installer packages are available in the [YaST:Head project in
-OBS](https://build.opensuse.org/project/show/YaST:Head). This document summarizes the process we
-follow to build those packages.
+OBS](https://build.opensuse.org/project/show/YaST:Head:D-Installer). This document summarizes the
+process we follow to build those packages.
 
 ## Service
 
 You can check the current package in
-[YaST:Head/rubygem-d-installer](https://build.opensuse.org/package/show/YaST:Head/rubygem-d-installer).
+[YaST:Head/rubygem-d-installer](https://build.opensuse.org/package/show/YaST:Head:D-Installer/rubygem-d-installer).
 At this point, D-Installer has not been released as a Rubygem yet, so you need to do an extra step.
 
 The process to release a new version can be summarized in these steps:
@@ -26,7 +26,7 @@ in the repository](./yastd/package/gem2rpm.yml). To regenerate the spec, just ty
 ## Web interface
 
 The current package is
-[YaST:Head/d-installer-web](https://build.opensuse.org/package/show/YaST:Head/rubygem-d-installer).
+[YaST:Head/d-installer-web](https://build.opensuse.org/package/show/YaST:Head:D-Installer/rubygem-d-installer).
 You can figure out most details by checking the
 [_service](_./web/package/_service) file. It might happen that you get
 out of RAM when building the package, so in this case, it is better to

--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -1,13 +1,13 @@
 # Packaging
 
-D-Installer packages are available in the [YaST:Head project in
+D-Installer packages are available in the [YaST:Head:D-Installer project in
 OBS](https://build.opensuse.org/project/show/YaST:Head:D-Installer). This document summarizes the
 process we follow to build those packages.
 
 ## Service
 
 You can check the current package in
-[YaST:Head/rubygem-d-installer](https://build.opensuse.org/package/show/YaST:Head:D-Installer/rubygem-d-installer).
+[YaST:Head:D-Installer/rubygem-d-installer](https://build.opensuse.org/package/show/YaST:Head:D-Installer/rubygem-d-installer).
 At this point, D-Installer has not been released as a Rubygem yet, so you need to do an extra step.
 
 The process to release a new version can be summarized in these steps:
@@ -26,7 +26,7 @@ in the repository](./yastd/package/gem2rpm.yml). To regenerate the spec, just ty
 ## Web interface
 
 The current package is
-[YaST:Head/d-installer-web](https://build.opensuse.org/package/show/YaST:Head:D-Installer/rubygem-d-installer).
+[YaST:Head:D-Installer/d-installer-web](https://build.opensuse.org/package/show/YaST:Head:D-Installer/rubygem-d-installer).
 You can figure out most details by checking the
 [_service](_./web/package/_service) file. It might happen that you get
 out of RAM when building the package, so in this case, it is better to

--- a/README.md
+++ b/README.md
@@ -15,9 +15,11 @@ service. At first sight, we have identified these components:
 :warning: :warning: **This is a proof-of-concept so use a virtual machine to give it a try.** :warning: :warning: 
 
 The easiest way to give D-Installer a try is to install the
-[rubygem-d-installer](https://build.opensuse.org/package/show/YaST:Head/rubygem-d-installer) and
-[d-installer-web](https://build.opensuse.org/package/show/YaST:Head/d-installer-web) packages in an
-[openSUSE Tumbleweed Live image](https://get.opensuse.org/tumbleweed).
+[rubygem-d-installer](https://build.opensuse.org/package/show/YaST:Head:D-Installer/rubygem-d-installer)
+and
+[d-installer-web](https://build.opensuse.org/package/show/YaST:Head:D-Installer/d-installer-web)
+packages in an [openSUSE Tumbleweed Live
+image](https://get.opensuse.org/tumbleweed).
 
 You need to perform some additional steps, like starting the Cockpit service or setting a password
 for the "linux" user. However, the repository contains [a script](./deploy.sh) that takes care of

--- a/deploy.sh
+++ b/deploy.sh
@@ -3,7 +3,8 @@
 # This script is supposed to be used in an openSUSE Tumbleweed Live DVD.
 
 sudo rpm --import https://build.opensuse.org/projects/YaST/public_key
-sudo zypper ar -f https://download.opensuse.org/repositories/YaST:/Head/openSUSE_Tumbleweed/YaST:Head.repo
+sudo zypper ar -f \
+  https://download.opensuse.org/repositories/YaST:/Head:/D-Installer/openSUSE_Tumbleweed/YaST:Head:D-Installer.repo
 RUBY_VERSION=ruby:`rpm --eval '%{rb_ver}'`
 sudo zypper --non-interactive in --no-recommends \
   "rubygem($RUBY_VERSION:d-installer)" \

--- a/web/package/d-installer-web.spec
+++ b/web/package/d-installer-web.spec
@@ -52,7 +52,6 @@ cp -R --no-dereference --preserve=mode,links -v dist/* %{buildroot}/%{_datadir}/
 
 %files
 %doc README.md
-#%license LICENSE dist/index.js.LICENSE.txt.gz
 %{_datadir}/cockpit/static/installer
 
 %changelog

--- a/web/package/d-installer-web.spec
+++ b/web/package/d-installer-web.spec
@@ -44,11 +44,11 @@ rm -f package-lock.json
 local-npm-registry %{_sourcedir} install --with=dev --legacy-peer-deps || ( find ~/.npm/_logs -name '*-debug.log' -print0 | xargs -0 cat; false)
 
 %build
-NODE_ENV=production npm run build
+npm run build
 
 %install
 mkdir -p %{buildroot}/%{_datadir}/cockpit/static/installer
-cp -R --no-dereference --preserve=mode,links -v build/* %{buildroot}/%{_datadir}/cockpit/static/installer
+cp -R --no-dereference --preserve=mode,links -v dist/* %{buildroot}/%{_datadir}/cockpit/static/installer
 
 %files
 %doc README.md


### PR DESCRIPTION
* Update references to the OBS packages (they now live in [YaST:Head:D-Installer](https://build.opensuse.org/project/show/YaST:Head:D-Installer)).
* Fix the specfile according to the changes introduced by #32.