### PR TITLE
[web] Do not use a line as a section separator

### DIFF
--- a/web/src/app.scss
+++ b/web/src/app.scss
@@ -21,7 +21,7 @@
 // Note: for this particular case, we are not using
 // @use "eos-ds/dist/scss/eos-base/variables/typography.scss"
 // because it imports fonts from googleapis, external source.
-// Instead, we use @fontsource to import them from local sources in main.jsx
+// Instead, we use @fontsource to import them from local sources in App.jsx
 $base: Lato, arial, helvetica, sans-serif;
 $headlines: Poppins, san-serif;
 $code: 'Roboto Mono', monospace;

--- a/web/src/app.scss
+++ b/web/src/app.scss
@@ -134,12 +134,7 @@ h4, h5, h6 {
 }
 
 .installation-overview-section {
-  border-block-end: 1px solid branding.$eos-bc-gray-100;
   padding-block-end: 1rem;
-
-  &:last-child {
-    border-block-end: none;
-  }
 
   // FIXME: look for a better approach about this.
   // It overrides inline paddings for "button links" since using "isInline" prop


### PR DESCRIPTION
Because the headings are enough for now, although I have doubts if the explicit separator will be needed in the future (because we put some menu options / buttons or whatever per section or so)

| Before | After |
|-|-|
| ![Summary using explicit separator](https://user-images.githubusercontent.com/1691872/161222899-b1157295-f33e-4eda-bb63-1f15f6f7d5e9.png) | ![Summary not using explicit separator](https://user-images.githubusercontent.com/1691872/161222934-c82bbbe8-dc45-4b6d-83e7-ff4b36c690e5.png) |

