### PR TITLE
WIP: Experimenting how to make the layout more scalable

### DIFF
--- a/web/src/DBusError.jsx
+++ b/web/src/DBusError.jsx
@@ -22,13 +22,13 @@
 import React from "react";
 import { Button, Title, EmptyState, EmptyStateIcon, EmptyStateBody } from "@patternfly/react-core";
 
-import Layout from "./Layout";
-import Center from "./Center";
-
 import {
   EOS_ANNOUNCEMENT as SectionIcon,
   EOS_ENDPOINTS_DISCONNECTED as DisconnectionIcon
 } from "eos-icons-react";
+
+import Center from "./Center";
+import { SectionTitle } from "./layout/SectionTitle";
 
 // TODO: an example
 const ReloadAction = () => (
@@ -39,19 +39,18 @@ const ReloadAction = () => (
 
 function DBusError() {
   return (
-    <Layout sectionTitle="D-Bus Error" SectionIcon={SectionIcon} FooterActions={ReloadAction}>
-      <Center>
-        <EmptyState>
-          <EmptyStateIcon icon={DisconnectionIcon} />
-          <Title headingLevel="h4" size="lg">
-            Cannot connect to D-Bus
-          </Title>
-          <EmptyStateBody>
-            Could not connect to the D-Bus service. Please, check whether it is running.
-          </EmptyStateBody>
-        </EmptyState>
-      </Center>
-    </Layout>
+    <Center>
+      <SectionTitle>D-Bus error</SectionTitle>
+      <EmptyState>
+        <EmptyStateIcon icon={DisconnectionIcon} />
+        <Title headingLevel="h4" size="lg">
+          Cannot connect to D-Bus
+        </Title>
+        <EmptyStateBody>
+          Could not connect to the D-Bus service. Please, check whether it is running.
+        </EmptyStateBody>
+      </EmptyState>
+    </Center>
   );
 }
 

--- a/web/src/InstallationFinished.jsx
+++ b/web/src/InstallationFinished.jsx
@@ -30,14 +30,15 @@ import {
   EmptyStateSecondaryActions
 } from "@patternfly/react-core";
 
-import Layout from "./Layout";
-import Center from "./Center";
 import { useInstallerClient } from "./context/installer";
 
 import {
   EOS_TASK_ALT as InstallationFinishedIcon,
   EOS_CHECK_CIRCLE as SectionIcon
 } from "eos-icons-react";
+
+import Center from "./Center";
+import { SectionTitle } from "./layout/SectionTitle";
 
 const Actions = ({ onRestart }) => (
   <Button isLarge variant="secondary" onClick={onRestart}>
@@ -50,35 +51,30 @@ function InstallationFinished() {
   const onRestartAction = () => client.manager.startProbing();
 
   return (
-    <Layout
-      sectionTitle="Installation Finished"
-      SectionIcon={SectionIcon}
-      FooterActions={() => <Actions onRestart={onRestartAction} />}
-    >
-      <Center>
-        <EmptyState>
-          <EmptyStateIcon icon={InstallationFinishedIcon} className="success-icon" />
-          <Title headingLevel="h2" size="4xl">
-            Congratulations!
-          </Title>
-          <EmptyStateBody className="pf-c-content">
-            <div>
-              <Text>The installation on your machine is complete.</Text>
-              <Text>
-                At this point you can 'Restart installation' to continue playing with D-Installer or
-                manually reboot the machine to log in to the new system.
-              </Text>
-              <Text>Have a lot of fun! Your openSUSE Development Team.</Text>
-            </div>
-            <EmptyStateSecondaryActions>
-              <Button component="a" href="https://www.opensuse.org" target="_blank" variant="link">
-                www.opensuse.org
-              </Button>
-            </EmptyStateSecondaryActions>
-          </EmptyStateBody>
-        </EmptyState>
-      </Center>
-    </Layout>
+    <Center>
+      <SectionTitle>Installation Finished</SectionTitle>
+      <EmptyState>
+        <EmptyStateIcon icon={InstallationFinishedIcon} className="success-icon" />
+        <Title headingLevel="h2" size="4xl">
+          Congratulations!
+        </Title>
+        <EmptyStateBody className="pf-c-content">
+          <div>
+            <Text>The installation on your machine is complete.</Text>
+            <Text>
+              At this point you can 'Restart installation' to continue playing with D-Installer or
+              manually reboot the machine to log in to the new system.
+            </Text>
+            <Text>Have a lot of fun! Your openSUSE Development Team.</Text>
+          </div>
+          <EmptyStateSecondaryActions>
+            <Button component="a" href="https://www.opensuse.org" target="_blank" variant="link">
+              www.opensuse.org
+            </Button>
+          </EmptyStateSecondaryActions>
+        </EmptyStateBody>
+      </EmptyState>
+    </Center>
   );
 }
 

--- a/web/src/InstallationProgress.jsx
+++ b/web/src/InstallationProgress.jsx
@@ -22,18 +22,17 @@
 import React from "react";
 
 import Center from "./Center";
-import Layout from "./Layout";
 import ProgressReport from "./ProgressReport";
+import { SectionTitle } from "./layout/SectionTitle";
 
 import { EOS_DOWNLOADING as SectionIcon } from "eos-icons-react";
 
 function InstallationProgress() {
   return (
-    <Layout sectionTitle="Installing" SectionIcon={SectionIcon}>
-      <Center>
-        <ProgressReport />
-      </Center>
-    </Layout>
+    <Center>
+      <SectionTitle>Installing</SectionTitle>
+      <ProgressReport />
+    </Center>
   );
 }
 

--- a/web/src/LanguageSelector.jsx
+++ b/web/src/LanguageSelector.jsx
@@ -32,6 +32,8 @@ import {
   ModalVariant
 } from "@patternfly/react-core";
 
+import { SectionTitle } from "./layout/SectionTitle";
+
 const reducer = (state, action) => {
   switch (action.type) {
     case "LOAD": {
@@ -132,6 +134,7 @@ export default function LanguageSelector() {
           </Button>
         ]}
       >
+        <SectionTitle>Select the language</SectionTitle>
         <Form>
           <FormGroup
             fieldId="language"

--- a/web/src/LoadingEnvironment.jsx
+++ b/web/src/LoadingEnvironment.jsx
@@ -22,23 +22,21 @@
 import React from "react";
 import { Title, EmptyState, EmptyStateIcon } from "@patternfly/react-core";
 
-import Layout from "./Layout";
 import Center from "./Center";
+import { SectionTitle } from "./layout/SectionTitle";
 
 import { EOS_THREE_DOTS_LOADING_ANIMATED as LoadingIcon } from "eos-icons-react";
 
 function LoadingEnvironment() {
   return (
-    <Layout sectionTitle="D-Installer">
-      <Center>
-        <EmptyState>
-          <EmptyStateIcon icon={LoadingIcon} />
-          <Title headingLevel="h4" size="lg">
-            Loading installation environment, please wait.
-          </Title>
-        </EmptyState>
-      </Center>
-    </Layout>
+    <Center>
+      <EmptyState>
+        <EmptyStateIcon icon={LoadingIcon} />
+        <Title headingLevel="h4" size="lg">
+          Loading installation environment, please wait.
+        </Title>
+      </EmptyState>
+    </Center>
   );
 }
 

--- a/web/src/LoginForm.jsx
+++ b/web/src/LoginForm.jsx
@@ -24,7 +24,7 @@ import { useAuthContext } from "./context/auth";
 import { Alert, Button, Form, FormAlert, FormGroup, TextInput } from "@patternfly/react-core";
 
 import Center from "./Center";
-import Layout from "./Layout";
+import { SectionTitle } from "./layout/SectionTitle";
 
 const formError = error => (
   <FormAlert>
@@ -64,19 +64,19 @@ function LoginForm() {
   };
 
   return (
-    <Layout sectionTitle="Welcome to D-Installer" FooterActions={SubmitButton}>
-      <Center>
-        <Form id="d-installer-login">
-          {error && formError(error)}
-          <FormGroup label="Username" fieldId="username">
-            <TextInput isRequired type="text" id="username" ref={usernameRef} />
-          </FormGroup>
-          <FormGroup label="Password" fieldId="password">
-            <TextInput isRequired type="password" id="password" ref={passwordRef} />
-          </FormGroup>
-        </Form>
-      </Center>
-    </Layout>
+    <Center>
+      <SectionTitle>Please, log in</SectionTitle>
+      <Form id="d-installer-login">
+        {error && formError(error)}
+        <FormGroup label="Username" fieldId="username">
+          <TextInput isRequired type="text" id="username" ref={usernameRef} />
+        </FormGroup>
+        <FormGroup label="Password" fieldId="password">
+          <TextInput isRequired type="password" id="password" ref={passwordRef} />
+        </FormGroup>
+        <SubmitButton />
+      </Form>
+    </Center>
   );
 }
 

--- a/web/src/Overview.jsx
+++ b/web/src/Overview.jsx
@@ -24,11 +24,11 @@ import { useInstallerClient } from "./context/installer";
 
 import { Button, Flex, FlexItem } from "@patternfly/react-core";
 
-import Layout from "./Layout";
 import Category from "./Category";
 import LanguageSelector from "./LanguageSelector";
 import ProductSelector from "./ProductSelector";
 import Storage from "./Storage";
+import { SectionTitle } from "./layout/SectionTitle";
 
 import {
   EOS_FACT_CHECK as OverviewIcon,
@@ -71,13 +71,10 @@ function Overview() {
   };
 
   return (
-    <Layout
-      sectionTitle="Installation Summary"
-      SectionIcon={OverviewIcon}
-      FooterActions={InstallButton}
-    >
+    <>
+      <SectionTitle>Installation Summary</SectionTitle>
       <Flex direction={{ default: "column" }}>{renderCategories()}</Flex>
-    </Layout>
+    </>
   );
 }
 

--- a/web/src/ProbingProgress.jsx
+++ b/web/src/ProbingProgress.jsx
@@ -22,17 +22,16 @@
 import React from "react";
 
 import Center from "./Center";
-import Layout from "./Layout";
 import ProgressReport from "./ProgressReport";
+import { SectionTitle } from "./layout/SectionTitle";
 
 import { EOS_MULTISTATE as SectionIcon } from "eos-icons-react";
 
 const ProbingProgress = () => (
-  <Layout sectionTitle="Probing" SectionIcon={SectionIcon}>
-    <Center>
-      <ProgressReport />
-    </Center>
-  </Layout>
+  <Center>
+    <SectionTitle>Probing</SectionTitle>
+    <ProgressReport />
+  </Center>
 );
 
 export default ProbingProgress;

--- a/web/src/layout/Layout.jsx
+++ b/web/src/layout/Layout.jsx
@@ -21,6 +21,8 @@
 
 import React from "react";
 
+import { SectionTitlePlaceholder } from "./SectionTitle";
+
 /**
  * D-Installer main layout component.
  *
@@ -76,7 +78,7 @@ function Layout({
         <div className="layout__header-section-title">
           <h1>
             {SectionIcon && <SectionIcon className="layout__header-section-title-icon" />}
-            {sectionTitle}
+            <SectionTitlePlaceholder>D-Installer</SectionTitlePlaceholder>
           </h1>
         </div>
       </div>

--- a/web/src/layout/SectionTitle.jsx
+++ b/web/src/layout/SectionTitle.jsx
@@ -1,0 +1,18 @@
+import React, { useRef } from "react";
+
+import createLayoutSlot from "./slot";
+
+const Slot = createLayoutSlot();
+
+export function SectionTitlePlaceholder({ children, ...props }) {
+  const slotRef = useRef();
+  return (
+    <Slot.Placeholder ref={slotRef} {...props}>
+      {children}
+    </Slot.Placeholder>
+  );
+}
+
+export function SectionTitle({ children }) {
+  return <Slot.Content>{children}</Slot.Content>;
+}

--- a/web/src/layout/slot.jsx
+++ b/web/src/layout/slot.jsx
@@ -1,0 +1,68 @@
+import React, { forwardRef, useState, useImperativeHandle, useEffect } from "react";
+
+/**
+ * Function for creating a layout slot.
+ *
+ */
+export default function createLayoutSlot() {
+  const slot = { ref: null, defaultContent: null, previousContent: null };
+
+  const Placeholder = forwardRef(({ as: SlotContainer = "div", children, ...props }, ref) => {
+    console.log("props", props, "children", children);
+    const [content, setContent] = useState(children);
+    console.log("Rendering slot with default", children, "and content", content);
+    slot.defaultContent = children;
+
+    useImperativeHandle(ref, () => ({
+      changeContent: newContent => {
+        console.info("Saving previous slot content ", content);
+        slot.previousContent = content;
+        console.info("Changing the slot content to", newContent);
+        setContent(newContent);
+      }
+    }));
+
+    slot.ref = ref;
+
+    return (
+      <SlotContainer ref={ref} {...props}>
+        {content}
+      </SlotContainer>
+    );
+  });
+
+  const Content = ({ children }) => {
+    const container = slot.ref;
+    console.log("rendering Slot Content", children, container);
+
+    useEffect(() => {
+      // Set the new content, only if the container is available
+      if (container.current) {
+        console.log("calling #ChangeContent of ", container.current);
+
+        container.current.changeContent(children);
+      }
+
+      return () => {
+        if (!container) return;
+        // FIXME: this is tricky because usually defaultContent became previousContent
+        // Maybe defaultContent does not make sense
+        const contentToRestore = slot.previousContent ? slot.previousContent: slot.defaultContent;
+
+        // Restore previous or initial content
+        if (contentToRestore) {
+          container.current.changeContent(contentToRestore);
+          slot.previousContent = null;
+        }
+      };
+    }, [children]);
+
+    // Always return null, as it is changing the content of the slot;
+    return null;
+  };
+
+  Placeholder.displayName = "Layout Slot Placeholder";
+  Content.displayName = "Layout Slot Content";
+
+  return { Placeholder, Content };
+}

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -27,6 +27,8 @@ import { InstallerClientProvider } from "./context/installer";
 import { AuthProvider } from "./context/auth";
 import { createClient } from "./lib/client";
 
+import Layout from "./layout/Layout";
+
 import "./patternfly.scss";
 import "./app.scss";
 import "./layout.scss";
@@ -37,7 +39,9 @@ ReactDOM.render(
   <StrictMode>
     <InstallerClientProvider client={client}>
       <AuthProvider>
-        <App />
+        <Layout>
+          <App />
+        </Layout>
       </AuthProvider>
     </InstallerClientProvider>
   </StrictMode>,


### PR DESCRIPTION
This is an **incomplete** idea to make the layout more scalable, mounting it only once instead of every time a new component/screen is displayed.

It is highly inspired by https://gregberge.com/blog/react-scalable-layout but using the technique explained in https://www.sabinthedev.com/blog/using-a-react-components-function-from-its-parent instead of [React Portals](https://reactjs.org/docs/portals.html#gatsby-focus-wrapper).

  > In a React application, composition must always be preferred.
  > The layout is no exception.

At the time of creating this draft PR, only for sharing the idea, there are some issues and questions around:

* Only the SectionTitle has been adapted to use the "slot technique". Enough for discussing the topic.
* React documentation says that
  * [useRef](https://reactjs.org/docs/hooks-reference.html#useref) _doesn’t notify you when its content changes_, which I don't know now if it is a problem for this use case.
  * [useImperativeHandle](https://reactjs.org/docs/hooks-reference.html#useimperativehandle) _should be avoided in most cases_, but maybe this is a valid use case for it. Each _slot placeholder_ is exposing its _setContent_ to the component in charge of transfer the content for it. Not exactly a _parent_ component, but it works nicely, at least in the few manual tests done.