### PR TITLE
Relax dependency on ruby-dbus

### DIFF
--- a/service/d-installer.gemspec
+++ b/service/d-installer.gemspec
@@ -47,5 +47,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "fast_gettext", "~> 2.2.0"
   spec.add_dependency "nokogiri", "~> 1.13.1"
   spec.add_dependency "rexml", "~> 3.2.5"
-  spec.add_dependency "ruby-dbus", "~> 0.17.0"
+  spec.add_dependency "ruby-dbus", ">= 0.17.0"
 end


### PR DESCRIPTION
Using a conservative approach on RubyGems dependencies prevents the service to use newer ruby-dbus versions. For gems that are out of our control it is OK, but in this case let's relax the dependency so we can use anything above version 0.17.