### PR TITLE
Add user tests and fix users collection handling

### DIFF
--- a/service/lib/dinstaller/users.rb
+++ b/service/lib/dinstaller/users.rb
@@ -103,7 +103,14 @@ module DInstaller
     end
 
     def root_user
-      @root_user ||= config.users.root || Y2Users::User.create_root
+      return @root_user if @root_user
+
+      @root_user = config.users.root
+      return @root_user if @root_user
+
+      @root_user = Y2Users::User.create_root
+      config.attach(@root_user)
+      @root_user
     end
   end
 end

--- a/service/lib/dinstaller/users.rb
+++ b/service/lib/dinstaller/users.rb
@@ -63,7 +63,9 @@ module DInstaller
 
     def assign_first_user(full_name, user_name, password, auto_login, _data)
       # at first remove previous first user
-      config.users.reject(&:root?).map(&:id).each { |id| config.users.delete(id) }
+      old_users = config.users.reject(&:root?)
+      config.detach(old_users) unless old_users.empty?
+
       return if user_name.empty? # empty is used to remove first user
 
       user = Y2Users::User.new(user_name)

--- a/service/test/dinstaller/users_test.rb
+++ b/service/test/dinstaller/users_test.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+require "dinstaller/progress"
+require "dinstaller/users"
+
+describe DInstaller::Users do
+  subject(:storage) { described_class.new(logger) }
+
+  let(:logger) { Logger.new($stdout) }
+  let(:progress) { DInstaller::Progress.new }
+
+  let(:users_config) { Y2Users::Config.new }
+
+  before do
+    allow(Y2Users::ConfigManager.instance).to receive(:target)
+      .and_return(users_config)
+  end
+
+  describe "#assign_root_password" do
+    let(:root_user) { instance_double(Y2Users::User) }
+
+    context "when the password is encrypted" do
+      it "sets the password as encrypted" do
+        subject.assign_root_password("encrypted", true)
+        root_user = users_config.users.root
+        expect(root_user.password).to eq(Y2Users::Password.create_encrypted("encrypted"))
+      end
+    end
+
+    context "when the password is not encrypted" do
+      it "sets the password in clear text" do
+        subject.assign_root_password("12345", false)
+        root_user = users_config.users.root
+        expect(root_user.password).to eq(Y2Users::Password.create_plain("12345"))
+      end
+    end
+  end
+
+  describe "#root_password?" do
+    it "returns true if the root password is set" do
+      subject.assign_root_password("12345", false)
+      expect(subject.root_password?).to eq(true)
+    end
+
+    it "returns false if the root password is not set" do
+      expect(subject.root_password?).to eq(false)
+    end
+  end
+
+  describe "#assign_first_user" do
+    it "adds the user to the user's configuration" do
+      subject.assign_first_user("Jane Doe", "jane", "12345", false, {})
+      user = users_config.users.by_name("jane")
+      expect(user.full_name).to eq("Jane Doe")
+      expect(user.password).to eq(Y2Users::Password.create_plain("12345"))
+    end
+
+    context "when a first user exists" do
+      before do
+        subject.assign_first_user("Jane Doe", "jane", "12345", false, {})
+      end
+
+      it "replaces the user with the new one" do
+        subject.assign_first_user("John Doe", "john", "12345", false, {})
+
+        user = users_config.users.by_name("jane")
+        expect(user).to be_nil
+
+        user = users_config.users.by_name("john")
+        expect(user.full_name).to eq("John Doe")
+      end
+
+      context "and the given user name is empty" do
+        it "removes the already defined first user" do
+          expect { subject.assign_first_user("", "", "", false, {}) }
+            .to change { users_config.users.by_name("jane") }
+            .from(Y2Users::User).to(nil)
+        end
+      end
+    end
+  end
+
+  describe "#write" do
+    let(:writer) { instance_double(Y2Users::Linux::Writer, write: issues) }
+    let(:issues) { [] }
+
+    let(:system_config) do
+      user = Y2Users::User.create_system("messagebus")
+      config = Y2Users::Config.new
+      config.attach(user)
+    end
+
+    before do
+      allow(Y2Users::ConfigManager.instance).to receive(:system)
+        .with(force_read: true).and_return(system_config)
+      allow(Y2Users::Linux::Writer).to receive(:new).and_return(writer)
+    end
+
+    it "writes system and installer defined users" do
+      subject.assign_first_user("Jane Doe", "jane", "12345", false, {})
+
+      expect(Y2Users::Linux::Writer).to receive(:new) do |target_config, _old_config|
+        user_names = target_config.users.map(&:name)
+        expect(user_names).to include("messagebus", "jane")
+        writer
+      end
+
+      expect(writer).to receive(:write).and_return([])
+      subject.write(progress)
+    end
+
+    context "if some issue occurs" do
+      let(:issues) { [double("issue")] }
+
+      it "logs the issue" do
+        expect(logger).to receive(:error).with(/issue/)
+        subject.write(progress)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add tests for the `DInstaller::Users` class. Additionally, it fixes issues:

* Properly update the first user if it is already defined. The collection of users is frozen, so you it is expected to call `Config#detach` to remove elements from it.
* If the root user does not exist in the inst-sys (not expected), it will not be present in the final system.