### PR TITLE
Collapse subvolume storage actions

### DIFF
--- a/service/lib/dinstaller/dbus/service.rb
+++ b/service/lib/dinstaller/dbus/service.rb
@@ -111,13 +111,13 @@ module DInstaller
 
       def storage_proposal_dbus
         @storage_proposal_dbus ||= DInstaller::DBus::Storage::Proposal.new(
-          manager.storage_proposal, storage_actions_dbus, logger
+          manager.storage.proposal, storage_actions_dbus, logger
         )
       end
 
       def storage_actions_dbus
         @storage_actions_dbus ||=
-          DInstaller::DBus::Storage::Actions.new(manager.storage_actions, logger)
+          DInstaller::DBus::Storage::Actions.new(manager.storage.actions, logger)
       end
     end
   end

--- a/service/lib/dinstaller/dbus/storage/actions.rb
+++ b/service/lib/dinstaller/dbus/storage/actions.rb
@@ -73,7 +73,11 @@ module DInstaller
         # @param action [Y2Storage::CompoundAction]
         # @return [Hash]
         def to_dbus(action)
-          { "Text" => backend.text_for(action), "Subvol" => backend.subvol_action?(action) }
+          {
+            "Text"   => action.sentence,
+            "Subvol" => action.device_is?(:btrfs_subvolume),
+            "Delete" => action.delete?
+          }
         end
       end
     end

--- a/service/lib/dinstaller/storage.rb
+++ b/service/lib/dinstaller/storage.rb
@@ -25,5 +25,6 @@ module DInstaller
   end
 end
 
+require "dinstaller/storage/manager"
 require "dinstaller/storage/proposal"
 require "dinstaller/storage/actions"

--- a/service/lib/dinstaller/storage/actions.rb
+++ b/service/lib/dinstaller/storage/actions.rb
@@ -37,22 +37,6 @@ module DInstaller
         main_actions + subvolume_actions
       end
 
-      # Text for the given action
-      #
-      # @param action [Y2Storage::CompoundAction]
-      # @return [String]
-      def text_for(action)
-        action.sentence
-      end
-
-      # Whether the action acts over a Btrfs subvolume
-      #
-      # @param action [Y2Storage::CompoundAction]
-      # @return [Boolean]
-      def subvol_action?(action)
-        action.device_is?(:btrfs_subvolume)
-      end
-
     private
 
       # @param [Logger]
@@ -92,6 +76,14 @@ module DInstaller
       def sort_actions(actions)
         delete, other = actions.partition(&:delete?)
         delete.concat(other)
+      end
+
+      # Whether the action acts over a Btrfs subvolume
+      #
+      # @param action [Y2Storage::CompoundAction]
+      # @return [Boolean]
+      def subvol_action?(action)
+        action.device_is?(:btrfs_subvolume)
       end
     end
   end

--- a/service/lib/dinstaller/storage/manager.rb
+++ b/service/lib/dinstaller/storage/manager.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "y2storage/storage_manager"
+require "dinstaller/storage/proposal"
+require "dinstaller/storage/actions"
+
+module DInstaller
+  module Storage
+    # Backend class to handle storage configuration
+    class Manager
+      def initialize(logger)
+        @logger = logger
+      end
+
+      # Probes storage devices and performs an initial proposal
+      #
+      # @param progress [Progress] Progress reporting object
+      def probe(progress)
+        logger.info "Probing storage and performing proposal"
+        progress.init_minor_steps(2, "Probing Storage Devices")
+        Y2Storage::StorageManager.instance.probe
+        progress.next_minor_step("Calculating Storage Proposal")
+        proposal.calculate
+      end
+
+      # Prepares the partitioning to install the system
+      #
+      # @param _progress [Progress] Progress reporting object
+      def install(_progress)
+        Yast::WFM.CallFunction("inst_prepdisk", [])
+      end
+
+      # Storage proposal manager
+      #
+      # @return [Storage::Proposal]
+      def proposal
+        @proposal ||= Proposal.new(logger)
+      end
+
+      # Storage actions manager
+      #
+      # @return [Storage::Actions]
+      def actions
+        @actions ||= Actions.new(logger)
+      end
+
+    private
+
+      # @return [Logger]
+      attr_reader :logger
+    end
+  end
+end

