### PR TITLE
Show more information about disks in the target selector

### DIFF
--- a/service/lib/dinstaller/dbus/storage/proposal.rb
+++ b/service/lib/dinstaller/dbus/storage/proposal.rb
@@ -52,7 +52,7 @@ module DInstaller
 
           dbus_reader :candidate_devices, "as"
 
-          dbus_reader :available_devices, "as"
+          dbus_reader :available_devices, "a(ssa{sv})"
 
           # result: 0 success; 1 error
           dbus_method :Calculate, "in settings:a{sv}, out result:u" do |settings|
@@ -67,7 +67,9 @@ module DInstaller
 
         # @see DInstaller::Storage::Proposal
         def available_devices
-          backend.available_devices.map(&:name)
+          backend.available_devices.map do |dev|
+            [dev.name, backend.available_device_label(dev), {}]
+          end
         end
 
         # @see DInstaller::Storage::Proposal

--- a/service/lib/dinstaller/dbus/storage/proposal.rb
+++ b/service/lib/dinstaller/dbus/storage/proposal.rb
@@ -52,6 +52,13 @@ module DInstaller
 
           dbus_reader :candidate_devices, "as"
 
+          # The first string is the name of the device (as expected by #Calculate for
+          # the setting CandidateDevices), the second one is the label to represent that device in
+          # the UI when further information is needed.
+          #
+          # TODO: this representation is a temporary solution. In the future we should likely
+          # return more complex structures, probably with an interface similar to
+          # com.redhat.Blivet0.Device or org.freedesktop.UDisks2.Block.
           dbus_reader :available_devices, "a(ssa{sv})"
 
           # result: 0 success; 1 error
@@ -65,10 +72,17 @@ module DInstaller
           end
         end
 
+        # List of disks available for installation
+        #
+        # Each device is represented by an array containing id and UI label. See the documentation
+        # of the available_devices DBus reader.
+        #
         # @see DInstaller::Storage::Proposal
+        #
+        # @return [Array<Array>]
         def available_devices
           backend.available_devices.map do |dev|
-            [dev.name, backend.available_device_label(dev), {}]
+            [dev.name, backend.device_label(dev), {}]
           end
         end
 

--- a/service/lib/dinstaller/storage/proposal.rb
+++ b/service/lib/dinstaller/storage/proposal.rb
@@ -22,6 +22,7 @@
 require "y2storage/storage_manager"
 require "y2storage/guided_proposal"
 require "y2storage/proposal_settings"
+require "y2storage/dialogs/guided_setup/helpers/disk"
 
 module DInstaller
   module Storage
@@ -41,6 +42,21 @@ module DInstaller
       # @return [Array<Y2Storage::Device>]
       def available_devices
         disk_analyzer.candidate_disks
+      end
+
+      # Label that should be used to represent the given disk in the UI
+      #
+      # The label has the form: "NAME, SIZE, [USB], INSTALLED_SYSTEMS".
+      #
+      # Examples:
+      #
+      #   "/dev/sda, 250.00 GiB, Windows, OpenSUSE"
+      #   "/dev/sdb, 8.00 GiB, USB"
+      #
+      # @param device [Y2Storage::Device]
+      # @return [String]
+      def available_device_label(device)
+        disk_helper.label(device)
       end
 
       # Name of devices where to perform the installation
@@ -118,6 +134,13 @@ module DInstaller
       # @return [Y2Storage::DiskAnalyzer]
       def disk_analyzer
         storage_manager.probed_disk_analyzer
+      end
+
+      # Helper to generate a disk label
+      #
+      # @return [Helpers::Disk]
+      def disk_helper
+        @disk_helper ||= Y2Storage::Dialogs::GuidedSetup::Helpers::Disk.new(disk_analyzer)
       end
 
       # Devicegraph representing the system

--- a/service/lib/dinstaller/storage/proposal.rb
+++ b/service/lib/dinstaller/storage/proposal.rb
@@ -46,6 +46,9 @@ module DInstaller
 
       # Label that should be used to represent the given disk in the UI
       #
+      # NOTE: this is likely a temporary solution. The label should not be calculated in the backend
+      # in the future. See the note about available_devices at {DBus::Storage::Proposal}.
+      #
       # The label has the form: "NAME, SIZE, [USB], INSTALLED_SYSTEMS".
       #
       # Examples:
@@ -55,7 +58,7 @@ module DInstaller
       #
       # @param device [Y2Storage::Device]
       # @return [String]
