### PR TITLE
[web] Few UI improvements

### DIFF
--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -34,7 +34,7 @@ function App() {
 
   useEffect(autoLogin, []);
 
-  if (loggedIn == null) return <LoadingEnvironment />
+  if (loggedIn == null) return <LoadingEnvironment />;
   return loggedIn ? <Installer /> : <LoginForm />;
 }
 

--- a/web/src/App.test.jsx
+++ b/web/src/App.test.jsx
@@ -49,9 +49,11 @@ describe("when username and password are wrong", () => {
 
   it("shows an error", async () => {
     authRender(<App />);
+    const button = await screen.findByRole("button", { name: /Login/ });
+
     userEvent.type(screen.getByLabelText(/Username/i), "john");
     userEvent.type(screen.getByLabelText(/Password/i), "something");
-    userEvent.click(screen.getByRole("button", { name: /Login/ }));
+    userEvent.click(button);
     await screen.findByText(/Authentication failed/i);
   });
 });

--- a/web/src/App.test.jsx
+++ b/web/src/App.test.jsx
@@ -49,11 +49,13 @@ describe("when username and password are wrong", () => {
 
   it("shows an error", async () => {
     authRender(<App />);
-    const button = await screen.findByRole("button", { name: /Login/ });
+
+    await screen.findByText(/Username/i);
 
     userEvent.type(screen.getByLabelText(/Username/i), "john");
     userEvent.type(screen.getByLabelText(/Password/i), "something");
-    userEvent.click(button);
+    userEvent.click(screen.getByRole("button", { name: /Login/ }));
+
     await screen.findByText(/Authentication failed/i);
   });
 });

--- a/web/src/Center.jsx
+++ b/web/src/Center.jsx
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) [2022] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from "react";
+import { Bullseye } from "@patternfly/react-core";
+
+const Center = ({ children }) => (
+  <Bullseye className="layout__content-child--filling-block-size">{children}</Bullseye>
+);
+
+export default Center;

--- a/web/src/DBusError.jsx
+++ b/web/src/DBusError.jsx
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) [2022] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from "react";
+import {
+  Button,
+  Bullseye,
+  Title,
+  EmptyState,
+  EmptyStateIcon,
+  EmptyStateBody
+} from "@patternfly/react-core";
+
+import Layout from "./Layout";
+
+import {
+  EOS_ANNOUNCEMENT as SectionIcon,
+  EOS_ENDPOINTS_DISCONNECTED as DisconnectionIcon
+} from "eos-icons-react";
+
+// TODO: an example
+const ReloadAction = () => (
+  <Button isLarge isPrimary>
+    Reload
+  </Button>
+);
+
+function DBusError() {
+  return (
+    <Layout sectionTitle="DBus Error" SectionIcon={SectionIcon} FooterActions={ReloadAction}>
+      <Bullseye className="layout__content-child--filling-block-size">
+        <EmptyState>
+          <EmptyStateIcon icon={DisconnectionIcon} />
+          <Title headingLevel="h4" size="lg">
+            Cannot connect to DBus
+          </Title>
+          <EmptyStateBody>
+            D-Installer UI cannot connect with D-Installer DBus service. Please check if it is
+            running.
+          </EmptyStateBody>
+        </EmptyState>
+      </Bullseye>
+    </Layout>
+  );
+}
+
+export default DBusError;

--- a/web/src/DBusError.jsx
+++ b/web/src/DBusError.jsx
@@ -20,16 +20,10 @@
  */
 
 import React from "react";
-import {
-  Button,
-  Bullseye,
-  Title,
-  EmptyState,
-  EmptyStateIcon,
-  EmptyStateBody
-} from "@patternfly/react-core";
+import { Button, Title, EmptyState, EmptyStateIcon, EmptyStateBody } from "@patternfly/react-core";
 
 import Layout from "./Layout";
