### PR TITLE
Import gpg keys from /usr/lib/rpm/gnupg/keys

### DIFF
--- a/service/lib/dinstaller/software.rb
+++ b/service/lib/dinstaller/software.rb
@@ -19,7 +19,6 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "pathname"
 require "yast"
 require "dinstaller/package_callbacks"
 require "y2packager/product"
@@ -33,8 +32,8 @@ Yast.import "Stage"
 module DInstaller
   # This class is responsible for software handling
   class Software
-    GPG_KEYS_PATH = "/"
-    private_constant :GPG_KEYS_PATH
+    GPG_KEYS_GLOB = "/usr/lib/rpm/gnupg/keys/gpg-*"
+    private_constant :GPG_KEYS_GLOB
 
     FALLBACK_REPO = "https://download.opensuse.org/tumbleweed/repo/oss/"
     private_constant :FALLBACK_REPO
@@ -137,10 +136,10 @@ module DInstaller
     end
 
     def import_gpg_keys
-      gpg_keys = Pathname.new(GPG_KEYS_PATH).glob("*.gpg").map(&:to_s)
+      gpg_keys = Dir.glob(GPG_KEYS_GLOB).map(&:to_s)
       logger.info "Importing GPG keys: #{gpg_keys}"
       gpg_keys.each do |path|
-        Yast::Pkg.ImportGPGKey(path.to_s, true)
+        Yast::Pkg.ImportGPGKey(path, true)
       end
     end
 

--- a/service/test/dinstaller/software_test.rb
+++ b/service/test/dinstaller/software_test.rb
@@ -33,12 +33,12 @@ describe DInstaller::Software do
   let(:other_prod) { instance_double(Y2Packager::Product, name: "another") }
   let(:base_url) { "" }
   let(:destdir) { "/mnt" }
-  let(:gpg_path) { instance_double(Pathname, glob: []) }
+  let(:gpg_keys) { [] }
 
   before do
     allow(Yast::Pkg).to receive(:TargetInitialize)
     allow(Yast::Pkg).to receive(:ImportGPGKey)
-    allow(Pathname).to receive(:new).with("/").and_return(gpg_path)
+    allow(Dir).to receive(:glob).with(/keys/).and_return(gpg_keys)
     allow(Y2Packager::Product).to receive(:available_base_products)
       .and_return(products)
     allow(Yast::Packages).to receive(:Proposal).and_return({})
@@ -55,12 +55,12 @@ describe DInstaller::Software do
     end
 
     context "when GPG keys are available at /" do
-      before do
-        allow(gpg_path).to receive(:glob).with("*.gpg").and_return(["/installkey.gpg"])
+      let(:gpg_keys) do
+        ["/usr/lib/gnupg/keys/gpg-key.asc"]
       end
 
       it "imports the GPG keys" do
-        expect(Yast::Pkg).to receive(:ImportGPGKey).with("/installkey.gpg", true)
+        expect(Yast::Pkg).to receive(:ImportGPGKey).with(gpg_keys.first, true)
         subject.probe(progress)
       end
     end


### PR DESCRIPTION
GPG keys are now in `/usr/lib/rpm/gnupg/keys`. Import them from the new location.