### PR TITLE
Move the users section to the bottom

### DIFF
--- a/web/src/Overview.jsx
+++ b/web/src/Overview.jsx
@@ -46,14 +46,14 @@ function Overview() {
     <Category title="Language" icon={LanguagesSelectionIcon}>
       <LanguageSelector />
     </Category>,
-    <Category title="Users" icon={UsersIcon}>
-      <Users />
-    </Category>,
     <Category title="Product" icon={ProductsIcon}>
       <ProductSelector />
     </Category>,
     <Category title="Target" icon={HardDriveIcon}>
       <Storage />
+    </Category>,
+    <Category title="Users" icon={UsersIcon}>
+      <Users />
     </Category>
   ];
 


### PR DESCRIPTION
Move the users section to the bottom of the overview page to follow the same order that we have in YaST: language, product, partitioning and users.