### PR TITLE
Handle language selection

### DIFF
--- a/service/lib/dinstaller/dbus/language.rb
+++ b/service/lib/dinstaller/dbus/language.rb
@@ -20,6 +20,7 @@
 # find current contact information at www.suse.com.
 
 require "dbus"
+require "dinstaller/language"
 
 module DInstaller
   module DBus
@@ -34,8 +35,7 @@ module DInstaller
       private_constant :LANGUAGE_INTERFACE
 
       # @param installer [Yast2::Installer] YaST installer instance
-      def initialize(installer, logger)
-        @installer = installer
+      def initialize(logger)
         @logger = logger
 
         super(PATH)
@@ -58,24 +58,28 @@ module DInstaller
       end
 
       def available_languages
-        @available_languages ||= installer.languages.map { |k, v| [k, v.first, {}] }
+        @available_languages ||= backend.languages.map { |k, v| [k, v.first, {}] }
       end
 
       def marked_for_install
         # TODO: change when installer support multiple target languages
-        res = [installer.language]
+        res = [backend.language]
         logger.info "MarkedForInstall #{res}"
         res
       end
 
       def select_to_install(lang_ids)
         # TODO: adapt installer API to allow more languages to install
-        installer.language = lang_ids.first
+        backend.language = lang_ids.first
       end
 
     private
 
-      attr_reader :installer, :logger
+      attr_reader :logger
+
+      def backend
+        @backend ||= ::DInstaller::Language.instance.tap { |i| i.logger = @logger }
+      end
     end
   end
 end

--- a/service/lib/dinstaller/dbus/service.rb
+++ b/service/lib/dinstaller/dbus/service.rb
@@ -77,7 +77,7 @@ module DInstaller
       end
 
       def language_dbus
-        @language_dbus ||= DInstaller::DBus::Language.new(installer, @logger)
+        @language_dbus ||= DInstaller::DBus::Language.new(@logger)
       end
 
       def software_dbus

--- a/service/lib/dinstaller/errors.rb
+++ b/service/lib/dinstaller/errors.rb
@@ -1,0 +1,26 @@
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+module DInstaller
+  # Module containing common errors
+  module Errors
+    # Invalid value given by the user
+    class InvalidValue < StandardError; end
+  end
+end

--- a/service/lib/dinstaller/language.rb
+++ b/service/lib/dinstaller/language.rb
@@ -42,6 +42,7 @@ module DInstaller
       raise Errors::InvalidValue unless languages.include?(name)
 
       Yast::Language.Set(name)
+      Yast::Language.PackagesInit([name])
     end
 
     def language

--- a/service/lib/dinstaller/language.rb
+++ b/service/lib/dinstaller/language.rb
@@ -1,0 +1,51 @@
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "singleton"
+require "yast"
+require "dinstaller/errors"
+
+Yast.import "Language"
+
+module DInstaller
+  # Backend for handling language settings
+  class Language
+    include Singleton
+
+    attr_writer :logger
+
+    def logger
+      @logger || Logger.new($stdout)
+    end
+
+    def languages
+      Yast::Language.GetLanguagesMap(true)
+    end
+
+    def language=(name)
+      raise Errors::InvalidValue unless languages.include?(name)
+
+      Yast::Language.Set(name)
+    end
+
+    def language
+      Yast::Language.language
+    end
+  end
+end

--- a/service/lib/dinstaller/manager.rb
+++ b/service/lib/dinstaller/manager.rb
@@ -46,15 +46,10 @@ module DInstaller
     extend Forwardable
 
     # TODO: move to own module classes
-    DEFAULT_LANGUAGE = "en_US"
-
-    # TODO: move to own module classes
     attr_reader :disks, :languages
     # TODO: move to own module classes
     attr_reader :disk
     attr_reader :logger
-    # TODO: move to own module classes
-    attr_reader :language
 
     # TODO: software should use directly software module for getting and settings products
     def_delegators :@software, :products, :product
@@ -68,7 +63,7 @@ module DInstaller
     attr_reader :progress
 
     def options
-      { "disk" => disk, "product" => product, "language" => language }
+      { "disk" => disk, "product" => product }
     end
 
     # Starts the probing process
@@ -84,7 +79,6 @@ module DInstaller
         sleep(1) # do sleep to ensure that dbus service is already attached
         change_status(InstallerStatus::PROBING)
         progress.init_progress(3, "Probing Languages")
-        probe_languages
         progress.next_step("Probing Storage")
         probe_storage
         progress.next_step("Probing Software")
@@ -112,12 +106,6 @@ module DInstaller
       @software.select_product(name)
     rescue StandardError
       raise InvalidValue
-    end
-
-    def language=(name)
-      raise InvalidValue unless languages.include?(name)
-
-      @language = name
     end
 
     def storage_proposal
