### PR TITLE
[web] Adapt login screen to the new layout

### DIFF
--- a/web/src/LoginForm.jsx
+++ b/web/src/LoginForm.jsx
@@ -61,7 +61,7 @@ function LoginForm() {
 
   return (
     <Layout>
-      <Bullseye>
+      <Bullseye className="layout__content-child--filling-block-size">
         <Form>
           <TextContent>
             <Text component={TextVariants.h1}>Welcome to D-Installer</Text>

--- a/web/src/LoginForm.jsx
+++ b/web/src/LoginForm.jsx
@@ -47,7 +47,9 @@ function LoginForm() {
   const usernameRef = useRef();
   const passwordRef = useRef();
 
-  const submitLogin = () => {
+  const submitLogin = (e) => {
+    e.preventDefault();
+
     setError(undefined);
     login(usernameRef.current.value, passwordRef.current.value)
       .then(() => window.location.reload())
@@ -63,6 +65,8 @@ function LoginForm() {
         <Button
           isLarge
           variant="primary"
+          type="submit"
+          form="d-installer-login"
           onClick={submitLogin}
         >
           Login
@@ -78,7 +82,7 @@ function LoginForm() {
       FooterActions={SubmitButton}
     >
       <Bullseye className="layout__content-child--filling-block-size">
-        <Form>
+        <Form id="d-installer-login">
           {error && formError(error)}
           <FormGroup label="Username" fieldId="username">
             <TextInput isRequired type="text" id="username" ref={usernameRef} />

--- a/web/src/LoginForm.jsx
+++ b/web/src/LoginForm.jsx
@@ -25,15 +25,12 @@ import {
   Alert,
   Bullseye,
   Button,
+  Flex,
+  FlexItem,
   Form,
   FormAlert,
   FormGroup,
-  TextInput,
-  TextContent,
-  Text,
-  TextVariants,
-  Flex,
-  FlexItem
+  TextInput
 } from "@patternfly/react-core";
 
 import Layout from "./Layout";
@@ -59,13 +56,29 @@ function LoginForm() {
       });
   };
 
+  const SubmitButton = () => {
+    return (
+    <Flex justifyContent={{ default: 'justifyContentFlexEnd' }}>
+      <FlexItem>
+        <Button
+          isLarge
+          variant="primary"
+          onClick={submitLogin}
+        >
+          Login
+        </Button>
+      </FlexItem>
+    </Flex>
+    );
+  };
+
   return (
-    <Layout>
+    <Layout
+      sectionTitle="Welcome to D-Installer"
+      FooterActions={SubmitButton}
+    >
       <Bullseye className="layout__content-child--filling-block-size">
         <Form>
-          <TextContent>
-            <Text component={TextVariants.h1}>Welcome to D-Installer</Text>
-          </TextContent>
           {error && formError(error)}
           <FormGroup label="Username" fieldId="username">
             <TextInput isRequired type="text" id="username" ref={usernameRef} />
@@ -78,9 +91,6 @@ function LoginForm() {
               ref={passwordRef}
             />
           </FormGroup>
-          <Button variant="primary" onClick={submitLogin}>
-            Login
-          </Button>
         </Form>
       </Bullseye>
     </Layout>


### PR DESCRIPTION
In #44, the login screen was not fully integrated with the new layout.

After a short discussion with @imobachgs, we decided to go for it, moving the _title_ to the header and the form action to the footer. Thus, d-installer look&feel it's more consistent.

About the plenty of empty space remaining, we could use it for adding more information about that _weird_ login screen as the first d-installer screen and/or to show the machine IP if interacting with d-installer from a different one.

| | Before | After |
|-|-|-|
| 6.55" Android Smartphone | ![Screenshot_2022-03-06-01-43-53-477_com android chrome](https://user-images.githubusercontent.com/1691872/156905663-2afac8a5-bd8d-495e-b0d2-3c3833a3ebae.jpg) | ![photo5850602333648566965](https://user-images.githubusercontent.com/1691872/157076958-843ef1ea-9652-489d-b134-90ebef6f4696.jpg) |
| Emulated 1080x810 landscaped device | ![Screen Shot 2022-03-06 at 00 58 48](https://user-images.githubusercontent.com/1691872/156905712-24dfa945-1984-4e6f-8e4e-c57f7c68a5ab.png) | ![Screen Shot 2022-03-07 at 16 27 25](https://user-images.githubusercontent.com/1691872/157077008-4a062cee-338c-44ad-a9cc-89f61d72b9c0.png) |
|  Firefox in a 1920x1080 (16:9) laptop screen | ![Screenshot 2022-03-06 at 01-02-24 D-Installer](https://user-images.githubusercontent.com/1691872/156905749-30f2e478-203e-4619-b66a-bdc19e40d5db.png) | ![Screenshot 2022-03-07 at 16-26-51 D-Installer](https://user-images.githubusercontent.com/1691872/157077069-efcf8d1a-50fb-41c7-8304-9966d51f3d0b.png) |

---

It also _restores_ the ability of sending the login form when hitting _Enter_.