--- a/service/test/dbus/service_test.rb
+++ b/service/test/dbus/service_test.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+require "dinstaller/dbus/service"
+require "dinstaller/manager"
+
+describe DInstaller::DBus::Service do
+  subject(:service) { described_class.new(manager, logger) }
+
+  let(:logger) { Logger.new($stdout) }
+  let(:manager) { DInstaller::Manager.new(logger) }
+  let(:bus) { instance_double(::DBus::SystemBus) }
+  let(:bus_service) do
+    instance_double(::DBus::Service, export: nil)
+  end
+
+  before do
+    allow(::DBus::SystemBus).to receive(:instance).and_return(bus)
+    allow(bus).to receive(:request_service).and_return(bus_service)
+  end
+
+  describe "#export" do
+    it "exports the language manager object" do
+      language_obj = instance_double(DInstaller::DBus::Language, path: nil)
+      allow(DInstaller::DBus::Language).to receive(:new)
+        .with(manager.language, logger).and_return(language_obj)
+
+      expect(bus_service).to receive(:export).with(language_obj)
+      service.export
+    end
+
+    it "exports the software manager object" do
+      software_obj = instance_double(DInstaller::DBus::Software, path: nil)
+      allow(DInstaller::DBus::Software).to receive(:new)
+        .with(manager.software, logger).and_return(software_obj)
+
+      expect(bus_service).to receive(:export).with(software_obj)
+      service.export
+    end
+
+    it "exports the storage actions object" do
+      actions_obj = instance_double(DInstaller::DBus::Storage::Actions, path: nil)
+      allow(DInstaller::DBus::Storage::Actions).to receive(:new)
+        .with(manager.storage.actions, logger).and_return(actions_obj)
+
+      expect(bus_service).to receive(:export).with(actions_obj)
+      service.export
+    end
+
+    it "exports the storage proposal object" do
+      proposal_obj = instance_double(DInstaller::DBus::Storage::Proposal, path: nil)
+      allow(DInstaller::DBus::Storage::Proposal).to receive(:new)
+        .with(manager.storage.proposal, DInstaller::DBus::Storage::Actions, logger)
+        .and_return(proposal_obj)
+
+      expect(bus_service).to receive(:export).with(proposal_obj)
+      service.export
+    end
+
+    it "exports the users manager object" do
+      users_obj = instance_double(DInstaller::DBus::Users, path: nil)
+      allow(DInstaller::DBus::Users).to receive(:new)
+        .with(manager.users, logger).and_return(users_obj)
+
+      expect(bus_service).to receive(:export).with(users_obj)
+      service.export
+    end
+  end
+
+  describe "#dispatch" do
+    it "dispatches the messages from the bus" do
+      expect(bus).to receive(:dispatch_message_queue)
+      service.dispatch
+    end
+  end
+end

--- a/service/test/dinstaller/dbus/storage/actions_test.rb
+++ b/service/test/dinstaller/dbus/storage/actions_test.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../../test_helper"
+require "dinstaller/dbus/storage/actions"
+require "dinstaller/storage/actions"
+require "y2storage/compound_action"
+
+describe DInstaller::DBus::Storage::Actions do
+  subject { described_class.new(backend, logger) }
+
+  let(:backend) do
+    instance_double(DInstaller::Storage::Actions, all: actions)
+  end
+
+  let(:logger) { Logger.new($stdout) }
+
+  let(:actions) do
+    [
+      instance_double(
+        Y2Storage::CompoundAction,
+        sentence:   "Delete action",
+        device_is?: false,
+        delete?:    true
+      ),
+      instance_double(
+        Y2Storage::CompoundAction,
+        sentence:   "File system action",
+        device_is?: false,
+        delete?:    false
+      ),
+      instance_double(
+        Y2Storage::CompoundAction,
+        sentence:   "Subvolume action",
+        device_is?: true,
+        delete?:    false
+      )
+    ]
+  end
+
+  describe "#all" do
+    it "returns the list of actions" do
+      expect(subject.all).to contain_exactly(
+        { "Text" => "Delete action", "Subvol" => false, "Delete" => true },
+        { "Text" => "File system action", "Subvol" => false, "Delete" => false },
+        { "Text" => "Subvolume action", "Subvol" => true, "Delete" => false }
+      )
+    end
+  end
+end

