### PR TITLE
[web] Few more UI improvements

### DIFF
--- a/web/src/Proposal.jsx
+++ b/web/src/Proposal.jsx
@@ -25,7 +25,7 @@ import { List, ListItem, ExpandableSection } from "@patternfly/react-core";
 const renderActionsList = actions => {
   const items = actions.map((a, i) => {
     return (
-      <ListItem key={i} className={a.delete ? "delete-action" : ""}>
+      <ListItem key={i} className={a.delete ? "delete-action" : null}>
         {a.text}
       </ListItem>
     );

--- a/web/src/Proposal.jsx
+++ b/web/src/Proposal.jsx
@@ -25,7 +25,7 @@ import { List, ListItem, ExpandableSection } from "@patternfly/react-core";
 const renderActionsList = actions => {
   const items = actions.map((a, i) => {
     return (
-      <ListItem key={i} className={a.delete ? "delete-action" : null}>
+      <ListItem key={i} className={a.delete ? "proposal-action--delete" : null}>
         {a.text}
       </ListItem>
     );

--- a/web/src/Proposal.jsx
+++ b/web/src/Proposal.jsx
@@ -30,7 +30,7 @@ const renderActionsList = actions => {
       </ListItem>
     );
   });
-  return <List>{items}</List>;
+  return <List className="proposal-actions">{items}</List>;
 };
 
 const Proposal = ({ data = [] }) => {
@@ -53,6 +53,7 @@ const Proposal = ({ data = [] }) => {
           isExpanded={isExpanded}
           onToggle={() => setIsExpanded(!isExpanded)}
           toggleText={toggleText}
+          className="expandable-actions"
         >
           {renderActionsList(subvolActions)}
         </ExpandableSection>

--- a/web/src/Proposal.jsx
+++ b/web/src/Proposal.jsx
@@ -50,6 +50,7 @@ const Proposal = ({ data = [] }) => {
       {renderActionsList(generalActions)}
       {subvolActions.length > 0 && (
         <ExpandableSection
+          isIndented
           isExpanded={isExpanded}
           onToggle={() => setIsExpanded(!isExpanded)}
           toggleText={toggleText}

--- a/web/src/app.scss
+++ b/web/src/app.scss
@@ -1,10 +1,3 @@
-// Import PatternFly CSS
-@use "@patternfly/react-core/dist/styles/base.css";
-@use "@patternfly/patternfly/patternfly.css";
-
-// See https://github.com/patternfly/patternfly/pull/4297
-@use "@patternfly/react-styles/css/utilities/Sizing/sizing.css";
-
 // NOTE: eos-base/index imports a lot of styles not needed by now. Hence, let's
 // start importing them granularly until we have time to investigate how to purge
 // or "tree-shake" CSS while building (although it might not help while working
@@ -49,50 +42,24 @@ body {
   }
 }
 
-.component--centered {
+.loading-screen-icon {
   text-align: center;
+
+  svg {
+    block-size: 10rem;
+    inline-size: 10rem;
+  }
 }
 
 .success-icon {
   fill: branding.$eos-bc-green-500;
 }
 
-// PatternFly overrides for using CSS Logical Properties
-
-.pf-l-split.pf-m-gutter > :not(:last-child) {
-  margin-inline-end: var(--pf-l-split--m-gutter--MarginRight);
-}
-
-.pf-l-flex.pf-m-column > * {
-  margin: 0;
-  margin-block-end: var(--pf-l-flex--spacer);
-}
-
-.pf-c-alert__icon {
-  margin-block-start: var(--pf-c-alert__icon--MarginTop);
-  margin-inline-end: var(--pf-c-alert__icon--MarginRight);
-}
-
-.pf-m-grid-md.pf-c-table [data-label]::before {
-  text-align: start;
-}
-
-// EOS icons does not obey font-size
-.pf-c-empty-state__icon {
-  inline-size: 10rem;
-  block-size: 10rem;
-}
-
-// Fix single-line subprogress missaligment
-.pf-c-progress.pf-m-singleline .pf-c-progress__bar {
-  grid-row: 1/3;
-  grid-column: 1/3;
-}
-
 // Make proposal actiosn compact
 .proposal-actions li + li {
   margin-block-start: 0;
 }
+
 // Aling the expandable-actions with the actions list
 // See https://www.patternfly.org/v4/components/list#css-variables
 .expandable-actions {
@@ -102,6 +69,7 @@ body {
     - var(--pf-global--icon--FontSize--sm) // --pf-c-list--m-icon-lg__item-icon-MinWidth
   );
 }
+
 .expandable-actions > div {
   margin-block-start: 0;
 }

--- a/web/src/app.scss
+++ b/web/src/app.scss
@@ -93,7 +93,15 @@ body {
 .proposal-actions li + li {
   margin-block-start: 0;
 }
-
+// Aling the expandable-actions with the actions list
+// See https://www.patternfly.org/v4/components/list#css-variables
+.expandable-actions {
+  margin-inline-start: calc(
+    var(--pf-global--spacer--lg) // --pf-c-list--PaddingLeft
+    - var(--pf-global--spacer--sm) // --pf-c-list--nested--MarginLeft
+    - var(--pf-global--icon--FontSize--sm) // --pf-c-list--m-icon-lg__item-icon-MinWidth
+  );
+}
 .expandable-actions > div {
   margin-block-start: 0;
 }

--- a/web/src/app.scss
+++ b/web/src/app.scss
@@ -64,7 +64,7 @@ body {
   font-weight: bold
 }
 
-// Aling the expandable-actions with the actions list
+// Align the expandable-actions with the actions list
 // See https://www.patternfly.org/v4/components/list#css-variables
 .expandable-actions {
   margin-inline-start: calc(

--- a/web/src/app.scss
+++ b/web/src/app.scss
@@ -89,6 +89,15 @@ body {
   grid-column: 1/3;
 }
 
+// Make proposal actiosn compact
+.proposal-actions li + li {
+  margin-block-start: 0;
+}
+
+.expandable-actions > div {
+  margin-block-start: 0;
+}
+
 .delete-action {
   font-weight: bold
 }

--- a/web/src/app.scss
+++ b/web/src/app.scss
@@ -60,6 +60,10 @@ body {
   margin-block-start: 0;
 }
 
+.proposal-action--delete {
+  font-weight: bold
+}
+
 // Aling the expandable-actions with the actions list
 // See https://www.patternfly.org/v4/components/list#css-variables
 .expandable-actions {
@@ -72,8 +76,4 @@ body {
 
 .expandable-actions > div {
   margin-block-start: 0;
-}
-
-.delete-action {
-  font-weight: bold
 }

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -27,6 +27,7 @@ import { InstallerClientProvider } from "./context/installer";
 import { AuthProvider } from "./context/auth";
 import { createClient } from "./lib/client";
 
+import "./patternfly.scss";
 import "./app.scss";
 import "./layout.scss";
 

--- a/web/src/patternfly.scss
+++ b/web/src/patternfly.scss
@@ -1,0 +1,37 @@
+// Import PatternFly CSS
+@use "@patternfly/react-core/dist/styles/base.css";
+@use "@patternfly/patternfly/patternfly.css";
+
+// See https://github.com/patternfly/patternfly/pull/4297
+@use "@patternfly/react-styles/css/utilities/Sizing/sizing.css";
+
+// PatternFly overrides for using CSS Logical Properties
+.pf-l-split.pf-m-gutter > :not(:last-child) {
+  margin-inline-end: var(--pf-l-split--m-gutter--MarginRight);
+}
+
+.pf-l-flex.pf-m-column > * {
+  margin: 0;
+  margin-block-end: var(--pf-l-flex--spacer);
+}
+
+.pf-c-alert__icon {
+  margin-block-start: var(--pf-c-alert__icon--MarginTop);
+  margin-inline-end: var(--pf-c-alert__icon--MarginRight);
+}
+
+.pf-m-grid-md.pf-c-table [data-label]::before {
+  text-align: start;
+}
+
+// EOS icons does not obey font-size
+.pf-c-empty-state__icon {
+  inline-size: 10rem;
+  block-size: 10rem;
+}
+
+// Fix single-line subprogress missaligment
+.pf-c-progress.pf-m-singleline .pf-c-progress__bar {
+  grid-row: 1/3;
+  grid-column: 1/3;
+}


### PR DESCRIPTION
This PR basically changes a bit the presentation of proposal actions

* making the list more compact
* aligning the collapsible actions with the list
* indenting collapsed actions

| | Before | After |
|-|-|-|
| Collapsed | ![Screen Shot 2022-03-18 at 09 43 53-fullpage](https://user-images.githubusercontent.com/1691872/158979857-a00bc433-b6bd-4cc5-bf72-9ad8a2c85f05.png) | ![Screen Shot 2022-03-18 at 09 45 39-fullpage](https://user-images.githubusercontent.com/1691872/158979887-9e2b61b0-9456-4f86-9fa7-441aed6842a0.png) |
| Expanded | ![Screen Shot 2022-03-18 at 09 43 50-fullpage](https://user-images.githubusercontent.com/1691872/158979942-22293567-2e1b-4bae-b1c2-f56887fd98d6.png) | ![Screen Shot 2022-03-18 at 09 45 42-fullpage](https://user-images.githubusercontent.com/1691872/158979974-da37f2f9-cd3f-4c7b-bfde-f52bfc56ac72.png) |

Additionally, it moves PatternFly CSS imports and overrides to its own SCSS file.