@@ -155,16 +143,6 @@ module DInstaller
     def change_status(new_status)
       @status = new_status
       @status_callbacks.each(&:call)
-    end
-
-    # Returns the list of known languages
-    #
-    # @return [Hash]
-    def probe_languages
-      logger.info "Probing languages"
-      Yast.import "Language"
-      @languages = Yast::Language.GetLanguagesMap(true)
-      self.language = DEFAULT_LANGUAGE
     end
 
     def probe_storage

--- a/web/src/LanguageSelector.jsx
+++ b/web/src/LanguageSelector.jsx
@@ -52,7 +52,7 @@ export default function LanguageSelector() {
 
   useEffect(async () => {
     const languages = await client.getLanguages();
-    const current = await client.getOption("Language");
+    const [current] = await client.getSelectedLanguages();
     dispatch({
       type: "LOAD",
       payload: { languages, current, initial: current }
@@ -65,7 +65,7 @@ export default function LanguageSelector() {
 
   const accept = async () => {
     // TODO: handle errors
-    await client.setOption("Language", language);
+    await client.setLanguages([language]);
     dispatch({ type: "ACCEPT" });
   };
 

--- a/web/src/LanguageSelector.test.jsx
+++ b/web/src/LanguageSelector.test.jsx
@@ -14,7 +14,7 @@ const languages = [
 
 const clientMock = {
   getLanguages: () => Promise.resolve(languages),
-  getOption: () => Promise.resolve("en_US")
+  getSelectedLanguages: () => Promise.resolve(["en_US"])
 };
 
 beforeEach(() => {
@@ -27,15 +27,15 @@ it("displays the proposal", async () => {
 });
 
 describe("when the user changes the language", () => {
-  let setOptionFn;
+  let setLanguagesFn;
 
   beforeEach(() => {
     // if defined outside, the mock is cleared automatically
-    setOptionFn = jest.fn().mockResolvedValue();
+    setLanguagesFn = jest.fn().mockResolvedValue();
     InstallerClient.mockImplementation(() => {
       return {
         ...clientMock,
-        setOption: setOptionFn
+        setLanguages: setLanguagesFn
       };
     });
   });
@@ -50,6 +50,6 @@ describe("when the user changes the language", () => {
     userEvent.click(screen.getByRole("button", { name: "Confirm" }));
 
     await screen.findByRole("button", { name: "German" });
-    expect(setOptionFn).toHaveBeenCalledWith("Language", "de_DE");
+    expect(setLanguagesFn).toHaveBeenCalledWith(["de_DE"]);
   });
 });

--- a/web/src/lib/InstallerClient.test.js
+++ b/web/src/lib/InstallerClient.test.js
@@ -8,9 +8,9 @@ const cockpitModule = {
 
 const DBUS_PATH = "/org/opensuse/YaST/Installer";
 const DBUS_IFACE = "org.opensuse.YaST.Installer";
+const LANGUAGE_IFACE = "org.opensuse.DInstaller.Language1";
 
 const products = [{ name: "MicroOS", display_name: "openSUSE MicroOS" }];
-const languages = { cs_CZ: ["Cestina", "Cestina", ".UTF-8", "", "Checo"] };
 const disks = [{ name: "/dev/sda", model: "Some Brand", size: "0.5TiB" }];
 const proposal = [
   { mount: "/", device: "/dev/sdb2", type: "btrfs", size: "117354528768" }
@@ -19,14 +19,29 @@ const proposal = [
 const methodResponses = {
   GetStatus: 0,
   GetProducts: products,
-  GetLanguages: languages,
   GetDisks: disks,
   GetStorage: proposal
 };
 
 let dbusClient = {};
+let langProxy = {
+  wait: jest.fn(),
+  AvailableLanguages: [
+    { 
+      t: "av",
+      v: [ { t: "s", v: "cs_CZ" }, { t: "s", v: "Cestina" }, { t: "a{sv}", v: {} } ]
+    }
+  ]
+};
+
+const proxies = {
+  [LANGUAGE_IFACE]: langProxy
+}
 
 beforeEach(() => {
+  dbusClient.proxy = jest.fn().mockImplementation((iface, _path, _opts) => {
+    return proxies[iface];
+  });
   dbusClient.call = jest.fn().mockImplementation((path, iface, method) => {
     if (path !== DBUS_PATH || iface !== DBUS_IFACE) {
       return Promise.reject();


### PR DESCRIPTION
This PR is still a WIP.

## Tasks

- [x] Adapt the InstallerClient to the new Language API.
- [x] Create a `Language` backend similar to the `Users` backend.
- [x] Select packages for the chosen language.
- [ ] Write the language settings at the end of the installation
- [ ] Place the probing logic in a `#probe` method.
- [x] Adapt tests and make RuboCop happy.