--- a/service/test/dinstaller/storage/manager_test.rb
+++ b/service/test/dinstaller/storage/manager_test.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "dinstaller/storage/manager"
+require "dinstaller/progress"
+
+describe DInstaller::Storage::Manager do
+  subject(:storage) { described_class.new(logger) }
+
+  let(:logger) { Logger.new($stdout) }
+  let(:progress) { DInstaller::Progress.new }
+
+  describe "#probe" do
+    let(:y2storage_manager) { instance_double(Y2Storage::StorageManager, probe: nil) }
+    let(:proposal) { instance_double(DInstaller::Storage::Proposal, calculate: nil) }
+    let(:actions) { instance_double(DInstaller::Storage::Actions) }
+
+    before do
+      allow(DInstaller::Storage::Proposal).to receive(:new).and_return(proposal)
+      allow(DInstaller::Storage::Actions).to receive(:new).and_return(actions)
+      allow(Y2Storage::StorageManager).to receive(:instance).and_return(y2storage_manager)
+    end
+
+    it "probes the storage devices and calculates a proposal" do
+      expect(y2storage_manager).to receive(:probe)
+      expect(proposal).to receive(:calculate)
+      storage.probe(progress)
+    end
+  end
+
+  describe "#install" do
+    it "runs the inst_prepdisk client" do
+      expect(Yast::WFM).to receive(:CallFunction).with("inst_prepdisk", [])
+      storage.install(progress)
+    end
+  end
+
+  describe "#actions" do
+    it "returns an instance of the Storage::Actions class" do
+      expect(storage.actions).to be_a(DInstaller::Storage::Actions)
+    end
+  end
+
+  describe "#proposal" do
+    it "returns an instance of the Storage::Proposal class" do
+      expect(storage.proposal).to be_a(DInstaller::Storage::Proposal)
+    end
+  end
+end

--- a/web/src/Overview.test.jsx
+++ b/web/src/Overview.test.jsx
@@ -10,7 +10,8 @@ jest.mock("./lib/client");
 const proposal = {
   candidateDevices: ["/dev/sda"],
   availableDevices: [
-    {id: "/dev/sda", label: "/dev/sda, 500 GiB"}, {id: "/dev/sdb", label: "/dev/sdb, 650 GiB"}
+    { id: "/dev/sda", label: "/dev/sda, 500 GiB" },
+    { id: "/dev/sdb", label: "/dev/sdb, 650 GiB" }
   ],
   lvm: false
 };

--- a/web/src/Proposal.jsx
+++ b/web/src/Proposal.jsx
@@ -19,21 +19,46 @@
  * find current contact information at www.suse.com.
  */
 
-import React from "react";
-import { List, ListItem } from "@patternfly/react-core";
+import React, { useState } from "react";
+import { List, ListItem, ExpandableSection } from "@patternfly/react-core";
+
+const renderActionsList = actions => {
+  const items = actions.map((a, i) => {
+    return (
+      <ListItem key={i} className={a.delete ? "delete-action" : ""}>
+        {a.text}
+      </ListItem>
+    );
+  });
+  return <List>{items}</List>;
+};
 
 const Proposal = ({ data = [] }) => {
-  const renderActions = () => {
-    return data.map((p, i) => {
-      return <ListItem key={i}>{p.text}</ListItem>;
-    });
-  };
+  const [isExpanded, setIsExpanded] = useState(false);
 
   if (data.length === 0) {
     return null;
   }
 
-  return <List>{renderActions()}</List>;
+  const generalActions = data.filter(a => !a.subvol);
+  const subvolActions = data.filter(a => a.subvol);
+  const detailsText = isExpanded ? "hide details" : "see details";
+  const toggleText = `${subvolActions.length} subvolumes actions (${detailsText})`;
+
+  return (
+    <>
+      {renderActionsList(generalActions)}
+      {subvolActions.length > 0 && (
+        <ExpandableSection
+          isExpanded={isExpanded}
+          onToggle={() => setIsExpanded(!isExpanded)}
+          toggleText={toggleText}
+        >
+          {renderActionsList(subvolActions)}
+        </ExpandableSection>
+      )}
+    </>
+  );
 };
 
 export default Proposal;

--- a/web/src/Proposal.test.jsx
+++ b/web/src/Proposal.test.jsx
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) [2022] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from "react";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { installerRender } from "./test-utils";
+import Proposal from "./Proposal";
+
+const subvolAction = {
+  text: "Create subvolume @ on /dev/sda1",
+  subvol: true,
+  delete: false
+};
+
+const generalAction = {
+  text: "Mount /dev/sda1 as root",
+  subvol: false,
+  delete: false
+};
+
+it("displays the actions showing/hiding the subvolume ones on user request", () => {
+  installerRender(<Proposal data={[generalAction, subvolAction]} />);
+  expect(screen.getByText(generalAction.text)).toBeVisible();
+  expect(screen.getByText(subvolAction.text)).not.toBeVisible();
+
+  const showButton = screen.getByRole("button", { name: /see details/ });
+  userEvent.click(showButton);
+  expect(screen.getByText(subvolAction.text)).toBeVisible();
+
+  const hideButton = screen.getByRole("button", { name: /hide details/ });
+  userEvent.click(hideButton);
+  expect(screen.getByText(subvolAction.text)).not.toBeVisible();
+});

