### PR TITLE
Add network-online.target dependency

### DIFF
--- a/service/share/systemd.service
+++ b/service/share/systemd.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=D-Installer Service
 Requires=dbus.socket cockpit.socket
+After=network-online.target
 
 [Service]
 Type=dbus


### PR DESCRIPTION
We need to access the network by now to get the repositories. In the future, the repositories might be in the media, but that's not the case by now.