### PR TITLE
Add an API to listen for changes

### DIFF
--- a/web/src/App.test.jsx
+++ b/web/src/App.test.jsx
@@ -3,7 +3,7 @@ import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { authRender } from "./test-utils";
 import App from "./App";
-import InstallerClient from "./lib/client";
+import { createClient } from "./lib/client";
 
 jest.mock("./lib/client");
 jest.mock("./Installer", () => {
@@ -17,7 +17,7 @@ jest.mock("./Installer", () => {
 
 describe("when the user is already logged in", () => {
   beforeEach(() => {
-    InstallerClient.mockImplementation(() => {
+    createClient.mockImplementation(() => {
       return {
         auth: {
           authorize: (_username, _password) => Promise.resolve(false),
@@ -36,7 +36,7 @@ describe("when the user is already logged in", () => {
 
 describe("when username and password are wrong", () => {
   beforeEach(() => {
-    InstallerClient.mockImplementation(() => {
+    createClient.mockImplementation(() => {
       return {
         auth: {
           authorize: () => Promise.reject("password does not match"),

--- a/web/src/InstallationProgress.jsx
+++ b/web/src/InstallationProgress.jsx
@@ -34,11 +34,9 @@ function InstallationProgress() {
   const [progress, setProgress] = useState({});
 
   useEffect(() => {
-    return client.onPropertyChanged((_path, _iface, signal, args) => {
-      const iface = "org.opensuse.DInstaller.Manager1";
-      const [input_iface, changed] = args;
-      if (input_iface === iface && "Progress" in changed) {
-        const [title, steps, step, substeps, substep] = changed.Progress.v.map(pr => pr.v);
+    return client.manager.onChange(changes => {
+      if ("Progress" in changes) {
+        const [title, steps, step, substeps, substep] = changes.Progress;
         setProgress({ title, steps, step, substeps, substep });
       }
     });

--- a/web/src/Installer.jsx
+++ b/web/src/Installer.jsx
@@ -36,7 +36,7 @@ function Installer() {
   useEffect(async () => {
     try {
       const status = await client.manager.getStatus();
-      setIsProgress(status === 3 || status == 1);
+      setIsProgress(status === 3 || status === 1);
     } catch (err) {
       console.error(err);
       setIsDBusError(true);
@@ -45,15 +45,14 @@ function Installer() {
   }, []);
 
   useEffect(() => {
-    return client.onPropertyChanged((_path, _iface, _signal, args) => {
-      const iface = "org.opensuse.DInstaller.Manager1";
-      const [input_iface, changed] = args;
-      if (input_iface === iface && "Status" in changed) {
-        setIsProgress(changed.Status.v === 3 || changed.Status.v === 1);
+    return client.manager.onChange(changes => {
+      if ("Status" in changes) {
+        setIsProgress(changes.Status === 3 || changes.Status === 1);
         setIsDBusError(false); // rescue when dbus start acting
       }
     });
   }, []);
+
   // TODO: add suppport for installation complete ui
   if (isDBusError){
     return <h2>Cannot Connect to DBus</h2>

--- a/web/src/Installer.jsx
+++ b/web/src/Installer.jsx
@@ -32,7 +32,6 @@ function Installer() {
   // TODO: use reducer for states
   const [isDBusError, setIsDBusError] = useState(false);
 
-
   useEffect(async () => {
     try {
       const status = await client.manager.getStatus();
@@ -41,7 +40,6 @@ function Installer() {
       console.error(err);
       setIsDBusError(true);
     }
-
   }, []);
 
   useEffect(() => {
@@ -54,8 +52,8 @@ function Installer() {
   }, []);
 
   // TODO: add suppport for installation complete ui
-  if (isDBusError){
-    return <h2>Cannot Connect to DBus</h2>
+  if (isDBusError) {
+    return <h2>Cannot Connect to DBus</h2>;
   } else {
     return isProgress ? <InstallationProgress /> : <Overview />;
   }

--- a/web/src/LanguageSelector.test.jsx
+++ b/web/src/LanguageSelector.test.jsx
@@ -3,7 +3,7 @@ import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { installerRender } from "./test-utils";
 import LanguageSelector from "./LanguageSelector";
-import InstallerClient from "./lib/client";
+import { createClient } from "./lib/client";
 
 jest.mock("./lib/client");
 
@@ -22,7 +22,7 @@ const languageMock = {
 
 beforeEach(() => {
   // if defined outside, the mock is cleared automatically
-  InstallerClient.mockImplementation(() => {
+  createClient.mockImplementation(() => {
     return { language: languageMock };
   });
 });

--- a/web/src/Overview.test.jsx
+++ b/web/src/Overview.test.jsx
@@ -3,7 +3,7 @@ import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { installerRender } from "./test-utils";
 import Overview from "./Overview";
-import InstallerClient from "./lib/client";
+import { createClient } from "./lib/client";
 
 jest.mock("./lib/client");
 
@@ -18,7 +18,7 @@ const products = [{ id: "openSUSE", name: "openSUSE Tumbleweed" }];
 const startInstallationFn = jest.fn();
 
 beforeEach(() => {
-  InstallerClient.mockImplementation(() => {
+  createClient.mockImplementation(() => {
     return {
       storage: {
         getStorageProposal: () => Promise.resolve(proposal),

--- a/web/src/Overview.test.jsx
+++ b/web/src/Overview.test.jsx
@@ -23,7 +23,7 @@ beforeEach(() => {
       storage: {
         getStorageProposal: () => Promise.resolve(proposal),
         getStorageActions: () => Promise.resolve(actions),
-        onActionsChanged: jest.fn()
+        onActionsChange: jest.fn()
       },
       language: {
         getLanguages: () => Promise.resolve(languages),

--- a/web/src/Overview.test.jsx
+++ b/web/src/Overview.test.jsx
@@ -22,7 +22,8 @@ beforeEach(() => {
     return {
       storage: {
         getStorageProposal: () => Promise.resolve(proposal),
-        getStorageActions: () => Promise.resolve(actions)
+        getStorageActions: () => Promise.resolve(actions),
+        onActionsChanged: jest.fn()
       },
       language: {
         getLanguages: () => Promise.resolve(languages),
@@ -34,8 +35,7 @@ beforeEach(() => {
       },
       manager: {
         startInstallation: startInstallationFn
-      },
-      onPropertyChanged: jest.fn()
+      }
     };
   });
 });

--- a/web/src/ProductSelector.test.jsx
+++ b/web/src/ProductSelector.test.jsx
@@ -3,7 +3,7 @@ import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { installerRender } from "./test-utils";
 import ProductSelector from "./ProductSelector";
-import InstallerClient from "./lib/client";
+import { createClient } from "./lib/client";
 
 jest.mock("./lib/client");
 
@@ -21,7 +21,7 @@ const selectProductFn = jest.fn().mockResolvedValue();
 
 beforeEach(() => {
   // if defined outside, the mock is cleared automatically
-  InstallerClient.mockImplementation(() => {
+  createClient.mockImplementation(() => {
     return {
       software: {
         ...softwareMock,

--- a/web/src/Storage.jsx
+++ b/web/src/Storage.jsx
@@ -57,7 +57,7 @@ export default function Storage() {
   }, []);
 
   useEffect(() => {
-    return client.storage.onActionsChanged(changes => {
+    return client.storage.onActionsChange(changes => {
       const { All: newActions } = changes;
       dispatch({ type: "UPDATE_ACTIONS", payload: newActions });
     });

--- a/web/src/Storage.jsx
+++ b/web/src/Storage.jsx
@@ -57,19 +57,8 @@ export default function Storage() {
   }, []);
 
   useEffect(() => {
-    // TODO: abstract D-Bus details
-    return client.onPropertyChanged((_path, _iface, _signal, args) => {
-      const [iface, properties] = args;
-
-      if (iface !== "org.opensuse.DInstaller.Storage.Actions1") {
-        return;
-      }
-
-      const newActions = properties.All.v.map(action => {
-        const { Text: textVar, Subvol: subvolVar } = action.v;
-        return { text: textVar.v, subvol: subvolVar.v };
-      });
-
+    return client.storage.onActionsChanged(changes => {
+      const { All: newActions } = changes;
       dispatch({ type: "UPDATE_ACTIONS", payload: newActions });
     });
   }, []);

--- a/web/src/Storage.test.jsx
+++ b/web/src/Storage.test.jsx
@@ -28,7 +28,7 @@ beforeEach(() => {
         ...storageMock,
         calculateStorageProposal: calculateStorageProposalFn,
         onActionsChanged: onActionsChangedFn
-      },
+      }
     };
   });
 });
@@ -92,9 +92,7 @@ describe("when the proposal changes", () => {
     ];
     const [cb] = callbacks;
     act(() => {
-      cb(
-        { All: [ { text: "Mount /dev/sdb1 as root", subvol: false } ] }
-      );
+      cb({ All: [{ text: "Mount /dev/sdb1 as root", subvol: false }] });
     });
     await screen.findByText("Mount /dev/sdb1 as root");
   });

--- a/web/src/Storage.test.jsx
+++ b/web/src/Storage.test.jsx
@@ -13,7 +13,7 @@ const proposalSettings = {
   lvm: false
 };
 
-let onActionsChangedFn = jest.fn();
+let onActionsChangeFn = jest.fn();
 let calculateStorageProposalFn;
 
 const storageMock = {
@@ -27,7 +27,7 @@ beforeEach(() => {
       storage: {
         ...storageMock,
         calculateStorageProposal: calculateStorageProposalFn,
-        onActionsChanged: onActionsChangedFn
+        onActionsChange: onActionsChangeFn
       }
     };
   });
@@ -77,7 +77,7 @@ describe("when the proposal changes", () => {
 
   beforeEach(() => {
     callbacks = [];
-    onActionsChangedFn = cb => callbacks.push(cb);
+    onActionsChangeFn = cb => callbacks.push(cb);
   });
 
   it("updates the proposal", async () => {

--- a/web/src/Storage.test.jsx
+++ b/web/src/Storage.test.jsx
@@ -13,7 +13,7 @@ const proposalSettings = {
   lvm: false
 };
 
-let onPropertyChangedFn = jest.fn();
+let onActionsChangedFn = jest.fn();
 let calculateStorageProposalFn;
 
 const storageMock = {
@@ -26,9 +26,9 @@ beforeEach(() => {
     return {
       storage: {
         ...storageMock,
-        calculateStorageProposal: calculateStorageProposalFn
+        calculateStorageProposal: calculateStorageProposalFn,
+        onActionsChanged: onActionsChangedFn
       },
-      onPropertyChanged: onPropertyChangedFn
     };
   });
 });
@@ -77,7 +77,7 @@ describe("when the proposal changes", () => {
 
   beforeEach(() => {
     callbacks = [];
-    onPropertyChangedFn = cb => callbacks.push(cb);
+    onActionsChangedFn = cb => callbacks.push(cb);
   });
 
   it("updates the proposal", async () => {
@@ -93,10 +93,7 @@ describe("when the proposal changes", () => {
     const [cb] = callbacks;
     act(() => {
       cb(
-        "/org/openSUSE/DInstaller/Storage/Actions1",
-        "org.freedesktop.DBus.Properties",
-        "PropertiesChanged",
-        ["org.opensuse.DInstaller.Storage.Actions1", { All: { t: "av", v: actions } }]
+        { All: [ { text: "Mount /dev/sdb1 as root", subvol: false } ] }
       );
     });
     await screen.findByText("Mount /dev/sdb1 as root");

--- a/web/src/Storage.test.jsx
+++ b/web/src/Storage.test.jsx
@@ -3,7 +3,7 @@ import { act, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { installerRender } from "./test-utils";
 import Storage from "./Storage";
-import InstallerClient from "./lib/client";
+import { createClient } from "./lib/client";
 
 jest.mock("./lib/client");
 
@@ -22,7 +22,7 @@ const storageMock = {
 };
 
 beforeEach(() => {
-  InstallerClient.mockImplementation(() => {
+  createClient.mockImplementation(() => {
     return {
       storage: {
         ...storageMock,

--- a/web/src/context/auth.jsx
+++ b/web/src/context/auth.jsx
@@ -20,7 +20,7 @@
  */
 
 import React from "react";
-import InstallerClient from "../lib/client";
+import { createClient } from "../lib/client";
 
 const AuthContext = React.createContext();
 
@@ -63,7 +63,7 @@ function useAuthContext() {
   }
 
   const [state, dispatch] = context;
-  const client = new InstallerClient();
+  const client = createClient();
 
   const login = (username, password) => {
     dispatch({ type: "LOGIN", payload: { request: true } });

--- a/web/src/lib/client/auth.js
+++ b/web/src/lib/client/auth.js
@@ -19,7 +19,7 @@
  * find current contact information at www.suse.com.
  */
 
-import { withProxy, applyMixin } from "./mixins";
+import { applyMixin, withDBus } from "./mixins";
 
 import cockpit from "../cockpit";
 
@@ -73,4 +73,4 @@ export default class AuthClient {
   }
 }
 
-applyMixin(AuthClient, withProxy);
+applyMixin(AuthClient, withDBus);

--- a/web/src/lib/client/auth.js
+++ b/web/src/lib/client/auth.js
@@ -19,10 +19,11 @@
  * find current contact information at www.suse.com.
  */
 
-import Client from "./client";
+import { withProxy, applyMixin } from "./mixins";
+
 import cockpit from "../cockpit";
 
-export default class AuthClient extends Client {
+export default class AuthClient {
   /**
    * Authorize using username and password
    *
@@ -71,3 +72,5 @@ export default class AuthClient extends Client {
     return cockpit.user();
   }
 }
+
+applyMixin(AuthClient, withProxy);

--- a/web/src/lib/client/index.js
+++ b/web/src/lib/client/index.js
@@ -40,10 +40,7 @@ const createClient = () => {
     manager: new ManagerClient(client),
     software: new SoftwareClient(client),
     storage: new StorageClient(client)
-  }
-}
+  };
+};
 
-export {
-  createClient,
-  statuses
-}
+export { createClient, statuses };

--- a/web/src/lib/client/index.js
+++ b/web/src/lib/client/index.js
@@ -27,50 +27,21 @@ import StorageClient from "./storage";
 
 import cockpit from "../cockpit";
 
-export default class InstallerClient {
-  /**
-   * @constructor
-   */
-  constructor() {
-    this._proxies = {};
-    this._client = cockpit.dbus("org.opensuse.DInstaller", {
-      bus: "system",
-      superuser: "try"
-    });
+const createClient = () => {
+  const client = cockpit.dbus("org.opensuse.DInstaller", {
+    bus: "system",
+    superuser: "try"
+  });
 
-    this.auth = new AuthClient(this._client);
-    this.language = new LanguageClient(this._client);
-    this.manager = new ManagerClient(this._client);
-    this.software = new SoftwareClient(this._client);
-    this.storage = new StorageClient(this._client);
+  return {
+    auth: new AuthClient(),
+    language: new LanguageClient(client),
+    manager: new ManagerClient(client),
+    software: new SoftwareClient(client),
+    storage: new StorageClient(client)
   }
+}
 
-  /**
-   * Register a callback to run when some D-Bus property changes
-   *
-   * @param {function} handler - callback function
-   */
-  onPropertyChanged(handler) {
-    const { remove } = this._client.subscribe(
-      {
-        interface: "org.freedesktop.DBus.Properties",
-        member: "PropertiesChanged"
-      },
-      handler
-    );
-    return remove;
-  }
-
-  /**
-   * Register a callback to run when some D-Bus signal is emitted
-   *
-   * @param {function} handler - callback function
-   */
-  onSignal(signal, handler) {
-    const { remove } = this._client.subscribe(
-      { interface: "org.opensuse.YaST.Installer", member: signal },
-      handler
-    );
-    return remove;
-  }
+export {
+  createClient
 }

--- a/web/src/lib/client/language.js
+++ b/web/src/lib/client/language.js
@@ -19,11 +19,15 @@
  * find current contact information at www.suse.com.
  */
 
-import Client from "./client";
+import { applyMixin, withProxy } from "./mixins";
 
 const LANGUAGE_IFACE = "org.opensuse.DInstaller.Language1";
 
-export default class LanguageClient extends Client {
+export default class LanguageClient {
+  constructor(dbusClient) {
+    this._client = dbusClient;
+  }
+
   /**
    * Return the list of available languages
    *
@@ -58,3 +62,5 @@ export default class LanguageClient extends Client {
     return proxy.ToInstall(langIDs);
   }
 }
+
+applyMixin(LanguageClient, withProxy);

--- a/web/src/lib/client/language.js
+++ b/web/src/lib/client/language.js
@@ -19,7 +19,7 @@
  * find current contact information at www.suse.com.
  */
 
-import { applyMixin, withProxy } from "./mixins";
+import { applyMixin, withDBus } from "./mixins";
 
 const LANGUAGE_IFACE = "org.opensuse.DInstaller.Language1";
 
@@ -63,4 +63,4 @@ export default class LanguageClient {
   }
 }
 
-applyMixin(LanguageClient, withProxy);
+applyMixin(LanguageClient, withDBus);

--- a/web/src/lib/client/language.test.js
+++ b/web/src/lib/client/language.test.js
@@ -18,7 +18,7 @@ const langProxy = {
 };
 
 beforeEach(() => {
-  dbusClient.proxy = jest.fn().mockImplementation((iface, _path, _opts) => {
+  dbusClient.proxy = jest.fn().mockImplementation(iface => {
     if (iface === LANGUAGE_IFACE) return langProxy;
   });
 });

--- a/web/src/lib/client/manager.js
+++ b/web/src/lib/client/manager.js
@@ -19,11 +19,15 @@
  * find current contact information at www.suse.com.
  */
 
-import Client from "./client";
+import { withProxy, applyMixin } from "./mixins";
 
 const MANAGER_IFACE = "org.opensuse.DInstaller.Manager1";
 
-export default class ManagerClient extends Client {
+export default class ManagerClient {
+  constructor(dbusClient) {
+    this._client = dbusClient;
+  }
+
   /**
    * Start the installation process
    *
@@ -47,3 +51,5 @@ export default class ManagerClient extends Client {
     return proxy.Status;
   }
 }
+
+applyMixin(ManagerClient, withProxy);

--- a/web/src/lib/client/manager.js
+++ b/web/src/lib/client/manager.js
@@ -57,7 +57,7 @@ export default class ManagerClient {
    *
    * @param {function} handler - callback function
    */
-  async onChange(handler) {
+  onChange(handler) {
     return this.onObjectChanged(MANAGER_PATH, (changes, invalid) => {
       const data = {};
 

--- a/web/src/lib/client/manager.js
+++ b/web/src/lib/client/manager.js
@@ -53,7 +53,10 @@ export default class ManagerClient {
   }
 
   /**
-   * Register a callback to run when properties in the Actions object change
+   * Register a callback to run when properties in the Manager object change
+   *
+   * Additionally, this method handles the conversion of the values coming
+   * from the {cockpit} module.
    *
    * @param {function} handler - callback function
    */

--- a/web/src/lib/client/manager.js
+++ b/web/src/lib/client/manager.js
@@ -71,9 +71,6 @@ export default class ManagerClient {
 
       handler(data, invalid);
     });
-
-    const removeFn = () => proxy.removeEventListener("changed");
-    return removeFn;
   }
 }
 

--- a/web/src/lib/client/manager.js
+++ b/web/src/lib/client/manager.js
@@ -19,7 +19,7 @@
  * find current contact information at www.suse.com.
  */
 
-import { withProxy, onPropertyChanged, applyMixin } from "./mixins";
+import { applyMixin, withDBus } from "./mixins";
 
 const MANAGER_IFACE = "org.opensuse.DInstaller.Manager1";
 const MANAGER_PATH = "/org/opensuse/DInstaller/Manager1";
@@ -58,7 +58,7 @@ export default class ManagerClient {
    * @param {function} handler - callback function
    */
   async onChange(handler) {
-    return this.onPropertyChanged(MANAGER_PATH, (changes, invalid) => {
+    return this.onObjectChanged(MANAGER_PATH, (changes, invalid) => {
       const data = {};
 
       if ("Status" in changes) {
@@ -77,4 +77,4 @@ export default class ManagerClient {
   }
 }
 
-applyMixin(ManagerClient, withProxy, onPropertyChanged);
+applyMixin(ManagerClient, withDBus);

--- a/web/src/lib/client/manager.test.js
+++ b/web/src/lib/client/manager.test.js
@@ -10,7 +10,7 @@ let managerProxy = {
 };
 
 beforeEach(() => {
-  dbusClient.proxy = jest.fn().mockImplementation((iface, _path, _opts) => {
+  dbusClient.proxy = jest.fn().mockImplementation(iface => {
     if (iface == MANAGER_IFACE) return managerProxy;
   });
 });

--- a/web/src/lib/client/mixins.js
+++ b/web/src/lib/client/mixins.js
@@ -76,7 +76,7 @@ const withDBus = {
    */
   onSignal(signal, handler) {
     const { remove } = this._client.subscribe(
-      { interface: "org.opensuse.YaST.Installer", member: signal },
+      { interface: "org.opensuse.DInstaller", member: signal },
       handler
     );
     return remove;

--- a/web/src/lib/client/mixins.js
+++ b/web/src/lib/client/mixins.js
@@ -19,7 +19,7 @@
  * find current contact information at www.suse.com.
  */
 
-const withProxy = {
+const withDBus = {
   async proxy(iface) {
     const _proxies = this.proxies();
 
@@ -35,11 +35,9 @@ const withProxy = {
 
   proxies() {
     return this._proxies ||= {};
-  }
-};
+  },
 
-const onPropertyChanged = {
-  onPropertyChanged(path, handler) {
+  onObjectChanged(path, handler) {
     const { remove } = this._client.subscribe(
       {
         path,
@@ -59,6 +57,5 @@ const applyMixin = (klass, ...fn) => Object.assign(klass.prototype, ...fn);
 
 export {
   applyMixin,
-  withProxy,
-  onPropertyChanged
+  withDBus
 };

--- a/web/src/lib/client/mixins.js
+++ b/web/src/lib/client/mixins.js
@@ -20,6 +20,12 @@
  */
 
 const withDBus = {
+  /**
+   * Registers a proxy for given iface
+   *
+   * @param {string} iface - D-Bus iface
+   * @return {Object} a cockpit DBusProxy
+   */
   async proxy(iface) {
     const _proxies = this.proxies();
 
@@ -33,10 +39,21 @@ const withDBus = {
     return proxy;
   },
 
+  /**
+   * Returns known proxies
+   *
+   * @return {Object.<string, Object>} a collection of cockpit DBusProxy indexed by their D-Bus iface
+   */
   proxies() {
     return (this._proxies ||= {});
   },
 
+  /**
+   * Register a callback to run when properties change for given D-Bus path
+   *
+   * @param {string} path - D-Bus path
+   * @param {function} handler - callback function
+   */
   onObjectChanged(path, handler) {
     const { remove } = this._client.subscribe(
       {
@@ -66,6 +83,12 @@ const withDBus = {
   }
 };
 
+/**
+ * Utility method for applying mixins to given object
+ *
+ * @param {Object} klass - target object
+ * @param {...function} fn - function(s) to be copied to given object prototype
+ */
 const applyMixin = (klass, ...fn) => Object.assign(klass.prototype, ...fn);
 
 export { applyMixin, withDBus };

--- a/web/src/lib/client/mixins.js
+++ b/web/src/lib/client/mixins.js
@@ -34,7 +34,7 @@ const withDBus = {
   },
 
   proxies() {
-    return this._proxies ||= {};
+    return (this._proxies ||= {});
   },
 
   onObjectChanged(path, handler) {
@@ -45,17 +45,14 @@ const withDBus = {
         member: "PropertiesChanged"
       },
       (_path, _iface, _signal, args) => {
-        const [_, changes, invalid] = args;
+        const [, changes, invalid] = args;
         handler(changes, invalid);
       }
     );
     return remove;
   }
-}
+};
 
 const applyMixin = (klass, ...fn) => Object.assign(klass.prototype, ...fn);
 
-export {
-  applyMixin,
-  withDBus
-};
+export { applyMixin, withDBus };

--- a/web/src/lib/client/mixins.js
+++ b/web/src/lib/client/mixins.js
@@ -50,6 +50,19 @@ const withDBus = {
       }
     );
     return remove;
+  },
+
+  /**
+   * Register a callback to run when some D-Bus signal is emitted
+   *
+   * @param {function} handler - callback function
+   */
+  onSignal(signal, handler) {
+    const { remove } = this._client.subscribe(
+      { interface: "org.opensuse.YaST.Installer", member: signal },
+      handler
+    );
+    return remove;
   }
 };
 

--- a/web/src/lib/client/mixins.js
+++ b/web/src/lib/client/mixins.js
@@ -19,20 +19,28 @@
  * find current contact information at www.suse.com.
  */
 
-export default class Client {
-  constructor(dbusClient) {
-    this._client = dbusClient;
-    this._proxies = [];
-  }
-
+const withProxy = {
   async proxy(iface) {
-    if (this._proxies[iface]) {
-      return this._proxies[iface];
+    const _proxies = this.proxies();
+
+    if (_proxies[iface]) {
+      return _proxies[iface];
     }
 
     const proxy = this._client.proxy(iface, undefined, { watch: true });
     await proxy.wait();
-    this._proxies[iface] = proxy;
+    _proxies[iface] = proxy;
     return proxy;
+  },
+
+  proxies() {
+    return this._proxies ||= {};
   }
-}
+};
+
+const applyMixin = (klass, ...fn) => Object.assign(klass.prototype, ...fn);
+
+export {
+  applyMixin,
+  withProxy
+};

--- a/web/src/lib/client/mixins.js
+++ b/web/src/lib/client/mixins.js
@@ -38,9 +38,27 @@ const withProxy = {
   }
 };
 
+const onPropertyChanged = {
+  onPropertyChanged(path, handler) {
+    const { remove } = this._client.subscribe(
+      {
+        path,
+        interface: "org.freedesktop.DBus.Properties",
+        member: "PropertiesChanged"
+      },
+      (_path, _iface, _signal, args) => {
+        const [_, changes, invalid] = args;
+        handler(changes, invalid);
+      }
+    );
+    return remove;
+  }
+}
+
 const applyMixin = (klass, ...fn) => Object.assign(klass.prototype, ...fn);
 
 export {
   applyMixin,
-  withProxy
+  withProxy,
+  onPropertyChanged
 };

--- a/web/src/lib/client/software.js
+++ b/web/src/lib/client/software.js
@@ -19,7 +19,7 @@
  * find current contact information at www.suse.com.
  */
 
-import { applyMixin, withProxy } from "./mixins";
+import { applyMixin, withDBus } from "./mixins";
 
 const SOFTWARE_IFACE = "org.opensuse.DInstaller.Software1";
 
@@ -52,4 +52,4 @@ export default class SoftwareClient {
   }
 }
 
-applyMixin(SoftwareClient, withProxy);
+applyMixin(SoftwareClient, withDBus);

--- a/web/src/lib/client/software.js
+++ b/web/src/lib/client/software.js
@@ -19,11 +19,15 @@
  * find current contact information at www.suse.com.
  */
 
-import Client from "./client";
+import { applyMixin, withProxy } from "./mixins";
 
 const SOFTWARE_IFACE = "org.opensuse.DInstaller.Software1";
 
-export default class SoftwareClient extends Client {
+export default class SoftwareClient {
+  constructor(dbusClient) {
+    this._client = dbusClient;
+  }
+
   /**
    * Return the list of available products
    *
@@ -47,3 +51,5 @@ export default class SoftwareClient extends Client {
     return proxy.SelectProduct(id);
   }
 }
+
+applyMixin(SoftwareClient, withProxy);

--- a/web/src/lib/client/software.test.js
+++ b/web/src/lib/client/software.test.js
@@ -19,7 +19,7 @@ const softProxy = {
 };
 
 beforeEach(() => {
-  dbusClient.proxy = jest.fn().mockImplementation((iface, _path, _opts) => {
+  dbusClient.proxy = jest.fn().mockImplementation(iface => {
     if (iface === SOFTWARE_IFACE) return softProxy;
   });
 });

--- a/web/src/lib/client/statuses.js
+++ b/web/src/lib/client/statuses.js
@@ -19,11 +19,11 @@
  * find current contact information at www.suse.com.
  */
 
-const ERROR      = 0;
-const PROBING    = 1;
-const PROBED     = 2;
+const ERROR = 0;
+const PROBING = 1;
+const PROBED = 2;
 const INSTALLING = 3;
-const INSTALLED  = 4;
+const INSTALLED = 4;
 
 export default {
   ERROR,
@@ -31,4 +31,4 @@ export default {
   PROBED,
   INSTALLING,
   INSTALLED
-}
+};

--- a/web/src/lib/client/statuses.js
+++ b/web/src/lib/client/statuses.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2021] SUSE LLC
+ * Copyright (c) [2022] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -19,31 +19,16 @@
  * find current contact information at www.suse.com.
  */
 
-import AuthClient from "./auth";
-import LanguageClient from "./language";
-import ManagerClient from "./manager";
-import SoftwareClient from "./software";
-import StorageClient from "./storage";
-import statuses from "./statuses";
+const ERROR      = 0;
+const PROBING    = 1;
+const PROBED     = 2;
+const INSTALLING = 3;
+const INSTALLED  = 4;
 
-import cockpit from "../cockpit";
-
-const createClient = () => {
-  const client = cockpit.dbus("org.opensuse.DInstaller", {
-    bus: "system",
-    superuser: "try"
-  });
-
-  return {
-    auth: new AuthClient(),
-    language: new LanguageClient(client),
-    manager: new ManagerClient(client),
-    software: new SoftwareClient(client),
-    storage: new StorageClient(client)
-  }
-}
-
-export {
-  createClient,
-  statuses
+export default {
+  ERROR,
+  PROBING,
+  PROBED,
+  INSTALLING,
+  INSTALLED
 }

--- a/web/src/lib/client/storage.js
+++ b/web/src/lib/client/storage.js
@@ -70,7 +70,7 @@ export default class StorageClient {
    *
    * @param {function} handler - callback function
    */
-  onActionsChanged(handler) {
+  onActionsChange(handler) {
     return this.onObjectChanged(ACTIONS_PATH, changes => {
       const newActions = changes.All.v.map(action => {
         const { Text: textVar, Subvol: subvolVar } = action.v;

--- a/web/src/lib/client/storage.js
+++ b/web/src/lib/client/storage.js
@@ -20,10 +20,11 @@
  */
 
 import cockpit from "../cockpit";
-import { withProxy, applyMixin } from "./mixins";
+import { withProxy, applyMixin, onPropertyChanged } from "./mixins";
 
 const STORAGE_PROPOSAL_IFACE = "org.opensuse.DInstaller.Storage.Proposal1";
 const STORAGE_ACTIONS_IFACE = "org.opensuse.DInstaller.Storage.Actions1";
+const ACTIONS_PATH = "/org/opensuse/DInstaller/Storage/Actions1";
 
 export default class StorageClient {
   constructor(dbusClient) {
@@ -63,6 +64,21 @@ export default class StorageClient {
       CandidateDevices: cockpit.variant("as", candidateDevices)
     });
   }
+
+  /**
+   * Register a callback to run when properties in the Actions object change
+   *
+   * @param {function} handler - callback function
+   */
+  onActionsChanged(handler) {
+    return this.onPropertyChanged(ACTIONS_PATH, (changes, invalid) => {
+      const newActions = changes.All.v.map(action => {
+        const { Text: textVar, Subvol: subvolVar } = action.v;
+        return { text: textVar.v, subvol: subvolVar.v };
+      });
+      handler({ All: newActions });
+    });
+  }
 }
 
-applyMixin(StorageClient, withProxy);
+applyMixin(StorageClient, withProxy, onPropertyChanged);

--- a/web/src/lib/client/storage.js
+++ b/web/src/lib/client/storage.js
@@ -71,7 +71,7 @@ export default class StorageClient {
    * @param {function} handler - callback function
    */
   onActionsChanged(handler) {
-    return this.onObjectChanged(ACTIONS_PATH, (changes, invalid) => {
+    return this.onObjectChanged(ACTIONS_PATH, changes => {
       const newActions = changes.All.v.map(action => {
         const { Text: textVar, Subvol: subvolVar } = action.v;
         return { text: textVar.v, subvol: subvolVar.v };

--- a/web/src/lib/client/storage.js
+++ b/web/src/lib/client/storage.js
@@ -20,7 +20,7 @@
  */
 
 import cockpit from "../cockpit";
-import { withProxy, applyMixin, onPropertyChanged } from "./mixins";
+import { applyMixin, withDBus } from "./mixins";
 
 const STORAGE_PROPOSAL_IFACE = "org.opensuse.DInstaller.Storage.Proposal1";
 const STORAGE_ACTIONS_IFACE = "org.opensuse.DInstaller.Storage.Actions1";
@@ -71,7 +71,7 @@ export default class StorageClient {
    * @param {function} handler - callback function
    */
   onActionsChanged(handler) {
-    return this.onPropertyChanged(ACTIONS_PATH, (changes, invalid) => {
+    return this.onObjectChanged(ACTIONS_PATH, (changes, invalid) => {
       const newActions = changes.All.v.map(action => {
         const { Text: textVar, Subvol: subvolVar } = action.v;
         return { text: textVar.v, subvol: subvolVar.v };
@@ -81,4 +81,4 @@ export default class StorageClient {
   }
 }
 
-applyMixin(StorageClient, withProxy, onPropertyChanged);
+applyMixin(StorageClient, withDBus);

--- a/web/src/lib/client/storage.js
+++ b/web/src/lib/client/storage.js
@@ -19,13 +19,17 @@
  * find current contact information at www.suse.com.
  */
 
-import Client from "./client";
 import cockpit from "../cockpit";
+import { withProxy, applyMixin } from "./mixins";
 
 const STORAGE_PROPOSAL_IFACE = "org.opensuse.DInstaller.Storage.Proposal1";
 const STORAGE_ACTIONS_IFACE = "org.opensuse.DInstaller.Storage.Actions1";
 
-export default class StorageClient extends Client {
+export default class StorageClient {
+  constructor(dbusClient) {
+    this._client = dbusClient;
+  }
+
   /**
    * Return the actions for the current proposal
    *
@@ -60,3 +64,5 @@ export default class StorageClient extends Client {
     });
   }
 }
+
+applyMixin(StorageClient, withProxy);

--- a/web/src/lib/client/storage.test.js
+++ b/web/src/lib/client/storage.test.js
@@ -31,7 +31,7 @@ const proxies = {
 };
 
 beforeEach(() => {
-  dbusClient.proxy = jest.fn().mockImplementation((iface, _path, _opts) => {
+  dbusClient.proxy = jest.fn().mockImplementation(iface => {
     return proxies[iface];
   });
 });

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -24,12 +24,12 @@ import ReactDOM from "react-dom";
 import App from "./App";
 import { InstallerClientProvider } from "./context/installer";
 import { AuthProvider } from "./context/auth";
-import InstallerClient from "./lib/client";
+import { createClient } from "./lib/client";
 
 import "./app.scss";
 import "./layout.scss";
 
-const client = new InstallerClient();
+const client = createClient();
 
 ReactDOM.render(
   <StrictMode>

--- a/web/src/test-utils.js
+++ b/web/src/test-utils.js
@@ -3,10 +3,10 @@ import { render } from "@testing-library/react";
 
 import { InstallerClientProvider } from "./context/installer";
 import { AuthProvider } from "./context/auth";
-import InstallerClient from "./lib/client";
+import { createClient } from "./lib/client";
 
 const InstallerProvider = ({ children }) => {
-  const client = new InstallerClient();
+  const client = createClient();
   return <InstallerClientProvider client={client}>{children}</InstallerClientProvider>;
 };
 


### PR DESCRIPTION
This PR improves the overall installer clients approach by

* making use of [mixins](https://javascript.info/mixins)
* dropping the `InstallerClient` in favor of `createClient` [factory function](https://www.javascripttutorial.net/javascript-factory-functions/)
* **adding an API for listening changes in different modules**
  
  * _StorageClient#onActionsChange_, for reacting to storage proposal actions changes.
  * _ManagerClient#onChange_, for listening to installation progress changes.

  Both make use of the `onObjectChanged` _withDBus_ mixin method, which allows registering a method to be triggered when properties change for a given D-Bus path hiding the details of calling the `onPropertyChanged` cockpit method.

Additionally, the PR also improves the way of dealing with the installation progress status by adding a specific module for those statuses.