### PR TITLE
Updated users summary

### DIFF
--- a/web/src/FirstUser.jsx
+++ b/web/src/FirstUser.jsx
@@ -126,7 +126,7 @@ export default function Users() {
     );
   };
 
-  const link = (content) => (
+  const link = content => (
     <Button variant="link" isInline onClick={open}>
       {content}
     </Button>

--- a/web/src/FirstUser.jsx
+++ b/web/src/FirstUser.jsx
@@ -8,6 +8,7 @@ import {
   FormGroup,
   Modal,
   ModalVariant,
+  Text,
   TextInput
 } from "@patternfly/react-core";
 
@@ -82,14 +83,6 @@ export default function Users() {
     dispatch({ type: "ACCEPT" });
   };
 
-  const userLabel = () => {
-    if (user !== undefined && user.userName != "") {
-      return "User " + user.userName + " Set.";
-    } else {
-      return "First User Not Set.";
-    }
-  };
-
   const userForm = () => {
     return (
       <Form>
@@ -133,11 +126,23 @@ export default function Users() {
     );
   };
 
+  const link = (content) => (
+    <Button variant="link" isInline onClick={open}>
+      {content}
+    </Button>
+  );
+
+  const renderLink = () => {
+    if (user?.userName !== "") {
+      return <Text>User {link(user.userName)} is defined</Text>;
+    } else {
+      return <Text>A user {link("is not defined")}</Text>;
+    }
+  };
+
   return (
     <>
-      <Button variant="link" onClick={open}>
-        {userLabel()}
-      </Button>
+      {renderLink()}
 
       <Modal
         isOpen={isFormOpen}

--- a/web/src/Overview.jsx
+++ b/web/src/Overview.jsx
@@ -22,7 +22,7 @@
 import React from "react";
 import { useInstallerClient } from "./context/installer";
 
-import { Button, Flex, FlexItem, Stack, StackItem } from "@patternfly/react-core";
+import { Button, Flex, FlexItem } from "@patternfly/react-core";
 
 import Layout from "./Layout";
 import Category from "./Category";

--- a/web/src/Overview.jsx
+++ b/web/src/Overview.jsx
@@ -31,6 +31,7 @@ import ProductSelector from "./ProductSelector";
 import Storage from "./Storage";
 import FirstUser from "./FirstUser";
 import RootUser from "./RootUser";
+import RootSSHKey from "./RootSSHKey";
 
 import {
   EOS_FACT_CHECK as OverviewIcon,
@@ -51,6 +52,9 @@ function Overview() {
       <Stack>
         <StackItem>
           <RootUser />
+        </StackItem>
+        <StackItem>
+          <RootSSHKey />
         </StackItem>
         <StackItem>
           <FirstUser />

--- a/web/src/Overview.jsx
+++ b/web/src/Overview.jsx
@@ -29,9 +29,7 @@ import Category from "./Category";
 import LanguageSelector from "./LanguageSelector";
 import ProductSelector from "./ProductSelector";
 import Storage from "./Storage";
-import FirstUser from "./FirstUser";
-import RootUser from "./RootUser";
-import RootSSHKey from "./RootSSHKey";
+import Users from "./Users";
 
 import {
   EOS_FACT_CHECK as OverviewIcon,
@@ -49,17 +47,7 @@ function Overview() {
       <LanguageSelector />
     </Category>,
     <Category title="Users" icon={UsersIcon}>
-      <Stack>
-        <StackItem>
-          <RootUser />
-        </StackItem>
-        <StackItem>
-          <RootSSHKey />
-        </StackItem>
-        <StackItem>
-          <FirstUser />
-        </StackItem>
-      </Stack>
+      <Users />
     </Category>,
     <Category title="Product" icon={ProductsIcon}>
       <ProductSelector />

--- a/web/src/RootSSHKey.jsx
+++ b/web/src/RootSSHKey.jsx
@@ -60,7 +60,7 @@ export default function RootSSHKey() {
       </Button>
     );
 
-    return <Text>SSH public key {link}</Text>;
+    return <Text>Root SSH public key {link}</Text>;
   };
 
   return (

--- a/web/src/RootSSHKey.jsx
+++ b/web/src/RootSSHKey.jsx
@@ -56,7 +56,7 @@ export default function RootSSHKey({ value, onValueChange }) {
     setIsFormOpen(false);
   };
 
-  const cancel = () => {};
+  const cancel = () => setIsFormOpen(false);
   const open = () => setIsFormOpen(true);
 
   if (sshKey === null) return null;

--- a/web/src/RootSSHKey.jsx
+++ b/web/src/RootSSHKey.jsx
@@ -21,7 +21,15 @@
 
 import React, { useState, useEffect } from "react";
 import { useInstallerClient } from "./context/installer";
-import { Button, Form, FormGroup, Modal, ModalVariant, TextInput } from "@patternfly/react-core";
+import {
+  Button,
+  Form,
+  FormGroup,
+  Modal, 
+  ModalVariant,
+  Text,
+  TextInput
+} from "@patternfly/react-core";
 import { FileUpload } from "@patternfly/react-core";
 
 export default function RootSSHKey({ value, onValueChange }) {
@@ -32,9 +40,9 @@ export default function RootSSHKey({ value, onValueChange }) {
 
   const sshKeyLabel = () => {
     if (sshKey === "") {
-      return "SSH Key Not Set. ";
+      return "SSH public key is not set ";
     } else {
-      return "SSH Key Set. ";
+      return "SSH public key is set";
     }
   };
 
@@ -53,12 +61,20 @@ export default function RootSSHKey({ value, onValueChange }) {
 
   if (sshKey === null) return null;
 
+  const renderLink = () => {
+    const label = sshKey !== "" ? "is set" : "is not set";
+    const link = <Button variant="link" isInline onClick={open}>
+      {label}
+    </Button>
+
+    return (
+      <Text>SSH public key {link}</Text>
+    );
+  };
+
   return (
     <>
-      <Button variant="link" onClick={open}>
-        {sshKeyLabel()}
-      </Button>
-
+      {renderLink()}
       <Modal
         isOpen={isFormOpen}
         showClose={false}

--- a/web/src/RootSSHKey.jsx
+++ b/web/src/RootSSHKey.jsx
@@ -25,7 +25,7 @@ import {
   Button,
   Form,
   FormGroup,
-  Modal, 
+  Modal,
   ModalVariant,
   Text,
   TextInput
@@ -63,13 +63,13 @@ export default function RootSSHKey({ value, onValueChange }) {
 
   const renderLink = () => {
     const label = sshKey !== "" ? "is set" : "is not set";
-    const link = <Button variant="link" isInline onClick={open}>
-      {label}
-    </Button>
-
-    return (
-      <Text>SSH public key {link}</Text>
+    const link = (
+      <Button variant="link" isInline onClick={open}>
+        {label}
+      </Button>
     );
+
+    return <Text>SSH public key {link}</Text>;
   };
 
   return (
@@ -103,7 +103,7 @@ export default function RootSSHKey({ value, onValueChange }) {
               onClearClick={() => setSSHKey("")}
               isLoading={loading}
               browseButtonText="Upload"
-              />
+            />
           </FormGroup>
         </Form>
       </Modal>

--- a/web/src/RootSSHKey.jsx
+++ b/web/src/RootSSHKey.jsx
@@ -1,22 +1,96 @@
-import React, { useState } from "react";
+/*
+ * Copyright (c) [2022] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React, { useState, useEffect } from "react";
+import { useInstallerClient } from "./context/installer";
+import { Button, Form, FormGroup, Modal, ModalVariant, TextInput } from "@patternfly/react-core";
 import { FileUpload } from "@patternfly/react-core";
 
 export default function RootSSHKey({ value, onValueChange }) {
+  const client = useInstallerClient();
   const [loading, setLoading] = useState(false);
+  const [sshKey, setSSHKey] = useState(null);
+  const [isFormOpen, setIsFormOpen] = useState(false);
+
+  const sshKeyLabel = () => {
+    if (sshKey === "") {
+      return "SSH Key Not Set. ";
+    } else {
+      return "SSH Key Set. ";
+    }
+  };
+
+  useEffect(async () => {
+    const key = await client.users.getRootSSHKey();
+    setSSHKey(key);
+  }, []);
+
+  const accept = async () => {
+    await client.users.setRootSSHKey(sshKey);
+    setIsFormOpen(false);
+  };
+
+  const cancel = () => {};
+  const open = () => setIsFormOpen(true);
+
+  if (sshKey === null) return null;
 
   return (
-    <FileUpload
-      id="SSHKey"
-      type="text"
-      value={value}
-      filenamePlaceholder="Drag and drop a SSH public key or upload one"
-      onDataChange={onValueChange}
-      onTextChange={onValueChange}
-      onReadStarted={() => setLoading(true)}
-      onReadFinished={() => setLoading(false)}
-      onClearClick={() => onValueChange("")}
-      isLoading={loading}
-      browseButtonText="Upload"
-    />
+    <>
+      <Button variant="link" onClick={open}>
+        {sshKeyLabel()}
+      </Button>
+
+      <Modal
+        isOpen={isFormOpen}
+        showClose={false}
+        variant={ModalVariant.small}
+        title="Root Configuration"
+        actions={[
+          <Button key="confirm" variant="primary" onClick={accept}>
+            Confirm
+          </Button>,
+          <Button key="cancel" variant="link" onClick={cancel}>
+            Cancel
+          </Button>
+        ]}
+      >
+        <Form>
+          <FormGroup fieldId="sshKey" label="Root SSH key">
+            <FileUpload
+              id="sshKey"
+              type="text"
+              value={sshKey}
+              filenamePlaceholder="Drag and drop a SSH public key or upload one"
+              onDataChange={setSSHKey}
+              onTextChange={setSSHKey}
+              onReadStarted={() => setLoading(true)}
+              onReadFinished={() => setLoading(false)}
+              onClearClick={() => setSSHKey("")}
+              isLoading={loading}
+              browseButtonText="Upload"
+              />
+          </FormGroup>
+        </Form>
+      </Modal>
+    </>
   );
 }

--- a/web/src/RootSSHKey.jsx
+++ b/web/src/RootSSHKey.jsx
@@ -28,23 +28,14 @@ import {
   Modal,
   ModalVariant,
   Text,
-  TextInput
 } from "@patternfly/react-core";
 import { FileUpload } from "@patternfly/react-core";
 
-export default function RootSSHKey({ value, onValueChange }) {
+export default function RootSSHKey() {
   const client = useInstallerClient();
   const [loading, setLoading] = useState(false);
   const [sshKey, setSSHKey] = useState(null);
   const [isFormOpen, setIsFormOpen] = useState(false);
-
-  const sshKeyLabel = () => {
-    if (sshKey === "") {
-      return "SSH public key is not set ";
-    } else {
-      return "SSH public key is set";
-    }
-  };
 
   useEffect(async () => {
     const key = await client.users.getRootSSHKey();

--- a/web/src/RootUser.jsx
+++ b/web/src/RootUser.jsx
@@ -1,6 +1,5 @@
 import React, { useReducer, useEffect } from "react";
 import { useInstallerClient } from "./context/installer";
-import RootSSHKey from "./RootSSHKey";
 
 import { Button, Form, FormGroup, Modal, ModalVariant, TextInput } from "@patternfly/react-core";
 
@@ -34,23 +33,20 @@ const reducer = (state, action) => {
 const initialState = {
   rootPassword: null,
   isFormOpen: false,
-  SSHKey: ""
 };
 
 export default function RootUser() {
   const client = useInstallerClient();
   const [state, dispatch] = useReducer(reducer, initialState);
-  const { rootPassword, isFormOpen, SSHKey } = state;
+  const { rootPassword, isFormOpen } = state;
   const hiddenPassword = "_____DINSTALLALER_PASSWORD_SET";
 
   useEffect(async () => {
     const rootPassword = (await client.users.isRootPassword()) ? hiddenPassword : "";
-    const SSHKey = await client.users.getRootSSHKey();
     dispatch({
       type: "LOAD",
       payload: {
         rootPassword,
-        SSHKey
       }
     });
   }, []);
@@ -65,7 +61,6 @@ export default function RootUser() {
       await client.users.setRootPassword(rootPassword);
     }
     const remembered_password = rootPassword === "" ? "" : hiddenPassword;
-    client.users.setRootSSHKey(SSHKey);
     // TODO use signals instead
     dispatch({ type: "ACCEPT", payload: { rootPassword: remembered_password } });
   };
@@ -75,14 +70,6 @@ export default function RootUser() {
       return "Root Password Set.";
     } else {
       return "Root Password Not Set.";
-    }
-  };
-
-  const SSHKeyLabel = () => {
-    if (SSHKey === "") {
-      return "SSH Key Not Set. ";
-    } else {
-      return "SSH Key Set. ";
     }
   };
 
@@ -98,12 +85,6 @@ export default function RootUser() {
             onChange={v => dispatch({ type: "CHANGE", payload: { rootPassword: v } })}
           />
         </FormGroup>
-        <FormGroup fieldId="SSHKey" label="Root SSH key">
-          <RootSSHKey
-            value={SSHKey}
-            valueChanged={v => dispatch({ type: "CHANGE", payload: { SSHKey: v } })}
-          />
-        </FormGroup>
       </>
     );
   };
@@ -114,7 +95,7 @@ export default function RootUser() {
   return (
     <>
       <Button variant="link" onClick={open}>
-        `${rootLabel()} ${SSHKeyLabel()}`
+        {rootLabel()}
       </Button>
 
       <Modal

--- a/web/src/RootUser.jsx
+++ b/web/src/RootUser.jsx
@@ -7,8 +7,6 @@ import {
   FormGroup,
   Modal,
   ModalVariant,
-  Split,
-  SplitItem,
   Text,
   TextInput
 } from "@patternfly/react-core";

--- a/web/src/RootUser.jsx
+++ b/web/src/RootUser.jsx
@@ -42,7 +42,7 @@ const reducer = (state, action) => {
 
 const initialState = {
   rootPassword: null,
-  isFormOpen: false,
+  isFormOpen: false
 };
 
 export default function RootUser() {
@@ -56,7 +56,7 @@ export default function RootUser() {
     dispatch({
       type: "LOAD",
       payload: {
-        rootPassword,
+        rootPassword
       }
     });
   }, []);
@@ -96,13 +96,13 @@ export default function RootUser() {
 
   const renderLink = () => {
     const label = rootPassword === hiddenPassword ? "is set" : "is not set";
-    const link = <Button variant="link" isInline onClick={open}>
-      {label}
-    </Button>
-
-    return (
-      <Text>Root password {link}</Text>
+    const link = (
+      <Button variant="link" isInline onClick={open}>
+        {label}
+      </Button>
     );
+
+    return <Text>Root password {link}</Text>;
   };
 
   return (

--- a/web/src/RootUser.jsx
+++ b/web/src/RootUser.jsx
@@ -1,7 +1,17 @@
 import React, { useReducer, useEffect } from "react";
 import { useInstallerClient } from "./context/installer";
 
-import { Button, Form, FormGroup, Modal, ModalVariant, TextInput } from "@patternfly/react-core";
+import {
+  Button,
+  Form,
+  FormGroup,
+  Modal,
+  ModalVariant,
+  Split,
+  SplitItem,
+  Text,
+  TextInput
+} from "@patternfly/react-core";
 
 const reducer = (state, action) => {
   switch (action.type) {
@@ -65,14 +75,6 @@ export default function RootUser() {
     dispatch({ type: "ACCEPT", payload: { rootPassword: remembered_password } });
   };
 
-  const rootLabel = () => {
-    if (rootPassword === hiddenPassword) {
-      return "Root Password Set.";
-    } else {
-      return "Root Password Not Set.";
-    }
-  };
-
   const rootForm = () => {
     return (
       <>
@@ -92,11 +94,20 @@ export default function RootUser() {
   // Renders nothing until know about the status of password
   if (rootPassword === null) return null;
 
+  const renderLink = () => {
+    const label = rootPassword === hiddenPassword ? "is set" : "is not set";
+    const link = <Button variant="link" isInline onClick={open}>
+      {label}
+    </Button>
+
+    return (
+      <Text>Root password {link}</Text>
+    );
+  };
+
   return (
     <>
-      <Button variant="link" onClick={open}>
-        {rootLabel()}
-      </Button>
+      {renderLink()}
 
       <Modal
         isOpen={isFormOpen}

--- a/web/src/RootUser.test.jsx
+++ b/web/src/RootUser.test.jsx
@@ -21,7 +21,7 @@
 
 import React from "react";
 
-import { screen } from "@testing-library/react";
+import { screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { authRender } from "./test-utils";
 import { createClient } from "./lib/client";
@@ -48,7 +48,8 @@ describe("RootUser", () => {
   it("displays a form set or change root password when user clicks the link", async () => {
     authRender(<RootUser />);
 
-    const passwordLink = await screen.findByRole("button", { name: /Root Password/i });
+    const rootPassword = await screen.findByText(/Root password/i);
+    const passwordLink = within(rootPassword).getByRole("button", { name: "is not set" });
     userEvent.click(passwordLink);
     await screen.findByRole("dialog");
     await screen.findByText(/Root Configuration/i);
@@ -61,7 +62,9 @@ describe("RootUser", () => {
 
     it("displays a link to set the root password", async () => {
       authRender(<RootUser />);
-      await screen.findByRole("button", { name: /Root Password Not Set/i });
+      const rootPassword = await screen.findByText(/Root password/i);
+      const button = within(rootPassword).getByRole("button", { name: "is not set" });
+      expect(button).toBeInTheDocument();
     });
   });
 
@@ -72,7 +75,9 @@ describe("RootUser", () => {
 
     it("displays a link to change the root password", async () => {
       authRender(<RootUser />);
-      await screen.findByRole("button", { name: /Root Password Set/i });
+      const rootPassword = await screen.findByText(/Root password/i);
+      const button = within(rootPassword).getByRole("button", { name: "is set" });
+      expect(button).toBeInTheDocument();
     });
   });
 });

--- a/web/src/Users.jsx
+++ b/web/src/Users.jsx
@@ -1,0 +1,44 @@
+
+/*
+ * Copyright (c) [2022] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from "react";
+import { Stack, StackItem } from "@patternfly/react-core";
+
+import FirstUser from "./FirstUser";
+import RootUser from "./RootUser";
+import RootSSHKey from "./RootSSHKey";
+
+export default function Users () {
+  return (
+    <Stack>
+      <StackItem>
+        <RootUser />
+      </StackItem>
+      <StackItem>
+        <RootSSHKey />
+      </StackItem>
+      <StackItem>
+        <FirstUser />
+      </StackItem>
+    </Stack>
+  );
+}

--- a/web/src/Users.jsx
+++ b/web/src/Users.jsx
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (c) [2022] SUSE LLC
  *
@@ -27,7 +26,7 @@ import FirstUser from "./FirstUser";
 import RootUser from "./RootUser";
 import RootSSHKey from "./RootSSHKey";
 
-export default function Users () {
+export default function Users() {
   return (
     <Stack>
       <StackItem>


### PR DESCRIPTION
This PR introduces some changes to #84. In summary:

* It changes the user's summary (see the screenshot below).
* It separates root password and SSH key handling into two different components (and forms).
* It creates an additional `<Users/>` component to put everything related to that section within that component.
* 
![users](https://user-images.githubusercontent.com/15836/159731815-2a58b1a9-64a6-4465-beaa-3d9c1040f7c8.png)