### PR TITLE
Set up proposed layout

### DIFF
--- a/web/src/Category.jsx
+++ b/web/src/Category.jsx
@@ -4,30 +4,34 @@ import {
   CardBody,
   Split,
   SplitItem,
+  Stack,
+  StackItem,
   Text,
   TextContent,
   TextVariants
 } from "@patternfly/react-core";
 
-export default function Category({ icon, title, children, ...rest }) {
+export default function Category({ icon, title, children }) {
   // FIXME: improve how icons are managed
   const Icon = icon;
 
   return (
-    <Card {...rest}>
-      <CardBody>
-        <Split>
-          <SplitItem>
-            <Icon size="48" />
-          </SplitItem>
-          <SplitItem>
+    <Split hasGutter>
+      <SplitItem>
+        <Icon size="32" />
+      </SplitItem>
+      <SplitItem>
+        <Stack>
+          <StackItem>
             <TextContent>
               <Text component={TextVariants.h2}>{title}</Text>
             </TextContent>
+          </StackItem>
+          <StackItem>
             {children}
-          </SplitItem>
-        </Split>
-      </CardBody>
-    </Card>
+          </StackItem>
+        </Stack>
+      </SplitItem>
+    </Split>
   );
 }

--- a/web/src/Category.jsx
+++ b/web/src/Category.jsx
@@ -20,7 +20,7 @@ export default function Category({ icon, title, children }) {
       <SplitItem>
         <Icon size="32" />
       </SplitItem>
-      <SplitItem>
+      <SplitItem isFilled>
         <Stack>
           <StackItem>
             <TextContent>

--- a/web/src/InstallationProgress.jsx
+++ b/web/src/InstallationProgress.jsx
@@ -24,6 +24,7 @@ import { useInstallerClient } from "./context/installer";
 
 import {
   Alert,
+  Bullseye,
   Button,
   Progress,
   Stack,
@@ -96,13 +97,15 @@ function InstallationProgress() {
       FooterMessages={Messages}
       FooterActions={Actions}
     >
-      <Stack hasGutter>
-        <StackItem>
-          <Progress title="Overall progress" value={percentage} />
-        </StackItem>
+      <Bullseye className="layout__content-child--filling-block-size">
+        <Stack hasGutter className="pf-u-w-100">
+          <StackItem>
+            <Progress title="Overall progress" value={percentage} />
+          </StackItem>
 
-        { renderSubprogress() }
-      </Stack>
+          { renderSubprogress() }
+        </Stack>
+      </Bullseye>
     </Layout>
   );
 }

--- a/web/src/InstallationProgress.jsx
+++ b/web/src/InstallationProgress.jsx
@@ -22,9 +22,20 @@
 import React, { useState, useEffect } from "react";
 import { useInstallerClient } from "./context/installer";
 
-import { EOS_DOWNLOADING as ProgressIcon } from "eos-icons-react";
+import {
+  Alert,
+  Button,
+  Progress,
+  Stack,
+  StackItem
+} from "@patternfly/react-core";
+
+import Layout from "./Layout";
 import Category from "./Category";
-import { Progress, Stack, StackItem } from "@patternfly/react-core";
+
+import {
+  EOS_DOWNLOADING as ProgressIcon
+} from "eos-icons-react";
 
 function InstallationProgress() {
   const client = useInstallerClient();
@@ -44,20 +55,55 @@ function InstallationProgress() {
       ? 0
       : Math.round((progress.step / progress.steps) * 100);
 
-  return (
-    <Stack hasGutter>
+  // FIXME: this is an example. Update or drop it.
+  const Messages = () => {
+    return (
+      <Alert variant="info" isInline isPlain title="Did you know?">
+        You can <a href='#'>read the release notes</a> while the system is being installed.
+      </Alert>
+    );
+  }
+
+  // FIXME: this is an example. Update or drop it.
+  const Actions = () => {
+    return (
+      <Button
+        isDisabled
+        onClick={() => console.log("User want to see the summary!") }
+      >
+        Reboot system
+      </Button>
+    );
+  }
+
+  const renderSubprogress = () => {
+    if (!showSubsteps) return;
+
+    return (
       <StackItem>
-        <Category title="Progress" icon={ProgressIcon}>
-          <Progress title="Installing" value={percentage} />
-          {showSubsteps && (
-            <Progress
-              title={progress.title}
-              value={Math.round((progress.substep / progress.substeps) * 100)}
-            />
-          )}
-        </Category>
+        <Progress
+          title={progress.title}
+          value={Math.round((progress.substep / progress.substeps) * 100)}
+        />
       </StackItem>
-    </Stack>
+    );
+  }
+
+  return (
+    <Layout
+      sectionTitle="Installing"
+      SectionIcon={ProgressIcon}
+      FooterMessages={Messages}
+      FooterActions={Actions}
+    >
+      <Stack hasGutter>
+        <StackItem>
+          <Progress title="Overall progress" value={percentage} />
+        </StackItem>
+
+        { renderSubprogress() }
+      </Stack>
+    </Layout>
   );
 }
 

--- a/web/src/Layout.jsx
+++ b/web/src/Layout.jsx
@@ -48,33 +48,48 @@ import {
  * @param {React.ReactNode} [props.children] - the section content
  *
  */
-function Layout({ sectionTitle, SectionIcon, FooterMessages, FooterActions, children }) {
+function Layout({ sectionTitle, SectionIcon, FooterMessages, FooterActions, children: sectionContent }) {
   const responsiveWidthRules = "pf-u-w-75-on-md pf-u-w-66-on-lg pf-u-w-50-on-xl pf-u-w-33-on-2xl"
   const className = `layout ${responsiveWidthRules}`
 
   // FIXME: by now, it is here only for illustrating a possible app/section menu
-  const renderHeaderLeftAction = () => <MenuIcon className="layout__header__action-icon" />
+  const renderHeaderLeftAction = () => {
+    // if (!SectionAction)
+    if (!MenuIcon) return null;
 
-  const renderSectionTitle = () => {
     return (
-      <h1>
-        <SectionIcon className="layout__header__section-title-icon" />
-        { sectionTitle }
-      </h1>
+      <div className="layout__header__left-action">
+        <MenuIcon className="layout__header__action-icon" />
+      </div>
+    );
+  }
+
+  const renderHeader = () => {
+    return (
+      <div className="layout__header">
+        { renderHeaderLeftAction () }
+
+        <div className="layout__header__section-title">
+          <h1>
+            { SectionIcon && <SectionIcon className="layout__header__section-title-icon" /> }
+            { sectionTitle }
+          </h1>
+        </div>
+      </div>
     );
   }
 
   const renderFooter = () => {
-    if(!FooterActions) return null;
+    if (!FooterActions && !FooterMessages) return null;
 
     return (
       <div className="layout__footer">
         <div className="layout__footer-info-area">
-          <FooterMessages />
+          { FooterMessages && <FooterMessages /> }
         </div>
 
         <div className="layout__footer-actions-area">
-          <FooterActions />
+          { FooterActions && <FooterActions /> }
         </div>
       </div>
     );
@@ -82,18 +97,10 @@ function Layout({ sectionTitle, SectionIcon, FooterMessages, FooterActions, chil
 
   return (
     <div className={className}>
-      <div className="layout__header">
-        <div className="layout__header__left-action">
-          { renderHeaderLeftAction () }
-        </div>
-
-        <div className="layout__header__section-title">
-          { renderSectionTitle() }
-        </div>
-      </div>
+      { renderHeader() }
 
       <main className="layout__content">
-        { children }
+        { sectionContent }
       </main>
 
       { renderFooter() }

--- a/web/src/Layout.jsx
+++ b/web/src/Layout.jsx
@@ -49,7 +49,7 @@ import {
  *
  */
 function Layout({ sectionTitle, SectionIcon, FooterMessages, FooterActions, children: sectionContent }) {
-  const responsiveWidthRules = "pf-u-w-75-on-md pf-u-w-66-on-lg pf-u-w-50-on-xl pf-u-w-33-on-2xl"
+  const responsiveWidthRules = "pf-u-w-66-on-lg pf-u-w-50-on-xl pf-u-w-33-on-2xl"
   const className = `layout ${responsiveWidthRules}`
 
   // FIXME: by now, it is here only for illustrating a possible app/section menu

--- a/web/src/Layout.jsx
+++ b/web/src/Layout.jsx
@@ -58,8 +58,8 @@ function Layout({ sectionTitle, SectionIcon, FooterMessages, FooterActions, chil
     if (!MenuIcon) return null;
 
     return (
-      <div className="layout__header__left-action">
-        <MenuIcon className="layout__header__action-icon" />
+      <div className="layout__header-left-action">
+        <MenuIcon className="layout__header-action-icon" />
       </div>
     );
   }
@@ -69,9 +69,9 @@ function Layout({ sectionTitle, SectionIcon, FooterMessages, FooterActions, chil
       <div className="layout__header">
         { renderHeaderLeftAction () }
 
-        <div className="layout__header__section-title">
+        <div className="layout__header-section-title">
           <h1>
-            { SectionIcon && <SectionIcon className="layout__header__section-title-icon" /> }
+            { SectionIcon && <SectionIcon className="layout__header-section-title-icon" /> }
             { sectionTitle }
           </h1>
         </div>

--- a/web/src/Layout.jsx
+++ b/web/src/Layout.jsx
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) [2022] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from "react";
+
+import {
+  EOS_MENU as MenuIcon
+} from "eos-icons-react";
+
+/**
+ * D-Installer main layout component.
+ *
+ * It displays the content in a single vertical responsive column with sticky
+ * header and fixed footer.
+ *
+ * @example
+ *   <Layout
+ *     sectionTitle="Software"
+ *     SectionIcon={SoftwareSectionIcon}
+ *     FooterActions={SoftwareSectionActions}
+ *   >
+ *     <SoftwareSection />
+ *   </Layout>
+ *
+ * @param {object} props - component props
+ * @param {string} [props.sectionTitle] - the section title in the header
+ * @param {React.ReactNode} [props.SectionIcon] - the section icon in the header
+ * @param {React.ReactNode} [props.FooterMessages] - messages to be  shown in the footer
+ * @param {React.ReactNode} [props.FooterActions] - actions shown in the footer
+ * @param {React.ReactNode} [props.children] - the section content
+ *
+ */
+function Layout({ sectionTitle, SectionIcon, FooterMessages, FooterActions, children }) {
+  const responsiveWidthRules = "pf-u-w-75-on-md pf-u-w-66-on-lg pf-u-w-50-on-xl pf-u-w-33-on-2xl"
+  const className = `layout ${responsiveWidthRules}`
+
+  // FIXME: by now, it is here only for illustrating a possible app/section menu
+  const renderHeaderLeftAction = () => <MenuIcon className="layout__header__action-icon" />
+
+  const renderSectionTitle = () => {
+    return (
+      <h1>
+        <SectionIcon className="layout__header__section-title-icon" />
+        { sectionTitle }
+      </h1>
+    );
+  }
+
+  const renderFooter = () => {
+    if(!FooterActions) return null;
+
+    return (
+      <div className="layout__footer">
+        <div className="layout__footer-info-area">
+          <FooterMessages />
+        </div>
+
+        <div className="layout__footer-actions-area">
+          <FooterActions />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={className}>
+      <div className="layout__header">
+        <div className="layout__header__left-action">
+          { renderHeaderLeftAction () }
+        </div>
+
+        <div className="layout__header__section-title">
+          { renderSectionTitle() }
+        </div>
+      </div>
+
+      <main className="layout__content">
+        { children }
+      </main>
+
+      { renderFooter() }
+    </div>
+  );
+}
+
+export default Layout;

--- a/web/src/LoginForm.jsx
+++ b/web/src/LoginForm.jsx
@@ -31,8 +31,12 @@ import {
   TextInput,
   TextContent,
   Text,
-  TextVariants
+  TextVariants,
+  Flex,
+  FlexItem
 } from "@patternfly/react-core";
+
+import Layout from "./Layout";
 
 const formError = error => (
   <FormAlert>
@@ -56,28 +60,30 @@ function LoginForm() {
   };
 
   return (
-    <Bullseye>
-      <Form>
-        <TextContent>
-          <Text component={TextVariants.h1}>Welcome to D-Installer</Text>
-        </TextContent>
-        {error && formError(error)}
-        <FormGroup label="Username" fieldId="username">
-          <TextInput isRequired type="text" id="username" ref={usernameRef} />
-        </FormGroup>
-        <FormGroup label="Password" fieldId="password">
-          <TextInput
-            isRequired
-            type="password"
-            id="password"
-            ref={passwordRef}
-          />
-        </FormGroup>
-        <Button variant="primary" onClick={submitLogin}>
-          Login
-        </Button>
-      </Form>
-    </Bullseye>
+    <Layout>
+      <Bullseye>
+        <Form>
+          <TextContent>
+            <Text component={TextVariants.h1}>Welcome to D-Installer</Text>
+          </TextContent>
+          {error && formError(error)}
+          <FormGroup label="Username" fieldId="username">
+            <TextInput isRequired type="text" id="username" ref={usernameRef} />
+          </FormGroup>
+          <FormGroup label="Password" fieldId="password">
+            <TextInput
+              isRequired
+              type="password"
+              id="password"
+              ref={passwordRef}
+            />
+          </FormGroup>
+          <Button variant="primary" onClick={submitLogin}>
+            Login
+          </Button>
+        </Form>
+      </Bullseye>
+    </Layout>
   );
 }
 

--- a/web/src/Overview.jsx
+++ b/web/src/Overview.jsx
@@ -23,20 +23,20 @@ import React from "react";
 import { useInstallerClient } from "./context/installer";
 
 import {
+  Alert,
   Button,
-  Stack,
-  StackItem,
-  Text,
-  TextContent,
-  TextVariants
+  Flex,
+  FlexItem,
 } from "@patternfly/react-core";
 
+import Layout from "./Layout";
 import Category from "./Category";
 import LanguageSelector from "./LanguageSelector";
 import ProductSelector from "./ProductSelector";
 import Storage from "./Storage";
 
 import {
+  EOS_FACT_CHECK as OverviewIcon,
   EOS_TRANSLATE as LanguagesSelectionIcon,
   EOS_VOLUME as HardDriveIcon,
   EOS_PACKAGES as ProductsIcon
@@ -45,34 +45,22 @@ import {
 function Overview() {
   const client = useInstallerClient();
 
-  return (
-    <>
-      <Stack hasGutter>
-        <StackItem>
-          <TextContent>
-            <Text component={TextVariants.h1}>Installation Overview</Text>
-          </TextContent>
-        </StackItem>
+  const categories = [
+    <Category title="Language" icon={LanguagesSelectionIcon}>
+      <LanguageSelector />
+    </Category>,
+    <Category title="Product" icon={ProductsIcon}>
+      <ProductSelector />
+    </Category>,
+    <Category title="Target" icon={HardDriveIcon}>
+      <Storage />
+    </Category>
+  ];
 
-        <StackItem>
-          <Category title="Language" icon={LanguagesSelectionIcon}>
-            <LanguageSelector />
-          </Category>
-        </StackItem>
-
-        <StackItem>
-          <Category title="Target" icon={HardDriveIcon}>
-            <Storage />
-          </Category>
-        </StackItem>
-
-        <StackItem>
-          <Category title="Product" icon={ProductsIcon}>
-            <ProductSelector />
-          </Category>
-        </StackItem>
-
-        <StackItem>
+  const InstallButton = () => {
+    return (
+      <Flex justifyContent={{ default: 'justifyContentFlexEnd' }}>
+        <FlexItem>
           <Button
             isLarge
             variant="primary"
@@ -80,9 +68,37 @@ function Overview() {
           >
             Install
           </Button>
-        </StackItem>
-      </Stack>
-    </>
+        </FlexItem>
+      </Flex>
+    );
+  }
+
+  const OverviewWarnings = () => {
+    // FIXME: this is just an example... drop it or use real messaages/warnings if needed
+    const text = "This area is always on top, some important information or even warnings can be shown here."
+
+    return <Alert isInline isPlain title={text} />;
+  }
+
+  const renderCategories = () => {
+    return categories.map(category => (
+      <FlexItem key={category.props.title} className="installation-overview-section" >
+        {category}
+      </FlexItem>
+    ));
+  };
+
+  return (
+    <Layout
+      sectionTitle="Installation Summary"
+      SectionIcon={OverviewIcon}
+      FooterActions={InstallButton}
+      FooterMessages={OverviewWarnings}
+    >
+      <Flex direction={{ default: "column" }}>
+        { renderCategories() }
+      </Flex>
+    </Layout>
   );
 }
 

--- a/web/src/Overview.test.jsx
+++ b/web/src/Overview.test.jsx
@@ -37,7 +37,7 @@ beforeEach(() => {
 
 test("renders the Overview", async () => {
   installerRender(<Overview />);
-  const title = screen.getByText(/Installation Overview/i);
+  const title = screen.getByText(/Installation Summary/i);
   expect(title).toBeInTheDocument();
 
   await screen.findByText("English");

--- a/web/src/Proposal.jsx
+++ b/web/src/Proposal.jsx
@@ -16,10 +16,10 @@ const Proposal = ({ data = [] }) => {
     return data.map(p => {
       return (
         <Tr key={p.mount}>
-          <Td>{p.mount}</Td>
-          <Td>{p.type}</Td>
-          <Td>{p.device}</Td>
-          <Td>{filesize(p.size)}</Td>
+          <Td dataLabel="Mount Point">{p.mount}</Td>
+          <Td dataLabel="Type">{p.type}</Td>
+          <Td dataLabel="Device">{p.device}</Td>
+          <Td dataLabel="Size">{filesize(p.size)}</Td>
         </Tr>
       );
     });

--- a/web/src/app.scss
+++ b/web/src/app.scss
@@ -24,17 +24,47 @@
   --pf-global--BackgroundColor--dark-100: #{branding.$eos-bc-pine-500};
 }
 
+body {
+  text-align: start;
+}
+
 #root {
-  min-height: 100vh;
+  min-block-size: 100vh;
   background-color: branding.$eos-bc-gray-50;
 }
 
 .installation-overview-section {
-  border-bottom: 1px solid branding.$eos-bc-gray-100;
-  padding-bottom: 1rem;
+  border-block-end: 1px solid branding.$eos-bc-gray-100;
+  padding-block-end: 1rem;
 
   &:last-child {
-    border-bottom: none;
+    border-block-end: none;
+  }
+
+  // FIXME: look for a better approach about this.
+  // It overrides inline paddings for "button links" since using "isInline" prop
+  // is not an option becaue it removes block margins too.
+  .pf-m-link {
+    padding-inline: 0;
   }
 }
+
+// PatternFly overrides for using CSS Logical Properties
+
+.pf-l-split.pf-m-gutter > :not(:last-child) {
+  margin-inline-end: var(--pf-l-split--m-gutter--MarginRight);
+}
+
+.pf-l-flex.pf-m-column > * {
+  margin: 0;
+  margin-block-end: var(--pf-l-flex--spacer);
+}
+
+.pf-c-alert__icon {
+  margin-block-start: var(--pf-c-alert__icon--MarginTop);
+  margin-inline-end: var(--pf-c-alert__icon--MarginRight);
+}
+
+.pf-m-grid-md.pf-c-table [data-label]::before {
+  text-align: start;
 }

--- a/web/src/app.scss
+++ b/web/src/app.scss
@@ -2,6 +2,9 @@
 @use "@patternfly/react-core/dist/styles/base.css";
 @use "@patternfly/patternfly/patternfly.css";
 
+// See https://github.com/patternfly/patternfly/pull/4297
+@use "@patternfly/react-styles/css/utilities/Sizing/sizing.css";
+
 // NOTE: eos-base/index imports a lot of styles not needed by now. Hence, let's
 // start importing them granularly until we have time to investigate how to purge
 // or "tree-shake" CSS while building (although it might not help while working
@@ -18,8 +21,20 @@
   --pf-global--primary-color--200: #{branding.$eos-bc-green-900};
   --pf-global--link--Color: var(--pf-global--primary-color--100);
   --pf-global--link--Color--hover: var(--pf-global--primary-color--200);
+  --pf-global--BackgroundColor--dark-100: #{branding.$eos-bc-pine-500};
 }
 
 #root {
-  padding: $eos-xxl;
+  min-height: 100vh;
+  background: branding.$eos-bc-gray-50;
+}
+
+.installation-overview-section {
+  border-bottom: 1px solid branding.$eos-bc-gray-100;
+  padding-bottom: 1rem;
+
+  &:last-child {
+    border-bottom: none;
+  }
+}
 }

--- a/web/src/app.scss
+++ b/web/src/app.scss
@@ -2,8 +2,13 @@
 @import "@patternfly/react-core/dist/styles/base.css";
 @import "@patternfly/patternfly/patternfly.css";
 
-// Import EOS Base
-@import "eos-ds/dist/scss/eos-base/index.scss";
+// NOTE: eos-base/index imports a lot of styles not needed by now. Hence, let's
+// start importing them granularly until we have time to investigate how to purge
+// or "tree-shake" CSS while building (although it might not help while working
+// in development mode)
+
+// @import "eos-ds/dist/scss/eos-base/index.scss";
+@import "eos-ds/dist/scss/eos-base/variables/branding.scss";
 
 // Overrides some PatternFly variables using EOS Design System colors
 // See more at https://github.com/mcoker/patternfly/blob/main/src/patternfly/base/_variables.scss and

--- a/web/src/app.scss
+++ b/web/src/app.scss
@@ -26,7 +26,7 @@
 
 #root {
   min-height: 100vh;
-  background: branding.$eos-bc-gray-50;
+  background-color: branding.$eos-bc-gray-50;
 }
 
 .installation-overview-section {

--- a/web/src/app.scss
+++ b/web/src/app.scss
@@ -1,6 +1,6 @@
 // Import PatternFly CSS
-@import "@patternfly/react-core/dist/styles/base.css";
-@import "@patternfly/patternfly/patternfly.css";
+@use "@patternfly/react-core/dist/styles/base.css";
+@use "@patternfly/patternfly/patternfly.css";
 
 // NOTE: eos-base/index imports a lot of styles not needed by now. Hence, let's
 // start importing them granularly until we have time to investigate how to purge
@@ -8,15 +8,14 @@
 // in development mode)
 
 // @import "eos-ds/dist/scss/eos-base/index.scss";
-@import "eos-ds/dist/scss/eos-base/variables/branding.scss";
+@use "eos-ds/dist/scss/eos-base/variables/branding.scss";
 
 // Overrides some PatternFly variables using EOS Design System colors
 // See more at https://github.com/mcoker/patternfly/blob/main/src/patternfly/base/_variables.scss and
 // https://gitlab.com/SUSE-UIUX/eos-ds-npm/
 :root {
-  --pf-global--primary-color--100: #{$eos-bc-green-500};
-  --pf-global--primary-color--200: #{$eos-bc-green-900};
-
+  --pf-global--primary-color--100: #{branding.$eos-bc-green-500};
+  --pf-global--primary-color--200: #{branding.$eos-bc-green-900};
   --pf-global--link--Color: var(--pf-global--primary-color--100);
   --pf-global--link--Color--hover: var(--pf-global--primary-color--200);
 }

--- a/web/src/layout.scss
+++ b/web/src/layout.scss
@@ -5,54 +5,56 @@
 @use "eos-ds/dist/scss/eos-base/variables/branding";
 
 .layout {
+  --header-height: 8ex;
+  --footer-height: calc(2 * var(--header-height));
+
   @extend .pf-u-box-shadow-md;
 
   background-color: white;
   margin-left: auto;
   margin-right: auto;
-  --header-height: 8ex;
-  --footer-height: calc(2 * var(--header-height));
 }
 
 .layout__header {
   @extend .pf-u-box-shadow-md-bottom;
 
-  background-color: branding.$eos-bc-pine-500;
-  color: white;
-
-  height: var(--header-height);
   // Note: "position: fixed" + "width: inherit" does not work here. Sticky is enough for the header
   position: sticky;
   z-index: 100;
   top: 0;
 
+  background-color: branding.$eos-bc-pine-500;
+  color: white;
+
+  height: var(--header-height);
+  padding: 0.5rem;
+
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  padding: 0.5rem;
 }
 
-.layout__header__left-action {
+.layout__header-left-action {
 }
 
-.layout__header__action-icon {
+.layout__header-action-icon {
   fill: white;
-  width: 1.5rem;
   height: 1.5rem;
+  width: 1.5rem;
   vertical-align: middle;
 }
 
-.layout__header__section-title {
+.layout__header-section-title {
   font-size: 1.5rem;
 }
 
-.layout__header__section-title-icon {
+.layout__header-section-title-icon {
   fill: white;
   // Sadly, we can't use font-size with EOS Icons
-  width: 1em;
   height: 1em;
+  width: 1em;
   vertical-align: sub;
-  margin: 0;
+  margin-right: 0.5em;
 }
 
 .layout__content {
@@ -63,17 +65,19 @@
 
 .layout__footer {
   @extend .pf-u-box-shadow-sm-top;
-  background-color: white;
 
   position: fixed;
   bottom: 0;
+
+  background-color: white;
+
   height: var(--footer-height);
   width: inherit;
+  padding: 1rem;
+
   display: grid;
   grid-template-columns: 2fr 1fr;
   gap: 1rem 1rem;
-  padding: 1rem;
-  
 }
 
 .layout__footer-info-area {

--- a/web/src/layout.scss
+++ b/web/src/layout.scss
@@ -9,8 +9,8 @@
 
   background: white;
   margin: 0 auto;
-  --header-height: 48px;
-  --footer-height: 96px;
+  --header-height: 8ex;
+  --footer-height: calc(2 * var(--header-height));
 }
 
 .layout__header {

--- a/web/src/layout.scss
+++ b/web/src/layout.scss
@@ -1,0 +1,91 @@
+// See https://github.com/patternfly/patternfly/pull/4297
+@use "@patternfly/react-styles/css/utilities/BoxShadow/box-shadow.css";
+@use "@patternfly/react-styles/css/utilities/Text/text.css";
+
+@use "eos-ds/dist/scss/eos-base/variables/branding";
+
+.layout {
+  @extend .pf-u-box-shadow-md;
+
+  background: white;
+  margin: 0 auto;
+  --header-height: 48px;
+  --footer-height: 96px;
+}
+
+.layout__header {
+  @extend .pf-u-box-shadow-md-bottom;
+
+  background-color: branding.$eos-bc-pine-500;
+  color: white;
+
+  height: var(--header-height);
+  // Note: "position: fixed" + "width: inherit" does not work here. Sticky is enough for the header
+  position: sticky;
+  z-index: 100;
+  top: 0;
+
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem;
+}
+
+.layout__header__left-action {
+}
+
+.layout__header__action-icon {
+  fill: white;
+  width: 1.5rem;
+  height: 1.5rem;
+  vertical-align: middle;
+}
+
+.layout__header__section-title {
+  font-size: 1.5rem;
+}
+
+.layout__header__section-title-icon {
+  fill: white;
+  // Sadly, we can't use font-size with EOS Icons
+  width: 1em;
+  height: 1em;
+  vertical-align: sub;
+  margin: 0;
+}
+
+.layout__content {
+  padding: 1rem;
+  padding-bottom: calc(2rem + var(--footer-height));
+  min-height: calc(100vh - var(--header-height));
+}
+
+.layout__footer {
+  @extend .pf-u-box-shadow-sm-top;
+  background: white;
+
+  position: fixed;
+  bottom: 0;
+  height: var(--footer-height);
+  width: inherit;
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 1rem 1rem;
+  padding: 1rem;
+  
+}
+
+.layout__footer-info-area {
+  align-self: center;
+  overflow-y: auto;
+}
+
+// TODO: Keep alert icons vetically centered here?
+// .layout__footer-info-area .pf-c-alert__icon {
+//   align-self: center;
+// }
+
+.layout__footer-actions-area {
+  align-self: center;
+  text-align: center;
+}

--- a/web/src/layout.scss
+++ b/web/src/layout.scss
@@ -5,14 +5,16 @@
 @use "eos-ds/dist/scss/eos-base/variables/branding";
 
 .layout {
-  --header-height: 8ex;
-  --footer-height: calc(2 * var(--header-height));
+  --header-block-size: 8ex;
+  --footer-block-size: calc(2 * var(--header-block-size));
 
   @extend .pf-u-box-shadow-md;
 
   background-color: white;
-  margin-left: auto;
-  margin-right: auto;
+  margin-inline: auto;
+
+  // Needed for "telling" the fixed footer its (inherited) inline-size.
+  inline-size: 100%;
 }
 
 .layout__header {
@@ -21,12 +23,12 @@
   // Note: "position: fixed" + "width: inherit" does not work here. Sticky is enough for the header
   position: sticky;
   z-index: 100;
-  top: 0;
+  inset-block-start: 0;
 
   background-color: branding.$eos-bc-pine-500;
   color: white;
 
-  height: var(--header-height);
+  block-size: var(--header-block-size);
   padding: 0.5rem;
 
   display: flex;
@@ -39,8 +41,8 @@
 
 .layout__header-action-icon {
   fill: white;
-  height: 1.5rem;
-  width: 1.5rem;
+  block-size: 1.5rem;
+  inline-size: 1.5rem;
   vertical-align: middle;
 }
 
@@ -51,28 +53,28 @@
 .layout__header-section-title-icon {
   fill: white;
   // Sadly, we can't use font-size with EOS Icons
-  height: 1em;
-  width: 1em;
+  block-size: 1em;
+  inline-size: 1em;
   vertical-align: sub;
-  margin-right: 0.5em;
+  margin-inline-end: 0.5em;
 }
 
 .layout__content {
   padding: 1rem;
-  padding-bottom: calc(2rem + var(--footer-height));
-  min-height: calc(100vh - var(--header-height));
+  padding-block-end: calc(1rem + var(--footer-block-size));
+  min-block-size: calc(100vh - var(--header-block-size));
 }
 
 .layout__footer {
   @extend .pf-u-box-shadow-sm-top;
 
   position: fixed;
-  bottom: 0;
+  inset-block-end: 0;
 
   background-color: white;
 
-  height: var(--footer-height);
-  width: inherit;
+  block-size: var(--footer-block-size);
+  inline-size: inherit;
   padding: 1rem;
 
   display: grid;

--- a/web/src/layout.scss
+++ b/web/src/layout.scss
@@ -7,6 +7,12 @@
 .layout {
   --header-block-size: 8ex;
   --footer-block-size: calc(2 * var(--header-block-size));
+  --min-layout-content-block-size: calc(100vh - var(--header-block-size));
+  --layout-content-padding: 1rem;
+  --layout-content-padding-block-end: calc(
+    var(--layout-content-padding)
+    + var(--footer-block-size)
+  );
 
   @extend .pf-u-box-shadow-md;
 
@@ -60,9 +66,23 @@
 }
 
 .layout__content {
-  padding: 1rem;
-  padding-block-end: calc(1rem + var(--footer-block-size));
-  min-block-size: calc(100vh - var(--header-block-size));
+  padding: var(--layout-content-padding);
+  padding-block-end: var(--layout-content-padding-block-end);
+  min-block-size: var(--min-layout-content-block-size);
+}
+
+// Needed because a block-size: 100% is not an option when the parent does not
+// have an explicit block-size (it has a min-block-size instead).
+// See https://stackoverflow.com/a/8468131 and https://www.w3.org/TR/CSS22/visudet.html#the-height-property
+.layout__content-child--filling-block-size {
+  // NOTE: "min-block-size: inherit;" does not work for us. It produces padding
+  // that we do not want unless necessary. Moreover, the .layout__content
+  // container element already produce needed padding.
+  min-block-size: calc(
+    var(--min-layout-content-block-size)
+    - var(--layout-content-padding)
+    - var(--layout-content-padding-block-end)
+  );
 }
 
 .layout__footer {

--- a/web/src/layout.scss
+++ b/web/src/layout.scss
@@ -7,8 +7,9 @@
 .layout {
   @extend .pf-u-box-shadow-md;
 
-  background: white;
-  margin: 0 auto;
+  background-color: white;
+  margin-left: auto;
+  margin-right: auto;
   --header-height: 8ex;
   --footer-height: calc(2 * var(--header-height));
 }
@@ -62,7 +63,7 @@
 
 .layout__footer {
   @extend .pf-u-box-shadow-sm-top;
-  background: white;
+  background-color: white;
 
   position: fixed;
   bottom: 0;

--- a/web/src/layout.scss
+++ b/web/src/layout.scss
@@ -107,7 +107,7 @@
   overflow-y: auto;
 }
 
-// TODO: Keep alert icons vetically centered here?
+// TODO: Keep alert icons vertically centered here?
 // .layout__footer-info-area .pf-c-alert__icon {
 //   align-self: center;
 // }

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -28,6 +28,7 @@ import InstallerClient from "./lib/InstallerClient";
 import cockpit from "./lib/cockpit";
 
 import "./app.scss";
+import "./layout.scss";
 
 const client = new InstallerClient(cockpit);
 


### PR DESCRIPTION
## TL;DR

Set up the [proposed layout](https://yast.opensuse.org/blog/2022-02-23/start-2022#dinstaller) for D-Installer.

| Login Screen | Installation Summary | Popup | Progress screen |
|-|-|-|-|
| ![Screenshot_2022-03-06-01-43-53-477_com android chrome](https://user-images.githubusercontent.com/1691872/156905663-2afac8a5-bd8d-495e-b0d2-3c3833a3ebae.jpg) | ![Screenshot_2022-03-06-00-41-00-585_com android chrome](https://user-images.githubusercontent.com/1691872/156905677-0fb2444f-b28f-4d76-9f0c-b8d3df246db8.jpg) | ![Screenshot_2022-03-06-01-05-25-295_com android chrome](https://user-images.githubusercontent.com/1691872/156905688-e0333174-6a96-47a6-8444-bcd64e2004a2.jpg) | ![Screenshot_2022-03-05-21-34-12-247_com android chrome](https://user-images.githubusercontent.com/1691872/156905693-31a620ed-6b8f-4604-b7e2-5f7f4d00db3b.jpg) |



<p align="center"><em>How D-Installer looks in a 6.55" Android smartphone (using dummy data)</em></p>

---

| Login Screen | Installation Summary | Popup | Progress screen |
|-|-|-|-|
| ![Screen Shot 2022-03-06 at 00 58 48](https://user-images.githubusercontent.com/1691872/156905712-24dfa945-1984-4e6f-8e4e-c57f7c68a5ab.png) | ![Screen Shot 2022-03-06 at 01 04 58](https://user-images.githubusercontent.com/1691872/156905728-b2a56836-6825-47c3-9ef8-3db03a64099f.png) | ![Screen Shot 2022-03-06 at 01 04 43](https://user-images.githubusercontent.com/1691872/156905727-99e04c9c-6609-4a67-82b8-b84f1bb92ec2.png) | ![Screen Shot 2022-03-06 at 00 59 11](https://user-images.githubusercontent.com/1691872/156905720-da4dbe4a-b347-47a8-ba1c-11ff9a9c57ee.png) |

<p align="center"><em>How D-Installer looks in a desktop Firefox browser but emulating a landscaped device (1080x810) using the Responsive Design Mode and dummy data</em></p>

---

| Login Screen | Installation Summary | Popup | Progress screen |
|-|-|-|-|
| ![Screenshot 2022-03-06 at 01-02-24 D-Installer](https://user-images.githubusercontent.com/1691872/156905749-30f2e478-203e-4619-b66a-bdc19e40d5db.png) | ![Screenshot 2022-03-06 at 01-02-09 D-Installer](https://user-images.githubusercontent.com/1691872/156905758-5b0aafad-5c8e-4fb3-96aa-beaabacb6955.png) | ![Screenshot 2022-03-06 at 01-01-59 D-Installer](https://user-images.githubusercontent.com/1691872/156905767-6a71d56e-5247-4170-9ab8-8c44ba89dbbb.png) | ![Screenshot 2022-03-06 at 01-03-15 D-Installer](https://user-images.githubusercontent.com/1691872/156905780-9a9615ae-a22d-4140-958e-d68279de2aa1.png) |


<p align="center"><em>How D-Installer looks in Firefox in a 1920x1080 (16:9) laptop screen (using dummy data)</em></p>

## The Details

As discussed internally, going for a tiny, single-column, mobile first layout will not only help to have a multi-device installer, but ~~force~~ encourage us to develop a simple, yet powerful, UI.

Thus, this PR can be considered as a starting point for laying out the bases to achieve that end as well as a post collecting both, taken decisions and problems found.

### Fixed header

Having a single column layout somehow means having vertical scroll. It is something (almost) not present in current YaST UI, but quite common in web and mobile applications. For sure, we are committed to do our best for having not so long _screens_, but we have to ensure some context and actions are always visible/at hand for the user. For that reason, a fixed header has been implemented. The idea is to hold there a possible main menu, section title and maybe other actions (theme switcher, expert actions).

In the future, we could even consider making the header disappear when the user scroll down and making it appear again when scrolling up. A quite common patter nowadays, though.

https://www.codemzy.com/blog/react-sticky-header-disappear-scroll

### Fixed footer

Slightly related with the fixed header, there is a fixed footer to display either, actions or (short) messages. Or event both at the same time.

Although it is nothing hard to achieve in web development (we even see it all the time thanks to the infamous cookies warnings), we found an interesting problem in mobile browsers: the viewport if positioned partially offscreen because the URL Bar—which is hidden when user scrolls down—move it out when it is on the screen.

Fortunately, looks like most of mobile browsers has fixed the issue for elements that are `position: fixed`. At least, it is the case for Chrome, Firefox, and Brave on Android. Although not for DuckDuckGo :cry:

<details>
<summary>:point_right: Click to show/hide screenshots.</summary>

---
| URL bar **NOT** hidden | URL bar **hidden** |
|-|-|
| ![Screenshot_2022_03_06_00_40_21_562_com_duckduckgo_mobile_android](https://user-images.githubusercontent.com/1691872/156905812-f449ee7e-5d9d-4b25-b2c6-d47156dfc427.jpg) | ![Screenshot_2022_03_06_00_40_29_859_com_duckduckgo_mobile_android](https://user-images.githubusercontent.com/1691872/156905820-b5e40db9-d674-419b-8ba6-657a8f584b4f.jpg) |

<p align="center"><em>How the fixed footer looks in DuckDuckGo browser on
Android devices for both address bar statuses, displayed and hidden</em></p>

</details>

If interested, know more by reading below links

  * https://stackoverflow.com/a/57748562
  * https://developers.google.com/web/updates/2016/12/url-bar-resizing
  * https://css-tricks.com/the-trick-to-viewport-units-on-mobile/

And these others to follow the progress of DuckDuckGo issue

  * https://github.com/duckduckgo/Android/issues/638
  * https://github.com/duckduckgo/Android/issues/914

### Thinking on i18n

Despite the fact the code is not ready for translations yet, thinking on i18n it's important for us. But i18n goes beyond the content itself. It is all about 

> develop your content, application, specification, and so on, in a way that
> ensures it will work well for, or can be easily adapted for, users from any
> culture, region, or language. — https://www.w3.org/standards/webdesign/i18n

Our experience with YaST tell us that an installer has a wide target audience, reason why we don't want to elude having i18n in its full sense into account. Thus, we have started using [CSS Logical Properties](https://www.w3.org/TR/css-logical-1) instead directional ones. I.e., _margin-block-end_ instead of _margin-right_ and so on.

Yes, they still a [working draft](https://www.w3.org/2020/Process-20200915/#maturity-levels)  but latest browsers versions on both, desktop and mobile devices, have a good support for them. (check https://caniuse.com/css-logical-props). Moreover, PatternFly (the component library we are using) currently support [**only the latest versions** of Chrome, Firefox, Safari, and Edge browsers](https://www.patternfly.org/v4/get-started/about/#supported-browsers).

<details>
<summary>:point_right:  Click to show/hide screenshots and see the difference between using or not those logical properties.</summary>

---

  - **NOT USING** CSS logical props

    | `direction: rtl` | `direction: rtl`and `writing-mode: sideway-lr` |
    |-|-|
    | ![before-direction-rtl](https://user-images.githubusercontent.com/1691872/156905919-b13bbcc6-d7f4-445d-a190-8bc4054ee66a.png) | ![before-direction-rtl-wm-sideway-lr](https://user-images.githubusercontent.com/1691872/156905942-307c9ff0-1fea-4220-8820-1dd09366b8d8.png) |

 - **USING** CSS logical props

    | `direction: rtl` | `direction: rtl`and `writing-mode: sideway-lr` |
    |-|-|
    | ![Screen Shot 2022-03-06 at 02 09 01](https://user-images.githubusercontent.com/1691872/156906174-022c2008-ad35-4a29-b8aa-8dede6aabb5e.png) | ![Screen Shot 2022-03-06 at 02 09 12](https://user-images.githubusercontent.com/1691872/156906177-3fa35a50-747b-4d57-ad2d-5548cbf76a9b.png) |

<p align="center"><em>NOTE that those `direction` and `writing-mode` usages can make not sense without a right font/script. But they have been used just for illustration how the layout is _more_ in the right place when using CSS Logical Properties.</em></p>

</details>


#### Caveats

Beyond the browsers support, there are three foreseeable handicaps on the way to achieve a good i18n

  * We are not (web) experts on that regard (yet :wink:)
  * PatternFly does not use CSS Logical Properties at all
  * SVG Icons does not follow [writing mode](https://www.w3.org/TR/css-writing-modes-3/) (?)

Still, none of them should be an obstacle for continuing along this path because 

  * We ~~must~~ can learn about it and there are a plenty of resources to do so
    * https://chenhuijing.com/blog/css-for-i18n/
    * https://www.w3.org/International/questions/qa-html-dir 
    * https://web.dev/learn/design/internationalization
    * https://moderncss.dev/developing-for-imperfect-future-proofing-css-styles
    * https://rtlstyling.com/posts/rtl-styling
    * ...
  * We can override PatternFly CSS rules by now (and look for the best structural way to do it) until CSS Logical Properties reach the recommendation stage and, eventually, collaborate with upstream to adopt them.

Certainly, although it looks unlikely at its status of implementation, ~~shit happens~~ anything can happen and the CSS Logical Properties working draft could end up not reaching the [candidate recommendation](https://www.w3.org/2020/Process-20200915/#RecsCR) stage. But even in such case, the impact should not be so huge. A matter of _rolling back_ to directional properties, maybe with a script similar to this one for converting [to-logical](https://gist.github.com/nyurik/d438cb56a9059a0660ce4176ef94576f).

In short, betting for CSS Logical Properties looks safe and helps to have the CSS _i18n ready_ from the very beginning.

## What's next?

This set of changes is ready to be reviewed and merged (as long as nobody is against). However, a lot of (UI) work remains ahead, such as

  - Improve the layout component and its usage

    For this first iteration, the layout is imported in each wrapped component and it receives the section title, footer messages, and footer actions via props. Enough for prototyping, but perhaps another mechanism should be chosen for using the layout in a single point and letting it know everything it needs. A _layout context_? Don't know at this moment, but it is something to be discussed, especially when implementing the navigation among sections ([React Router](https://reactrouter.com)?).

  - Decides if fixed footer should be displayed in the login screen too

    Placing the Login button in the fixed footer (and re-enabling the return keystroke for triggering the form send).

  - Set a minimum size/orientation supported (?)

    Admittedly, having a responsive, mobile first UI is nice. But making the proposed single column layout useful in the landscape mode of small devices is hard (to not say impossible).

    <details>
    <summary>:point_right:  Click to show/hide screenshots taken in a 6.55" screen size Android smartphone</summary>

    ---

    | Portrait | Landscape |
    |-|-|
    | ![Screenshot_2022-03-06-00-41-00-585_com android chrome](https://user-images.githubusercontent.com/1691872/156905860-9fd66175-b503-43f8-8955-66624a9acad6.jpg) | ![Screenshot_2022-03-06-00-41-18-465_com android chrome](https://user-images.githubusercontent.com/1691872/156905867-18846997-3a3b-4bab-87f3-f1caf9caf538.jpg) |

    _It works_ in both orientations, but it does not feel so neat and tidy in landscape mode.

    </details>

    Should we block the landscape mode below a certain screen size, encouraging the user to rotate the device? See https://code-boxx.com/lock-screen-orientation

  - Investigate if tree shaking or any other _purge_ technique can be applied to (S)CSS

    For not including not needed parts of either, EOS or PatternFly, in the final build.

    * https://purgecss.com/getting-started.html
    * https://markmurray.co/blog/tree-shaking-css-modules/

  - Define reasonable layout width for each breakpoint and re-evaluate if still using PatternFly utilty classes for it or go for a custom media query instead. 

  - Extract some common components

    Like the one for centering the content inside the layout: a PatternFly Bullseye with a class name for fixing the ["percentage-sized children should only respect containers with an explicit height"](https://bugs.webkit.org/show_bug.cgi?id=26559#c31) _issue_ (we only set the _min-block-size_ for filling the full screen even if the content is shorter)

  - Tests (jest)

    In a next iteration, once the layout has been approved (and hopefully more defined)

  - General CSS improvements.

    * **Improve variables naming** (improves variables in general)
    * Defines how to organize PatternFly overrides rules
    * ...






