### PR TITLE
[web] More Layout improvements

### DIFF
--- a/web/src/FirstUser.jsx
+++ b/web/src/FirstUser.jsx
@@ -66,6 +66,8 @@ export default function Users() {
     setFormValues({ ...formValues, [name]: value });
   };
 
+  const userIsDefined = user?.userName !== "";
+
   const userForm = () => {
     return (
       <Form>
@@ -120,7 +122,7 @@ export default function Users() {
   );
 
   const renderLink = () => {
-    if (user?.userName !== "") {
+    if (userIsDefined) {
       return <Text>User {link(user.userName)} is defined</Text>;
     } else {
       return <Text>A user {link("is not defined")}</Text>;
@@ -148,7 +150,7 @@ export default function Users() {
           <Button key="cancel" variant="secondary" onClick={cancel}>
             Cancel
           </Button>,
-          <Button key="remove" variant="link" onClick={remove}>
+          <Button key="remove" variant="link" onClick={remove} isDisabled={!userIsDefined}>
             Do not create a user
           </Button>
         ]}

--- a/web/src/Layout.jsx
+++ b/web/src/Layout.jsx
@@ -40,19 +40,11 @@ import React from "react";
  * @param {React.ReactNode} [props.MenuIcon] - the icon for the application menu
  * @param {string} [props.sectionTitle] - the section title in the header
  * @param {React.ReactNode} [props.SectionIcon] - the section icon in the header
- * @param {React.ReactNode} [props.FooterMessages] - messages to be  shown in the footer
  * @param {React.ReactNode} [props.FooterActions] - actions shown in the footer
  * @param {React.ReactNode} [props.children] - the section content
  *
  */
-function Layout({
-  MenuIcon,
-  sectionTitle,
-  SectionIcon,
-  FooterMessages,
-  FooterActions,
-  children: sectionContent
-}) {
+function Layout({ MenuIcon, sectionTitle, SectionIcon, FooterActions, children: sectionContent }) {
   const responsiveWidthRules = "pf-u-w-66-on-lg pf-u-w-50-on-xl pf-u-w-33-on-2xl";
   const className = `layout ${responsiveWidthRules}`;
 
@@ -84,12 +76,10 @@ function Layout({
   };
 
   const renderFooter = () => {
-    if (!FooterActions && !FooterMessages) return null;
+    if (!FooterActions) return null;
 
     return (
       <div className="layout__footer">
-        <div className="layout__footer-info-area">{FooterMessages && <FooterMessages />}</div>
-
         <div
           className="layout__footer-actions-area"
           role="navigation"

--- a/web/src/ProgressReport.jsx
+++ b/web/src/ProgressReport.jsx
@@ -27,9 +27,11 @@ import { Progress, Stack, StackItem, Text } from "@patternfly/react-core";
 const renderSubprogress = progress => (
   <Progress
     size="sm"
+    min={0}
+    max={progress.substeps}
+    value={progress.substep}
     measureLocation="none"
     aria-label="Secondary progress bar"
-    value={Math.round((progress.substep / progress.substeps) * 100)}
   />
 );
 
@@ -49,12 +51,17 @@ const ProgressReport = () => {
   if (!progress.steps) return <Text>Waiting for progress status...</Text>;
 
   const showSubsteps = !!progress.substeps && progress.substeps >= 0;
-  const percentage = progress.steps === 0 ? 0 : Math.round((progress.step / progress.steps) * 100);
 
   return (
     <Stack hasGutter className="pf-u-w-100">
       <StackItem>
-        <Progress aria-label="Main progress bar" title={progress.title} value={percentage} />
+        <Progress
+          min={0}
+          max={progress.steps}
+          value={progress.step}
+          title={progress.title}
+          aria-label="Main progress bar"
+        />
       </StackItem>
 
       <StackItem>{showSubsteps && renderSubprogress(progress)}</StackItem>

--- a/web/src/ProgressReport.jsx
+++ b/web/src/ProgressReport.jsx
@@ -51,6 +51,7 @@ const ProgressReport = () => {
   if (!progress.steps) return <Text>Waiting for progress status...</Text>;
 
   const showSubsteps = !!progress.substeps && progress.substeps >= 0;
+  const label = `Step ${progress.step + 1} of ${progress.steps + 1}`;
 
   return (
     <Stack hasGutter className="pf-u-w-100">
@@ -59,6 +60,8 @@ const ProgressReport = () => {
           min={0}
           max={progress.steps}
           value={progress.step}
+          label={label}
+          valueText={label}
           title={progress.title}
           aria-label="Main progress bar"
         />

--- a/web/src/layout.scss
+++ b/web/src/layout.scss
@@ -40,6 +40,17 @@
   display: flex;
   align-items: center;
   gap: 0.5rem;
+
+  // Centers the section title.
+  // In a certain way it contradicts recommendations for headings given at
+  // https://eosdesignsystem.herokuapp.com/typography#headline-margins
+  // but it's more inline with the "branding" alignment at
+  // https://eosdesignsystem.herokuapp.com/layout
+  //
+  // See global heading styles at src/app.scss
+  h1 {
+    margin-block-start: 10px;
+  }
 }
 
 .layout__header-left-action {

--- a/web/src/layout.scss
+++ b/web/src/layout.scss
@@ -6,7 +6,7 @@
 
 .layout {
   --header-block-size: 8ex;
-  --footer-block-size: calc(2 * var(--header-block-size));
+  --footer-block-size: calc(1.5 * var(--header-block-size));
   --min-layout-content-block-size: calc(100vh - var(--header-block-size));
   --layout-content-padding: 1rem;
   --layout-content-padding-block-end: calc(

--- a/web/src/layout.scss
+++ b/web/src/layout.scss
@@ -98,20 +98,9 @@
   padding: 1rem;
 
   display: grid;
-  // We haven't decided yet the "final" distribution for the footer.
-  // grid-template-columns: 2fr 1fr;
+
   gap: 1rem 1rem;
 }
-
-.layout__footer-info-area {
-  align-self: center;
-  overflow-y: auto;
-}
-
-// TODO: Keep alert icons vertically centered here?
-// .layout__footer-info-area .pf-c-alert__icon {
-//   align-self: center;
-// }
 
 .layout__footer-actions-area {
   align-self: center;


### PR DESCRIPTION
A new set of layout improvements, namely

* Make the footer height short


* Center section title

  This is in a certain way _contrary_ to headings recommendations given at https://eosdesignsystem.herokuapp.com/typography#headline-margins but more inline with the "branding" alignment found at https://eosdesignsystem.herokuapp.com/layout. Additionally, together with the above point, it helps to save some vertical space.

* Do not calculate `ProgressReport` percentage: PatternFly `ProgressReport` already do it when _min_, _max_, and _value_ props are given.
* Display progress steps instead progress percent, which makes more sense since percentages are less accurate.

### Few screenshots

| | Before | After |
|-|-|-|
| Installation Summary | ![Installation summary before changes](https://user-images.githubusercontent.com/1691872/160559736-04da6f70-c741-4743-86b5-9010fa029dc5.png) | ![Installation summary after changes](https://user-images.githubusercontent.com/1691872/160559823-1576a5f2-54f9-414d-8d21-445c7074e330.png) |
| Probing | ![Probing before changes](https://user-images.githubusercontent.com/1691872/160560005-0f99fde5-b893-44a4-ae39-6c0cd6fabf2c.png) | ![Probing after changes](https://user-images.githubusercontent.com/1691872/160560093-1ac11f55-eed9-4699-b531-87bac7bd594a.png) | 
| Installing | ![Installing before changes](https://user-images.githubusercontent.com/1691872/160560178-8e58ceff-d4ac-4be3-83cc-c4f89a4cb10d.png) | ![Installing after changes](https://user-images.githubusercontent.com/1691872/160560263-1e74d930-43a4-4c31-a7a8-d57caab19891.png) |
| Installation finished | ![Installation finished before changes](https://user-images.githubusercontent.com/1691872/160560332-468fd78a-c121-45aa-85eb-de40449e22db.png) | ![Installation finished after changes](https://user-images.githubusercontent.com/1691872/160560395-0465827e-8cb6-43fa-9263-f00194b98434.png) |
 