### PR TITLE
[web] Minor UI fine-tuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ service. At first sight, we have identified these components:
 
 ## Quickstart
 
-:warning: :warning: **This is a proof-of-concept so use a virtual machine to give it a try.** :warning: :warning:
+:warning: **This is a proof-of-concept. Please, use a virtual machine to give it a try.** :warning:
 
 The easiest way to give D-Installer a try is to install the
 [rubygem-d-installer](https://build.opensuse.org/package/show/YaST:Head:D-Installer/rubygem-d-installer)

--- a/web/src/About.jsx
+++ b/web/src/About.jsx
@@ -40,7 +40,7 @@ export default function About() {
         variant={ModalVariant.small}
         title="About D-Installer"
         actions={[
-          <Button key="confirm" variant="primary" onClick={close}>
+          <Button key="confirm" variant="primary" onClick={close} autoFocus>
             Close
           </Button>
         ]}

--- a/web/src/FirstUser.jsx
+++ b/web/src/FirstUser.jsx
@@ -68,53 +68,6 @@ export default function Users() {
 
   const userIsDefined = user?.userName !== "";
 
-  const userForm = () => {
-    return (
-      <Form>
-        <FormGroup fieldId="userFullName" label="Full name">
-          <TextInput
-            id="userFullName"
-            name="fullName"
-            aria-label="user fullname"
-            value={formValues.fullName}
-            label="User full Name"
-            onChange={handleInputChange}
-          />
-        </FormGroup>
-        <FormGroup fieldId="userName" label="Username">
-          <TextInput
-            id="userName"
-            name="userName"
-            aria-label="user name"
-            value={formValues.userName}
-            label="Username"
-            required={true}
-            onChange={handleInputChange}
-          />
-        </FormGroup>
-        <FormGroup fieldId="userPassword" label="Password">
-          <TextInput
-            id="userPassword"
-            name="password"
-            type="password"
-            aria-label="user password"
-            value={formValues.password}
-            onChange={handleInputChange}
-          />
-        </FormGroup>
-        <FormGroup fieldId="autologin" label="Auto-login">
-          <Checkbox
-            aria-label="user autologin"
-            id="autologin"
-            name="autologin"
-            isChecked={formValues.autologin}
-            onChange={handleInputChange}
-          />
-        </FormGroup>
-      </Form>
-    );
-  };
-
   const link = content => (
     <Button variant="link" isInline onClick={open}>
       {content}
@@ -137,7 +90,7 @@ export default function Users() {
         isOpen={isFormOpen}
         showClose={false}
         variant={ModalVariant.small}
-        aria-label="First User"
+        title="User account"
         actions={[
           <Button
             key="confirm"
@@ -155,7 +108,50 @@ export default function Users() {
           </Button>
         ]}
       >
-        {userForm()}
+        <Form>
+          <FormGroup fieldId="userFullName" label="Full name">
+            <TextInput
+              id="userFullName"
+              name="fullName"
+              aria-label="User fullname"
+              value={formValues.fullName}
+              label="User full Name"
+              onChange={handleInputChange}
+            />
+          </FormGroup>
+
+          <FormGroup fieldId="userName" label="Username">
+            <TextInput
+              id="userName"
+              name="userName"
+              aria-label="Username"
+              value={formValues.userName}
+              label="Username"
+              required={true}
+              onChange={handleInputChange}
+            />
+          </FormGroup>
+
+          <FormGroup fieldId="userPassword" label="Password">
+            <TextInput
+              id="userPassword"
+              name="password"
+              type="password"
+              aria-label="User password"
+              value={formValues.password}
+              onChange={handleInputChange}
+            />
+          </FormGroup>
+
+          <Checkbox
+            aria-label="user autologin"
+            id="autologin"
+            name="autologin"
+            label="Auto-login"
+            isChecked={formValues.autologin}
+            onChange={handleInputChange}
+          />
+        </Form>
       </Modal>
     </>
   );


### PR DESCRIPTION
Some minor UI adjustments proposal:

* Put back a title to the `FirstUser` dialog

  It was removed in the context of  https://github.com/yast/d-installer/pull/96 and https://suse.eosdesignsystem.com/writing/ux-writing#best-practices, but actually that "User account" dialog deserves a explicit title because it contains more than a one, straightforward input/control. 

* Put the "Auto-login" label inline with its checkbox

* Force the _Close_ action to get the focus in the `About` dialog


## Screenshots

| Before | After |
|-|-|
| ![User account dialog before changes](https://user-images.githubusercontent.com/1691872/160725234-70e5c727-4554-41f6-8b02-29fd0b155247.png) |![User account dialog after changes](https://user-images.githubusercontent.com/1691872/160784145-04f3dfa0-a30c-434e-a424-68d3cecefff6.png) |
| ![About dialog without forcing the focus to the Close action](https://user-images.githubusercontent.com/1691872/160725470-b644526a-be08-4e19-bd0b-97ad31fc4588.png) | ![About dialog forcing the focus to the Close action](https://user-images.githubusercontent.com/1691872/160725508-8a97bcb8-5ca0-48e0-8957-92ac4fe8db14.png) |