+import Center from "./Center";
 
 import {
   EOS_ANNOUNCEMENT as SectionIcon,
@@ -46,7 +40,7 @@ const ReloadAction = () => (
 function DBusError() {
   return (
     <Layout sectionTitle="DBus Error" SectionIcon={SectionIcon} FooterActions={ReloadAction}>
-      <Bullseye className="layout__content-child--filling-block-size">
+      <Center>
         <EmptyState>
           <EmptyStateIcon icon={DisconnectionIcon} />
           <Title headingLevel="h4" size="lg">
@@ -57,7 +51,7 @@ function DBusError() {
             running.
           </EmptyStateBody>
         </EmptyState>
-      </Bullseye>
+      </Center>
     </Layout>
   );
 }

--- a/web/src/DBusError.jsx
+++ b/web/src/DBusError.jsx
@@ -39,16 +39,15 @@ const ReloadAction = () => (
 
 function DBusError() {
   return (
-    <Layout sectionTitle="DBus Error" SectionIcon={SectionIcon} FooterActions={ReloadAction}>
+    <Layout sectionTitle="D-Bus Error" SectionIcon={SectionIcon} FooterActions={ReloadAction}>
       <Center>
         <EmptyState>
           <EmptyStateIcon icon={DisconnectionIcon} />
           <Title headingLevel="h4" size="lg">
-            Cannot connect to DBus
+            Cannot connect to D-Bus
           </Title>
           <EmptyStateBody>
-            D-Installer UI cannot connect with D-Installer DBus service. Please check if it is
-            running.
+            Could not connect to the D-Bus service. Please, check whether it is running.
           </EmptyStateBody>
         </EmptyState>
       </Center>

--- a/web/src/InstallationProgress.jsx
+++ b/web/src/InstallationProgress.jsx
@@ -22,8 +22,9 @@
 import React, { useState, useEffect } from "react";
 import { useInstallerClient } from "./context/installer";
 
-import { Alert, Bullseye, Button, Progress, Stack, StackItem } from "@patternfly/react-core";
+import { Alert, Button, Progress, Stack, StackItem } from "@patternfly/react-core";
 
+import Center from "./Center";
 import Layout from "./Layout";
 import Category from "./Category";
 
@@ -82,7 +83,7 @@ function InstallationProgress() {
       FooterMessages={Messages}
       FooterActions={Actions}
     >
-      <Bullseye className="layout__content-child--filling-block-size">
+      <Center>
         <Stack hasGutter className="pf-u-w-100">
           <StackItem>
             <Progress title={progress.title} value={percentage} />
@@ -90,7 +91,7 @@ function InstallationProgress() {
 
           {renderSubprogress()}
         </Stack>
-      </Bullseye>
+      </Center>
     </Layout>
   );
 }

--- a/web/src/InstallationProgress.jsx
+++ b/web/src/InstallationProgress.jsx
@@ -50,6 +50,9 @@ function InstallationProgress() {
 
   // FIXME: this is an example. Update or drop it.
   const Messages = () => {
+    if (status !== 3)
+      return <Alert isInline isPlain title="Please, wait unitl system probing is done" />;
+
     return (
       <Alert variant="info" isInline isPlain title="Did you know?">
         You can <a href="#">read the release notes</a> while the system is being installed.
@@ -59,6 +62,8 @@ function InstallationProgress() {
 
   // FIXME: this is an example. Update or drop it.
   const Actions = () => {
+    if (status !== 3) return null;
+
     return (
       <Button isDisabled onClick={() => console.log("User want to see the summary!")}>
         Reboot system

--- a/web/src/InstallationProgress.jsx
+++ b/web/src/InstallationProgress.jsx
@@ -21,7 +21,7 @@
 
 import React, { useState, useEffect } from "react";
 import { useInstallerClient } from "./context/installer";
-import { PROBING, INSTALLING } from "./lib/client/statuses";
+import statuses from "./lib/client/statuses";
 
 import { Alert, Button, Progress, Stack, StackItem } from "@patternfly/react-core";
 
@@ -30,6 +30,8 @@ import Layout from "./Layout";
 import Category from "./Category";
 
 import { EOS_DOWNLOADING as ProgressIcon } from "eos-icons-react";
+
+const { PROBING, INSTALLING } = statuses;
 
 function InstallationProgress() {
   const client = useInstallerClient();

--- a/web/src/InstallationProgress.jsx
+++ b/web/src/InstallationProgress.jsx
@@ -21,6 +21,7 @@
 
 import React, { useState, useEffect } from "react";
 import { useInstallerClient } from "./context/installer";
+import { PROBING, INSTALLING } from "./lib/client/statuses";
 
 import { Alert, Button, Progress, Stack, StackItem } from "@patternfly/react-core";
 
@@ -46,11 +47,11 @@ function InstallationProgress() {
   const showSubsteps = !!progress.substeps && progress.substeps >= 0;
   const percentage = progress.steps === 0 ? 0 : Math.round((progress.step / progress.steps) * 100);
   const status = client.manager.getStatus();
-  const mainTitle = status === 3 ? "Instaling" : "Probing"; // so far only two actions need progress
+  const mainTitle = status === INSTALLING ? "Instaling" : "Probing"; // so far only two actions need progress
 
   // FIXME: this is an example. Update or drop it.
   const Messages = () => {
-    if (status !== 3)
+    if (status === PROBING)
       return <Alert isInline isPlain title="Please, wait unitl system probing is done" />;
 
     return (
@@ -62,7 +63,7 @@ function InstallationProgress() {
 
   // FIXME: this is an example. Update or drop it.
   const Actions = () => {
-    if (status !== 3) return null;
+    if (status === PROBING) return null;
 
     return (
       <Button isDisabled onClick={() => console.log("User want to see the summary!")}>

--- a/web/src/InstallationProgress.jsx
+++ b/web/src/InstallationProgress.jsx
@@ -71,7 +71,11 @@ function InstallationProgress() {
 
     return (
       <StackItem>
-        <Progress value={Math.round((progress.substep / progress.substeps) * 100)} />
+        <Progress
+          size="sm"
+          measureLocation="none"
+          value={Math.round((progress.substep / progress.substeps) * 100)}
+        />
       </StackItem>
     );
   };

--- a/web/src/Installer.jsx
+++ b/web/src/Installer.jsx
@@ -22,6 +22,7 @@
 import React, { useState, useEffect } from "react";
 import { useInstallerClient } from "./context/installer";
 
+import DBusError from "./DBusError";
 import Overview from "./Overview";
 import InstallationProgress from "./InstallationProgress";
 
@@ -52,11 +53,9 @@ function Installer() {
   }, []);
 
   // TODO: add suppport for installation complete ui
-  if (isDBusError) {
-    return <h2>Cannot Connect to DBus</h2>;
-  } else {
-    return isProgress ? <InstallationProgress /> : <Overview />;
-  }
+  if (isDBusError) return <DBusError />;
+
+  return isProgress ? <InstallationProgress /> : <Overview />;
 }
 
 export default Installer;

--- a/web/src/LoadingEnvironment.jsx
+++ b/web/src/LoadingEnvironment.jsx
@@ -25,9 +25,7 @@ import { Button, Title, EmptyState, EmptyStateIcon, EmptyStateBody } from "@patt
 import Layout from "./Layout";
 import Center from "./Center";
 
-import {
-  EOS_THREE_DOTS_LOADING_ANIMATED as LoadingIcon
-} from "eos-icons-react";
+import { EOS_THREE_DOTS_LOADING_ANIMATED as LoadingIcon } from "eos-icons-react";
 
 function LoadingEnvironment() {
   return (
@@ -36,7 +34,7 @@ function LoadingEnvironment() {
         <EmptyState>
           <EmptyStateIcon icon={LoadingIcon} />
           <Title headingLevel="h4" size="lg">
-            Loading environment, please wait.
+            Loading installation environment, please wait.
           </Title>
         </EmptyState>
       </Center>

--- a/web/src/LoadingEnvironment.jsx
+++ b/web/src/LoadingEnvironment.jsx
@@ -19,23 +19,29 @@
  * find current contact information at www.suse.com.
  */
 
-import React, { useEffect } from "react";
-import { useAuthContext } from "./context/auth";
+import React from "react";
+import { Button, Title, EmptyState, EmptyStateIcon, EmptyStateBody } from "@patternfly/react-core";
 
-import LoadingEnvironment from "./LoadingEnvironment";
-import LoginForm from "./LoginForm";
-import Installer from "./Installer";
+import Layout from "./Layout";
+import Center from "./Center";
 
-function App() {
-  const {
-    state: { loggedIn },
-    autoLogin
-  } = useAuthContext();
+import {
+  EOS_THREE_DOTS_LOADING_ANIMATED as LoadingIcon
+} from "eos-icons-react";
 
-  useEffect(autoLogin, []);
-
-  if (loggedIn == null) return <LoadingEnvironment />
-  return loggedIn ? <Installer /> : <LoginForm />;
+function LoadingEnvironment() {
+  return (
+    <Layout sectionTitle="D-Installer">
+      <Center>
+        <EmptyState>
+          <EmptyStateIcon icon={LoadingIcon} />
+          <Title headingLevel="h4" size="lg">
+            Loading environment, please wait.
+          </Title>
+        </EmptyState>
+      </Center>
+    </Layout>
+  );
 }
 
-export default App;
+export default LoadingEnvironment;

--- a/web/src/LoginForm.jsx
+++ b/web/src/LoginForm.jsx
@@ -23,7 +23,6 @@ import React, { useState, useRef } from "react";
 import { useAuthContext } from "./context/auth";
 import {
   Alert,
-  Bullseye,
   Button,
   Flex,
   FlexItem,
@@ -33,6 +32,7 @@ import {
   TextInput
 } from "@patternfly/react-core";
 
+import Center from "./Center";
 import Layout from "./Layout";
 
 const formError = error => (
@@ -78,7 +78,7 @@ function LoginForm() {
 
   return (
     <Layout sectionTitle="Welcome to D-Installer" FooterActions={SubmitButton}>
-      <Bullseye className="layout__content-child--filling-block-size">
+      <Center>
         <Form id="d-installer-login">
           {error && formError(error)}
           <FormGroup label="Username" fieldId="username">
@@ -88,7 +88,7 @@ function LoginForm() {
             <TextInput isRequired type="password" id="password" ref={passwordRef} />
           </FormGroup>
         </Form>
-      </Bullseye>
+      </Center>
     </Layout>
   );
 }

--- a/web/src/app.scss
+++ b/web/src/app.scss
@@ -68,3 +68,8 @@ body {
 .pf-m-grid-md.pf-c-table [data-label]::before {
   text-align: start;
 }
+
+.pf-c-empty-state__icon {
+  inline-size: 10rem;
+  block-size: 10rem;
+}

--- a/web/src/app.scss
+++ b/web/src/app.scss
@@ -69,7 +69,14 @@ body {
   text-align: start;
 }
 
+// EOS icons does not obey font-size
 .pf-c-empty-state__icon {
   inline-size: 10rem;
   block-size: 10rem;
+}
+
+// Fix single-line subprogress missaligment
+.pf-c-progress.pf-m-singleline .pf-c-progress__bar {
+  grid-row: 1/3;
+  grid-column: 1/3;
 }

--- a/web/src/context/auth.jsx
+++ b/web/src/context/auth.jsx
@@ -43,7 +43,7 @@ function authReducer(state = initialState, action) {
   }
 }
 
-const initialState = { loggedIn: false };
+const initialState = { loggedIn: null };
 
 function AuthProvider({ props, children }) {
   const [state, dispatch] = React.useReducer(authReducer, initialState);


### PR DESCRIPTION
This is an _intermediate_ PR that introduces few UI improvements. _Intermediate_ because it pushed things that should be improved later (like example code).

Those improvements are

* A component to inform about a DBus connection problem
  <details>
  <summary>Click to show/hide screenshots</summary>

  ---

  | Before | After |
  |-|-|
  | ![Screenshot 2022-03-14 at 10-04-29 D-Installer](https://user-images.githubusercontent.com/1691872/158166517-3858d487-14fd-4ffe-b23d-31318ce0b80a.png) | ![Screen Shot 2022-03-14 at 12 41 38-fullpage](https://user-images.githubusercontent.com/1691872/158174183-fb4c0930-6139-409f-bd47-48c27c0824fb.png) |

  </details>

  It can be extracted to a more general _ApplicationError_ component based on props. But let's wait until we have another blocking error and think about the real action to offer ("retry", "go back, etc)

* Extract the UI logic for centered the content to a `Center` component.
* Slightly improves the substep progress
  <details>
  <summary>Click to show/hide screenshots</summary>

  ---

  | Before | After |
  |-|-|
  | ![Screenshot 2022-03-14 at 10-19-29 D-Installer](https://user-images.githubusercontent.com/1691872/158166767-2d87ed60-7c34-4b86-9f96-9a7cf136d863.png) | ![Screenshot 2022-03-14 at 11-02-05 D-Installer](https://user-images.githubusercontent.com/1691872/158166817-1278d122-1031-4207-ab79-95390c17cd30.png) |
  </details>
  This improvement is arguably, of course. But it's a bit weird having a percentage without a description. In the near future, we could add information about the substep and still improving that screen.

* Add screen for _wiring up the UI_

  It helps to avoid flickering in the login screen, but the whole UI deserves more love to avoid flickering everywhere as much as possible.

  <details>
  <summary>Click to show/hide screenshot</summary>

  ---
 
  
  ![Screen Shot 2022-03-14 at 12 42 48-fullpage](https://user-images.githubusercontent.com/1691872/158174339-68644697-1add-45b1-8daf-b4f0ff5fafaa.png)

  </details>

  Note that, intentionally, the initial value for _isLoggedIn_ has been initializated to `null`. It is something to re-think in next iterations, enriching the status or whatever other option. 

