### PR TITLE
Copy network configuration to the installed system

### DIFF
--- a/yastd/lib/yast2/installation_progress.rb
+++ b/yastd/lib/yast2/installation_progress.rb
@@ -23,7 +23,7 @@
 module Yast2
   # This class represents the installer status
   class InstallationProgress
-    KNOWN_STEPS = 3 # keep it in sync with installer.rb
+    KNOWN_STEPS = 4 # keep it in sync with installer.rb
     def initialize(dbus_obj, logger: nil)
       @dbus_obj = dbus_obj
       @logger = logger
@@ -55,15 +55,27 @@ module Yast2
       )
     end
 
-    def bootloader_installation(&block)
+    def network_installation(&block)
       report(
         # TODO: localization
-        "Starting to deploy bootloader", 2
+        "Writing network configuration", 2
       )
       block.call(self)
       report(
         # TODO: localization
-        "Installation finished", 3
+        "Writing network configuration finished", 3
+      )
+    end
+
+    def bootloader_installation(&block)
+      report(
+        # TODO: localization
+        "Starting to deploy bootloader", 3
+      )
+      block.call(self)
+      report(
+        # TODO: localization
+        "Installation finished", 4
       )
     end
 

--- a/yastd/lib/yast2/installer.rb
+++ b/yastd/lib/yast2/installer.rb
@@ -108,8 +108,8 @@ module Yast2
       change_status(InstallerStatus::PROBING)
       probe_languages
       probe_storage
-      probe_network
       @software.probe
+      probe_network
       true
     rescue StandardError => e
       logger.error "Probing error: #{e.inspect}"

--- a/yastd/lib/yast2/installer.rb
+++ b/yastd/lib/yast2/installer.rb
@@ -161,13 +161,15 @@ module Yast2
         @software.install(progr)
       end
 
+      # Network & Bootloader needs to be chrooted
+      handle = Yast::WFM.SCROpen("chroot=#{Yast::Installation.destdir}:scr", false)
+      Yast::WFM.SCRSetDefault(handle)
+
       progress.network_installation do |progr|
         Yast::WFM.CallFunction("save_network", [])
       end
 
       progress.bootloader_installation do |_|
-        handle = Yast::WFM.SCROpen("chroot=#{Yast::Installation.destdir}:scr", false)
-        Yast::WFM.SCRSetDefault(handle)
         ::Bootloader::FinishClient.new.write
       end
       change_status(InstallerStatus::IDLE)

--- a/yastd/lib/yast2/installer.rb
+++ b/yastd/lib/yast2/installer.rb
@@ -25,6 +25,7 @@ require "y2storage"
 require "yast2/installer_status"
 require "yast2/software"
 require "yast2/installation_progress"
+require "y2network/proposal_settings"
 require "bootloader/proposal_client"
 require "bootloader/finish_client"
 require "dbus"
@@ -215,6 +216,9 @@ module Yast2
       logger.info "Probing network"
       Yast.import "Lan"
       Yast::Lan.read_config
+      settings = Y2Network::ProposalSettings.instance
+      settings.refresh_packages
+      settings.apply_defaults
     end
 
     # @return [Boolean] true if success; false if failed

--- a/yastd/lib/yast2/installer.rb
+++ b/yastd/lib/yast2/installer.rb
@@ -98,6 +98,7 @@ module Yast2
     #
     # * Software management
     # * Simplified storage probing
+    # * Network configuration
     #
     # The initialization of these subsystems should probably live in a different place.
     #
@@ -106,6 +107,7 @@ module Yast2
       change_status(InstallerStatus::PROBING)
       probe_languages
       probe_storage
+      probe_network
       @software.probe
       true
     rescue StandardError => e
@@ -207,6 +209,12 @@ module Yast2
       storage_manager.probe
       @disks = storage_manager.probed.disks
       self.disk = @disks.first&.name
+    end
+
+    def probe_network
+      logger.info "Probing network"
+      Yast.import "Lan"
+      Yast::Lan.read_config
     end
 
     # @return [Boolean] true if success; false if failed

--- a/yastd/lib/yast2/installer.rb
+++ b/yastd/lib/yast2/installer.rb
@@ -157,6 +157,11 @@ module Yast2
         Yast::WFM.CallFunction("inst_bootloader", [])
         @software.install(progr)
       end
+
+      progress.network_installation do |progr|
+        Yast::WFM.CallFunction("save_network", [])
+      end
+
       progress.bootloader_installation do |_|
         handle = Yast::WFM.SCROpen("chroot=#{Yast::Installation.destdir}:scr", false)
         Yast::WFM.SCRSetDefault(handle)


### PR DESCRIPTION
Added support for copying the network configuration to the installed system.

- https://trello.com/c/xPThihCG/2816-2-d-installer-basic-network-set-up

![Screenshot_opensusetumbleweed_2022-03-03_13:23:59](https://user-images.githubusercontent.com/7056681/156573413-553fc485-7e8a-4b30-bdc4-ddc7071ace03.png)
