### PR TITLE
Add screen/component to be displayed when installation finishes

### DIFF
--- a/web/src/InstallationFinished.jsx
+++ b/web/src/InstallationFinished.jsx
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) [2022] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from "react";
+import {
+  Button,
+  Title,
+  Text,
+  EmptyState,
+  EmptyStateIcon,
+  EmptyStateBody,
+  EmptyStateSecondaryActions
+} from "@patternfly/react-core";
+
+import Layout from "./Layout";
+import Center from "./Center";
+
+import {
+  EOS_TASK_ALT as InstallationFinishedIcon,
+  EOS_CHECK_CIRCLE as SectionIcon
+} from "eos-icons-react";
+
+const FinishAction = () => (
+  <Button
+    isLarge
+    variant="primary"
+    onClick={() => console.log("FIXME: trigger a reboot machine action here!")}
+  >
+    Finish
+  </Button>
+);
+
+function InstallationFinished() {
+  return (
+    <Layout
+      sectionTitle="Installation Finished"
+      SectionIcon={SectionIcon}
+      FooterActions={FinishAction}
+    >
+      <Center>
+        <EmptyState>
+          <EmptyStateIcon icon={InstallationFinishedIcon} className="success-icon" />
+          <Title headingLevel="h2" size="4xl">
+            Congratulations!
+          </Title>
+          <EmptyStateBody className="pf-c-content">
+            <div>
+              <Text>The installation on your machine is complete.</Text>
+              <Text>After clicking on "Finish" you can log in to the sytem.</Text>
+              <Text>Have a lot of fun! Your openSUSE Development Team.</Text>
+            </div>
+            <EmptyStateSecondaryActions>
+              <Button component="a" href="https://www.opensuse.org" target="_blank" variant="link">
+                www.opensuse.org
+              </Button>
+            </EmptyStateSecondaryActions>
+          </EmptyStateBody>
+        </EmptyState>
+      </Center>
+    </Layout>
+  );
+}
+
+export default InstallationFinished;

--- a/web/src/InstallationProgress.jsx
+++ b/web/src/InstallationProgress.jsx
@@ -28,10 +28,11 @@ import { Alert, Button, Progress, Stack, StackItem } from "@patternfly/react-cor
 import Center from "./Center";
 import Layout from "./Layout";
 import Category from "./Category";
+import InstallationFinished from "./InstallationFinished";
 
 import { EOS_DOWNLOADING as ProgressIcon } from "eos-icons-react";
 
-const { PROBING, INSTALLING } = statuses;
+const { PROBING, INSTALLING, FINISHED } = statuses;
 
 function InstallationProgress() {
   const client = useInstallerClient();
@@ -87,6 +88,8 @@ function InstallationProgress() {
       </StackItem>
     );
   };
+
+  if (status === FINISHED) return <InstallationFinished />;
 
   return (
     <Layout

--- a/web/src/InstallationProgress.test.jsx
+++ b/web/src/InstallationProgress.test.jsx
@@ -1,0 +1,87 @@
+import React from "react";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { authRender } from "./test-utils";
+import InstallationProgress from "./InstallationProgress";
+import { createClient } from "./lib/client";
+import statuses from "./lib/client/statuses";
+
+jest.mock("./lib/client");
+
+let getStatusFn = jest.fn();
+
+describe("InstallationProgress", () => {
+  beforeEach(() => {
+    createClient.mockImplementation(() => {
+      return {
+        manager: {
+          onChange: _changes => Promise.resolve({}),
+          getStatus: getStatusFn
+        }
+      };
+    });
+  });
+
+  describe("when probing the system", () => {
+    beforeEach(() => {
+      getStatusFn = () => statuses.PROBING;
+    });
+
+    it("uses 'Probing' as title", async () => {
+      authRender(<InstallationProgress />);
+
+      await screen.findByText("Probing");
+    });
+
+    it("shows none actions", async () => {
+      authRender(<InstallationProgress />);
+
+      await screen.findByText("Probing");
+
+      const button = screen.queryByRole("button", { name: /Finish/ });
+      expect(button).toBeNull();
+    });
+  });
+
+  describe("when installing", () => {
+    beforeEach(() => {
+      getStatusFn = () => statuses.INSTALLING;
+    });
+
+    it("uses 'Installing' as title", async () => {
+      authRender(<InstallationProgress />);
+
+      await screen.findByText("Installing");
+
+      const button = await screen.findByRole("button", { name: /Finish/ });
+      expect(button).toHaveAttribute("disabled");
+    });
+
+    it("shows disabled 'Finish' action", async () => {
+      authRender(<InstallationProgress />);
+
+      const button = await screen.findByRole("button", { name: /Finish/ });
+      expect(button).toHaveAttribute("disabled");
+    });
+  });
+
+  describe("when installation finished", () => {
+    beforeEach(() => {
+      getStatusFn = () => statuses.INSTALLED;
+    });
+
+    it("shows the finished installation screen", async () => {
+      authRender(<InstallationProgress />);
+
+      await screen.findByText("Congratulations!");
+      await screen.findByRole("button", { name: /Finish/ });
+    });
+
+    it("shows enabled 'Finish' action", async () => {
+      authRender(<InstallationProgress />);
+
+      const button = await screen.findByRole("button", { name: /Finish/ });
+      expect(button).not.toHaveAttribute("disabled");
+    });
+  });
+});

--- a/web/src/app.scss
+++ b/web/src/app.scss
@@ -49,6 +49,10 @@ body {
   }
 }
 
+.success-icon {
+  fill: branding.$eos-bc-green-500;
+}
+
 // PatternFly overrides for using CSS Logical Properties
 
 .pf-l-split.pf-m-gutter > :not(:last-child) {

--- a/web/src/app.scss
+++ b/web/src/app.scss
@@ -49,6 +49,10 @@ body {
   }
 }
 
+.component--centered {
+  text-align: center;
+}
+
 .success-icon {
   fill: branding.$eos-bc-green-500;
 }


### PR DESCRIPTION
As part of the `InstallationProgess` by now, this PR adds a new component for displaying feedback to the user when the installation finishes.

The example summary has been borrowed from the [openSUSE control file](https://github.com/yast/skelcd-control-openSUSE/blob/master/control/control.openSUSE.xml#L580-L584), but of course it's just an example.

About the `InstallationProgress` component itself, it has been restructured a bit as a consequence of minor issues found when adding a quite basic automated test.

---

![Screen Shot 2022-03-14 at 16 29 31-fullpage](https://user-images.githubusercontent.com/1691872/158351921-bad4cbe5-b4d2-4ffa-a438-9b59db35207f.png)

---

Related trello card (internal link): https://trello.com/c/7frozuK2