-      def available_device_label(device)
+      def device_label(device)
         disk_helper.label(device)
       end
 
@@ -138,7 +141,7 @@ module DInstaller
 
       # Helper to generate a disk label
       #
-      # @return [Helpers::Disk]
+      # @return [Y2Storage::Dialogs::GuidedSetup::Helpers::Disk]
       def disk_helper
         @disk_helper ||= Y2Storage::Dialogs::GuidedSetup::Helpers::Disk.new(disk_analyzer)
       end

--- a/web/src/Overview.test.jsx
+++ b/web/src/Overview.test.jsx
@@ -9,7 +9,9 @@ jest.mock("./lib/client");
 
 const proposal = {
   candidateDevices: ["/dev/sda"],
-  availableDevices: ["/dev/sda", "/dev/sdb"],
+  availableDevices: [
+    {id: "/dev/sda", label: "/dev/sda, 500 GiB"}, {id: "/dev/sdb", label: "/dev/sdb, 650 GiB"}
+  ],
   lvm: false
 };
 const actions = [{ text: "Mount /dev/sda1 as root", subvol: false }];

--- a/web/src/Storage.test.jsx
+++ b/web/src/Storage.test.jsx
@@ -8,7 +8,9 @@ import { createClient } from "./lib/client";
 jest.mock("./lib/client");
 
 const proposalSettings = {
-  availableDevices: ["/dev/sda", "/dev/sdb"],
+  availableDevices: [
+    {id: "/dev/sda", label: "/dev/sda, 500 GiB"}, {id: "/dev/sdb", label: "/dev/sdb, 650 GiB"}
+  ],
   candidateDevices: ["/dev/sda"],
   lvm: false
 };

--- a/web/src/TargetSelector.jsx
+++ b/web/src/TargetSelector.jsx
@@ -50,7 +50,7 @@ export default function TargetSelector({ target, targets, onAccept }) {
 
   const buildSelector = () => {
     const selectorOptions = targets.map(target => {
-      return <FormSelectOption key={target} value={target} label={target} />;
+      return <FormSelectOption key={target.id} value={target.id} label={target.label} />;
     });
 
     return (

--- a/web/src/lib/client/storage.js
+++ b/web/src/lib/client/storage.js
@@ -52,7 +52,10 @@ export default class StorageClient {
   async getStorageProposal() {
     const proxy = await this.proxy(STORAGE_PROPOSAL_IFACE);
     return {
-      availableDevices: proxy.AvailableDevices.map(d => d.v),
+      availableDevices: proxy.AvailableDevices.map(dev => {
+        const [{ v: id }, { v: label }] = dev.v;
+        return { id, label };
+      }),
       candidateDevices: proxy.CandidateDevices.map(d => d.v),
       lvm: proxy.LVM
     };

--- a/web/src/lib/client/storage.test.js
+++ b/web/src/lib/client/storage.test.js
@@ -8,8 +8,22 @@ const dbusClient = {};
 const storageProposalProxy = {
   wait: jest.fn(),
   AvailableDevices: [
-    { t: "s", v: "/dev/sda" },
-    { t: "s", v: "/dev/sdb" }
+    {
+      t: "av",
+      v: [
+        { t: "s", v: "/dev/sda" },
+        { t: "s", v: "/dev/sda, 950 GiB, Windows" },
+        { t: "a{sv}", v: {} }
+      ]
+    },
+    {
+      t: "av",
+      v: [
+        { t: "s", v: "/dev/sdb" },
+        { t: "s", v: "/dev/sdb, 500 GiB" },
+        { t: "a{sv}", v: {} }
+      ]
+    }
   ],
   CandidateDevices: [{ t: "s", v: "/dev/sda" }],
   LVM: true
@@ -41,7 +55,10 @@ describe("#getStorageProposal", () => {
     const client = new StorageClient(dbusClient);
     const proposal = await client.getStorageProposal();
     expect(proposal).toEqual({
-      availableDevices: ["/dev/sda", "/dev/sdb"],
+      availableDevices: [
+        { id: "/dev/sda", label: "/dev/sda, 950 GiB, Windows" },
+        { id: "/dev/sdb", label: "/dev/sdb, 500 GiB" }
+      ],
       candidateDevices: ["/dev/sda"],
       lvm: true
     });


### PR DESCRIPTION
Simple change to make the `<select>` on this form display something else than just the raw device name.

![disk_labels](https://user-images.githubusercontent.com/3638289/158595436-1dc35d47-e1fe-41e6-bfbf-d857b0b0a327.png)
