### PR TITLE
Add install confirmation

### DIFF
--- a/web/src/Overview.jsx
+++ b/web/src/Overview.jsx
@@ -19,10 +19,10 @@
  * find current contact information at www.suse.com.
  */
 
-import React from "react";
+import React, { useState } from "react";
 import { useInstallerClient } from "./context/installer";
 
-import { Button, Flex, FlexItem } from "@patternfly/react-core";
+import { Button, Modal, ModalVariant, Flex, FlexItem, Text } from "@patternfly/react-core";
 
 import Layout from "./Layout";
 import Category from "./Category";
@@ -58,10 +58,41 @@ function Overview() {
   ];
 
   const InstallButton = () => {
+    const [isOpen, setIsOpen] = useState(false);
+
+    const open = () => setIsOpen(true);
+    const close = () => setIsOpen(false);
+    const install = () => client.manager.startInstallation();
+
     return (
-      <Button isLarge variant="primary" onClick={() => client.manager.startInstallation()}>
-        Install
-      </Button>
+      <>
+        <Button isLarge variant="primary" onClick={open}>
+          Install
+        </Button>
+
+        <Modal
+          title="Confirm Installation"
+          isOpen={isOpen}
+          showClose={false}
+          variant={ModalVariant.small}
+          actions={[
+            <Button key="accept" variant="primary" onClick={install}>
+              Install
+            </Button>,
+            <Button key="back" variant="primary" onClick={close} autoFocus>
+              Back
+            </Button>
+          ]}
+        >
+          <Text>
+            If you continue, partitions on your hard disk will be modified according to the
+            installation settings in the previous dialog.
+          </Text>
+          <Text>
+            Go back and check the settings if you are unsure.
+          </Text>
+        </Modal>
+      </>
     );
   };
 

--- a/web/src/Overview.jsx
+++ b/web/src/Overview.jsx
@@ -79,8 +79,8 @@ function Overview() {
             <Button key="accept" variant="primary" onClick={install}>
               Install
             </Button>,
-            <Button key="back" variant="primary" onClick={close} autoFocus>
-              Back
+            <Button key="back" variant="secondary" onClick={close} autoFocus>
+              Cancel
             </Button>
           ]}
         >
@@ -89,7 +89,7 @@ function Overview() {
             installation settings in the previous dialog.
           </Text>
           <Text>
-            Go back and check the settings if you are unsure.
+            Please, cancel and check the settings if you are unsure.
           </Text>
         </Modal>
       </>

--- a/web/src/Overview.test.jsx
+++ b/web/src/Overview.test.jsx
@@ -109,8 +109,8 @@ describe("when the user clicks 'Install'", () => {
     expect(startInstallationFn).toBeCalled();
   });
 
-  test("does not start the installation if the user goes back", async () => {
-    const button = within(dialog).getByRole("button", { name: /Back/i });
+  test("does not start the installation if the user cancels", async () => {
+    const button = within(dialog).getByRole("button", { name: /Cancel/i });
     userEvent.click(button);
 
     expect(startInstallationFn).not.toBeCalled();

--- a/web/src/app.scss
+++ b/web/src/app.scss
@@ -128,6 +128,10 @@ h4, h5, h6 {
   margin-block-end: 10px;
 }
 
+p {
+  margin-block-start: $font-size-base;
+}
+
 #root {
   min-block-size: 100vh;
   background-color: branding.$eos-bc-gray-50;
@@ -141,6 +145,10 @@ h4, h5, h6 {
   // is not an option becaue it removes block margins too.
   .pf-m-link {
     padding-inline: 0;
+  }
+
+  p {
+    margin-block-start: 0;
   }
 }
 


### PR DESCRIPTION
## Problem

The *Install* button has the focus by default, and actioning it runs the installation without asking for confirmation. So, an unintentional enter keystroke raises the installation.

## Solution

Add a confirmation popup. The focus is on the *Cancel* button to avoid starting installation with unintentional double enter keystroke.

## Testing

- Added new unit tests
- Tested manually

## Screenshots

![Screenshot from 2022-04-05 15-19-57](https://user-images.githubusercontent.com/1112304/161775214-6171bfab-7195-43e1-9df3-b1d308293fdb.png)
