### PR TITLE
[web] RootSSHKey improvements

### DIFF
--- a/web/src/FirstUser.jsx
+++ b/web/src/FirstUser.jsx
@@ -31,7 +31,7 @@ export default function Users() {
     setFormValues({ ...formValues, ...userValues });
   }, []);
 
-  if (user === null) return <Skeleton width="60%" fontSize="sm" />;
+  if (user === null) return <Skeleton width="50%" fontSize="sm" />;
 
   const open = () => {
     setFormValues({ ...initialUser, ...user, password: "" });

--- a/web/src/RootSSHKey.jsx
+++ b/web/src/RootSSHKey.jsx
@@ -36,6 +36,7 @@ export default function RootSSHKey() {
   const client = useInstallerClient();
   const [loading, setLoading] = useState(false);
   const [sshKey, setSSHKey] = useState(null);
+  const [nextSSHKey, setNextSSHKey] = useState(null);
   const [isFormOpen, setIsFormOpen] = useState(false);
 
   useEffect(async () => {
@@ -45,13 +46,19 @@ export default function RootSSHKey() {
 
   if (sshKey === null) return <Skeleton width="55%" fontSize="sm" />;
 
-  const accept = async () => {
-    await client.users.setRootSSHKey(sshKey);
-    setIsFormOpen(false);
+  const open = () => {
+    setNextSSHKey(sshKey);
+    setIsFormOpen(true);
   };
 
   const cancel = () => setIsFormOpen(false);
-  const open = () => setIsFormOpen(true);
+
+  const accept = async () => {
+    await client.users.setRootSSHKey(nextSSHKey);
+    setSSHKey(nextSSHKey);
+    setIsFormOpen(false);
+  };
+
 
   const renderLink = () => {
     const label = sshKey !== "" ? "is set" : "is not set";
@@ -78,6 +85,9 @@ export default function RootSSHKey() {
           </Button>,
           <Button key="cancel" variant="link" onClick={cancel}>
             Cancel
+          </Button>,
+          <Button key="remove" variant="link" onClick={remove} isDisabled={sshKey === ""}>
+            Do not use SSH public key
           </Button>
         ]}
       >
@@ -86,15 +96,15 @@ export default function RootSSHKey() {
             <FileUpload
               id="sshKey"
               type="text"
-              value={sshKey}
+              value={nextSSHKey}
               filenamePlaceholder="Upload, paste, or drop a SSH public key"
               isLoading={loading}
               browseButtonText="Upload"
-              onDataChange={setSSHKey}
-              onTextChange={setSSHKey}
+              onDataChange={setNextSSHKey}
+              onTextChange={setNextSSHKey}
               onReadStarted={() => setLoading(true)}
               onReadFinished={() => setLoading(false)}
-              onClearClick={() => setSSHKey("")}
+              onClearClick={() => setNextSSHKey("")}
             />
           </FormGroup>
         </Form>

--- a/web/src/RootSSHKey.jsx
+++ b/web/src/RootSSHKey.jsx
@@ -43,7 +43,7 @@ export default function RootSSHKey() {
     setSSHKey(key);
   }, []);
 
-  if (sshKey === null) return <Skeleton width="60%" fontSize="sm" />;
+  if (sshKey === null) return <Skeleton width="55%" fontSize="sm" />;
 
   const accept = async () => {
     await client.users.setRootSSHKey(sshKey);

--- a/web/src/RootSSHKey.jsx
+++ b/web/src/RootSSHKey.jsx
@@ -21,7 +21,15 @@
 
 import React, { useState, useEffect } from "react";
 import { useInstallerClient } from "./context/installer";
-import { Button, Form, FormGroup, Modal, ModalVariant, Text } from "@patternfly/react-core";
+import {
+  Button,
+  Form,
+  FormGroup,
+  Modal,
+  ModalVariant,
+  Skeleton,
+  Text
+} from "@patternfly/react-core";
 import { FileUpload } from "@patternfly/react-core";
 
 export default function RootSSHKey() {
@@ -35,6 +43,8 @@ export default function RootSSHKey() {
     setSSHKey(key);
   }, []);
 
+  if (sshKey === null) return <Skeleton width="60%" fontSize="sm" />;
+
   const accept = async () => {
     await client.users.setRootSSHKey(sshKey);
     setIsFormOpen(false);
@@ -42,8 +52,6 @@ export default function RootSSHKey() {
 
   const cancel = () => setIsFormOpen(false);
   const open = () => setIsFormOpen(true);
-
-  if (sshKey === null) return null;
 
   const renderLink = () => {
     const label = sshKey !== "" ? "is set" : "is not set";

--- a/web/src/RootSSHKey.jsx
+++ b/web/src/RootSSHKey.jsx
@@ -71,7 +71,7 @@ export default function RootSSHKey() {
         isOpen={isFormOpen}
         showClose={false}
         variant={ModalVariant.small}
-        title="Root Configuration"
+        aria-label="Set root SSH public key"
         actions={[
           <Button key="confirm" variant="primary" onClick={accept}>
             Confirm
@@ -87,14 +87,14 @@ export default function RootSSHKey() {
               id="sshKey"
               type="text"
               value={sshKey}
-              filenamePlaceholder="Drag and drop a SSH public key or upload one"
+              filenamePlaceholder="Upload, paste, or drop a SSH public key"
+              isLoading={loading}
+              browseButtonText="Upload"
               onDataChange={setSSHKey}
               onTextChange={setSSHKey}
               onReadStarted={() => setLoading(true)}
               onReadFinished={() => setLoading(false)}
               onClearClick={() => setSSHKey("")}
-              isLoading={loading}
-              browseButtonText="Upload"
             />
           </FormGroup>
         </Form>

--- a/web/src/RootSSHKey.jsx
+++ b/web/src/RootSSHKey.jsx
@@ -92,7 +92,7 @@ export default function RootSSHKey() {
         ]}
       >
         <Form>
-          <FormGroup fieldId="sshKey" label="Root SSH key">
+          <FormGroup fieldId="sshKey" label="Root SSH public key">
             <FileUpload
               id="sshKey"
               type="text"

--- a/web/src/RootSSHKey.jsx
+++ b/web/src/RootSSHKey.jsx
@@ -59,6 +59,11 @@ export default function RootSSHKey() {
     setIsFormOpen(false);
   };
 
+  const remove = async () => {
+    await client.users.setRootSSHKey("");
+    setSSHKey("");
+    setIsFormOpen(false);
+  };
 
   const renderLink = () => {
     const label = sshKey !== "" ? "is set" : "is not set";

--- a/web/src/RootSSHKey.test.jsx
+++ b/web/src/RootSSHKey.test.jsx
@@ -54,7 +54,7 @@ it("allows defining a new root SSH public key", async () => {
 
   await screen.findByRole("dialog");
 
-  const sshKeyInput = screen.getByLabelText("Root SSH key");
+  const sshKeyInput = screen.getByLabelText("Root SSH public key");
   userEvent.type(sshKeyInput, testKey);
 
   const confirmButton = screen.getByRole("button", { name: /Confirm/i });
@@ -79,7 +79,7 @@ it("does not change anything if the user cancels", async () => {
 
   await screen.findByRole("dialog");
 
-  const sshKeyInput = screen.getByLabelText("Root SSH key");
+  const sshKeyInput = screen.getByLabelText("Root SSH public key");
   userEvent.type(sshKeyInput, testKey);
 
   const cancelButton = screen.getByRole("button", { name: /Cancel/i });

--- a/web/src/RootSSHKey.test.jsx
+++ b/web/src/RootSSHKey.test.jsx
@@ -108,11 +108,8 @@ describe("when the SSH public key is set", () => {
 
     await screen.findByRole("dialog");
 
-    const clearButton = await screen.findByRole("button", { name: /Clear/i });
-    userEvent.click(clearButton);
-
-    const confirmButton = await screen.findByRole("button", { name: /Confirm/i });
-    userEvent.click(confirmButton);
+    const removeButton = await screen.findByRole("button", { name: /Do not use/i });
+    userEvent.click(removeButton);
 
     expect(setRootSSHKeyFn).toHaveBeenCalledWith("");
 

--- a/web/src/RootSSHKey.test.jsx
+++ b/web/src/RootSSHKey.test.jsx
@@ -69,12 +69,18 @@ it("allows defining a new root SSH public key", async () => {
 });
 
 it("does not change anything if the user cancels", async () => {
+  let openButton;
+
   authRender(<RootSSHKey />);
+
   const rootSSHKey = await screen.findByText(/Root SSH public key/i);
-  const button = within(rootSSHKey).getByRole("button", { name: "is not set" });
-  userEvent.click(button);
+  openButton = within(rootSSHKey).getByRole("button", { name: "is not set" });
+  userEvent.click(openButton);
 
   await screen.findByRole("dialog");
+
+  const sshKeyInput = screen.getByLabelText("Root SSH key");
+  userEvent.type(sshKeyInput, testKey);
 
   const cancelButton = screen.getByRole("button", { name: /Cancel/i });
   userEvent.click(cancelButton);
@@ -83,6 +89,10 @@ it("does not change anything if the user cancels", async () => {
   await waitFor(() => {
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
+
+  // Extra check to ensure the component is aware that nothing changed.
+  openButton = within(rootSSHKey).getByRole("button", { name: "is not set" });
+  expect(openButton).toBeInTheDocument();
 });
 
 describe("when the SSH public key is set", () => {

--- a/web/src/RootSSHKey.test.jsx
+++ b/web/src/RootSSHKey.test.jsx
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) [2022] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from "react";
+
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { authRender } from "./test-utils";
+import { createClient } from "./lib/client";
+import RootSSHKey from "./RootSSHKey";
+
+jest.mock("./lib/client");
+
+let sshKey;
+const getRootSSHKeyFn = () => sshKey;
+const setRootSSHKeyFn = jest.fn();
+const testKey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDM+ test@example";
+
+beforeEach(() => {
+  sshKey = "";
+  createClient.mockImplementation(() => {
+    return {
+      users: {
+        getRootSSHKey: getRootSSHKeyFn,
+        setRootSSHKey: setRootSSHKeyFn
+      }
+    };
+  });
+});
+
+it("allows defining a new root SSH public key", async () => {
+  authRender(<RootSSHKey />);
+  const rootSSHKey = await screen.findByText(/Root SSH public key/i);
+  const button = within(rootSSHKey).getByRole("button", { name: "is not set" });
+  userEvent.click(button);
+
+  await screen.findByRole("dialog");
+
+  const sshKeyInput = screen.getByLabelText("Root SSH key");
+  userEvent.type(sshKeyInput, testKey);
+
+  const confirmButton = screen.getByRole("button", { name: /Confirm/i });
+  expect(confirmButton).toBeEnabled();
+  userEvent.click(confirmButton);
+
+  expect(setRootSSHKeyFn).toHaveBeenCalledWith(testKey);
+
+  await waitFor(() => {
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});
+
+it("does not change anything if the user cancels", async () => {
+  authRender(<RootSSHKey />);
+  const rootSSHKey = await screen.findByText(/Root SSH public key/i);
+  const button = within(rootSSHKey).getByRole("button", { name: "is not set" });
+  userEvent.click(button);
+
+  await screen.findByRole("dialog");
+
+  const cancelButton = screen.getByRole("button", { name: /Cancel/i });
+  userEvent.click(cancelButton);
+
+  expect(setRootSSHKeyFn).not.toHaveBeenCalled();
+  await waitFor(() => {
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});
+
+describe("when the SSH public key is set", () => {
+  beforeEach(() => {
+    sshKey = testKey;
+  });
+
+  it("allows removing the SSH public key", async () => {
+    authRender(<RootSSHKey />);
+    const rootSSHKey = await screen.findByText(/Root SSH public key/i);
+    const button = within(rootSSHKey).getByRole("button", { name: "is set" });
+    userEvent.click(button);
+
+    await screen.findByRole("dialog");
+
+    const clearButton = await screen.findByRole("button", { name: /Clear/i });
+    userEvent.click(clearButton);
+
+    const confirmButton = await screen.findByRole("button", { name: /Confirm/i });
+    userEvent.click(confirmButton);
+
+    expect(setRootSSHKeyFn).toHaveBeenCalledWith("");
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/web/src/Users.jsx
+++ b/web/src/Users.jsx
@@ -28,7 +28,7 @@ import RootSSHKey from "./RootSSHKey";
 
 export default function Users() {
   return (
-    <Stack>
+    <Stack className="overview-users">
       <StackItem>
         <RootPassword />
       </StackItem>

--- a/web/src/app.scss
+++ b/web/src/app.scss
@@ -77,3 +77,7 @@ body {
 .expandable-actions > div {
   margin-block-start: 0;
 }
+
+.overview-users > div {
+  margin-block-start: 0.5ex;
+}

--- a/web/src/lib/client/users.js
+++ b/web/src/lib/client/users.js
@@ -50,16 +50,6 @@ export default class UsersClient {
   }
 
   /**
-   * Return string with ssh key or empty string
-   *
-   * @return {Promise.<String>}
-   */
-  async getRootSSHKey() {
-    const proxy = await this.proxy(USERS_IFACE);
-    return proxy.RootSSHKey;
-  }
-
-  /**
    * Set the languages to install
    *
    * @param {object} user - object with full name, user name, password and boolean for autologin
@@ -109,6 +99,16 @@ export default class UsersClient {
     const proxy = await this.proxy(USERS_IFACE);
     const result = await proxy.RemoveRootPassword();
     return result === 0;
+  }
+
+  /**
+   * Return string with ssh key or empty string
+   *
+   * @return {Promise.<String>}
+   */
+  async getRootSSHKey() {
+    const proxy = await this.proxy(USERS_IFACE);
+    return proxy.RootSSHKey;
   }
 
   /**


### PR DESCRIPTION
This PR fix the cancel action for `RootSSHKey` component and, additionally 

* Add some tests
* Use consistent labels
* Add an explicit _remove_ action
* Simplify the UI by removing the modal dialog title (it uses an `aria-label` instead)
* Shows an `Skeleton` bar while checking the SSH public key status, as it's done with other subsections of users
* Adds some vertical margin between items inside `Users` overview section.
* Changes the placeholder for the SSH public key input

![Screen Shot 2022-03-25 at 14 19 15-fullpage](https://user-images.githubusercontent.com/1691872/160138451-ca00b7b2-1a4a-4ff5-a07e-0430925200aa.png)