--- a/web/src/Storage.test.jsx
+++ b/web/src/Storage.test.jsx
@@ -9,7 +9,8 @@ jest.mock("./lib/client");
 
 const proposalSettings = {
   availableDevices: [
-    {id: "/dev/sda", label: "/dev/sda, 500 GiB"}, {id: "/dev/sdb", label: "/dev/sdb, 650 GiB"}
+    { id: "/dev/sda", label: "/dev/sda, 500 GiB" },
+    { id: "/dev/sdb", label: "/dev/sdb, 650 GiB" }
   ],
   candidateDevices: ["/dev/sda"],
   lvm: false
@@ -20,7 +21,8 @@ let calculateStorageProposalFn;
 
 const storageMock = {
   getStorageProposal: () => Promise.resolve(proposalSettings),
-  getStorageActions: () => Promise.resolve([{ text: "Mount /dev/sda1 as root", subvol: false }])
+  getStorageActions: () =>
+    Promise.resolve([{ text: "Mount /dev/sda1 as root", subvol: false, delete: false }])
 };
 
 beforeEach(() => {

--- a/web/src/app.scss
+++ b/web/src/app.scss
@@ -80,3 +80,7 @@ body {
   grid-row: 1/3;
   grid-column: 1/3;
 }
+
+.delete-action {
+  font-weight: bold
+}

--- a/web/src/lib/client/storage.js
+++ b/web/src/lib/client/storage.js
@@ -26,6 +26,11 @@ const STORAGE_PROPOSAL_IFACE = "org.opensuse.DInstaller.Storage.Proposal1";
 const STORAGE_ACTIONS_IFACE = "org.opensuse.DInstaller.Storage.Actions1";
 const ACTIONS_PATH = "/org/opensuse/DInstaller/Storage/Actions1";
 
+const buildAction = action => {
+  const { Text: textVar, Subvol: subvolVar, Delete: deleteVar } = action.v;
+  return { text: textVar.v, subvol: subvolVar.v, delete: deleteVar.v };
+};
+
 export default class StorageClient {
   constructor(dbusClient) {
     this._client = dbusClient;
@@ -38,10 +43,7 @@ export default class StorageClient {
    */
   async getStorageActions() {
     const proxy = await this.proxy(STORAGE_ACTIONS_IFACE);
-    return proxy.All.map(action => {
-      const { Text: textVar, Subvol: subvolVar } = action.v;
-      return { text: textVar.v, subvol: subvolVar.v };
-    });
+    return proxy.All.map(buildAction);
   }
 
   /**
@@ -75,10 +77,7 @@ export default class StorageClient {
    */
   onActionsChange(handler) {
     return this.onObjectChanged(ACTIONS_PATH, changes => {
-      const newActions = changes.All.v.map(action => {
-        const { Text: textVar, Subvol: subvolVar } = action.v;
-        return { text: textVar.v, subvol: subvolVar.v };
-      });
+      const newActions = changes.All.v.map(buildAction);
       handler({ All: newActions });
     });
   }

--- a/web/src/lib/client/storage.test.js
+++ b/web/src/lib/client/storage.test.js
@@ -34,7 +34,11 @@ const storageActionsProxy = {
   All: [
     {
       t: "a{sv}",
-      v: { Text: { t: "s", v: "Mount /dev/sdb1 as root" }, Subvol: { t: "b", v: false } }
+      v: {
+        Text: { t: "s", v: "Mount /dev/sdb1 as root" },
+        Subvol: { t: "b", v: false },
+        Delete: { t: "b", v: false }
+      }
     }
   ]
 };
@@ -69,6 +73,6 @@ describe("#getStorageActions", () => {
   it("returns the storage actions", async () => {
     const client = new StorageClient(dbusClient);
     const actions = await client.getStorageActions();
-    expect(actions).toEqual([{ text: "Mount /dev/sdb1 as root", subvol: false }]);
+    expect(actions).toEqual([{ text: "Mount /dev/sdb1 as root", subvol: false, delete: false }]);
   });
 });


### PR DESCRIPTION
The list of storage actions has been improved to:

* Emphasize the destructive actions.
* Collapse the list of subvolume-related actions.

Additionally, this PR includes moving the storage logic living in the `Manager` class to its own `Storage::Manager` class.

Trello: https://trello.com/c/9ozekC4Z/

<details>
  <summary>Hiding and showing the subvolumes list</summary>

![storage-actions](https://user-images.githubusercontent.com/15836/158800819-c188d92b-ef5a-438d-9fcd-50e8ce8524c3.gif)
</details>
