### PR TITLE
Fix mount directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Point your browser to http://localhost:3000 and happy hacking!
     cd web
     npm run build
     sudo mkdir /usr/share/cockpit/static/installer
-    sudo mount -o bind build /usr/share/cockpit/static/installer
+    sudo mount -o bind dist /usr/share/cockpit/static/installer
 
 Point your browser to http://localhost:9090/cockpit/static/installer/index.html and enjoy!
 


### PR DESCRIPTION
Signed-off-by: Georg Pfuetzenreuter <mail@georg-pfuetzenreuter.net>

Hi,

`npm run build` outputs to the `dist` directory by default:

```
georg@localhost:~/d-installer/web> ls                                                                                                             
babel.config.js  index.html  jest.config.js  node_modules  package  package.json  package-lock.json  public  README.md  src  vite.config.js
georg@localhost:~/d-installer/web> npm run build
<imagine lots of output>
georg@localhost:~/d-installer/web> sudo mkdir /usr/share/cockpit/static/installer
georg@localhost:~/d-installer/web> sudo mount -o bind build /usr/share/cockpit/static/installer                                                   
mount: /usr/share/cockpit/static/installer: special device build does not exist.
georg@localhost:~/d-installer/web> ls                                                                                                             
babel.config.js  dist  index.html  jest.config.js  node_modules  package  package.json  package-lock.json  public  README.md  src  vite.config.js 
georg@localhost:~/d-installer/web> ls dist/                                                                                                       
assets  favicon.ico  index.html  logo192.png  logo512.png  manifest.json  robots.txt                                                              
georg@localhost:~/d-installer/web> sudo mount -o bind dist /usr/share/cockpit/static/installer                                                    
georg@localhost:~/d-installer/web> ls /usr/share/cockpit/static/installer/                                                                        
assets  favicon.ico  index.html  logo192.png  logo512.png  manifest.json  robots.txt
```

Best,
Georg