### PR TITLE
Fix the behavior of the modal language selector

### DIFF
--- a/web/src/LanguageSelector.jsx
+++ b/web/src/LanguageSelector.jsx
@@ -38,19 +38,19 @@ const reducer = (state, action) => {
       return { ...state, ...action.payload };
     }
     case "ACCEPT": {
-      return { ...state, isFormOpen: false };
+      return { ...state, isFormOpen: false, current: state.formCurrent };
     }
 
     case "CANCEL": {
-      return { ...state, isFormOpen: false, current: state.initial };
+      return { ...state, isFormOpen: false };
     }
 
     case "CHANGE": {
-      return { ...state, current: action.payload };
+      return { ...state, formCurrent: action.payload };
     }
 
     case "OPEN": {
-      return { ...state, isFormOpen: true };
+      return { ...state, isFormOpen: true, formCurrent: state.current };
     }
 
     default: {
@@ -61,8 +61,8 @@ const reducer = (state, action) => {
 
 const initialState = {
   languages: [],
-  initial: null,
   current: null,
+  formCurrent: null,
   isFormOpen: false
 };
 
@@ -77,7 +77,7 @@ export default function LanguageSelector() {
       const [current] = await client.language.getSelectedLanguages();
       dispatch({
         type: "LOAD",
-        payload: { languages, current, initial: current }
+        payload: { languages, current }
       });
     };
 
@@ -90,7 +90,7 @@ export default function LanguageSelector() {
 
   const accept = async () => {
     // TODO: handle errors
-    await client.language.setLanguages([language]);
+    await client.language.setLanguages([state.formCurrent]);
     dispatch({ type: "ACCEPT" });
   };
 
@@ -99,7 +99,7 @@ export default function LanguageSelector() {
     return selectedLanguage ? selectedLanguage.name : "Select language";
   };
 
-  const buildSelector = () => {
+  const buildSelector = formCurrent => {
     const selectorOptions = languages.map(lang => (
       <FormSelectOption key={lang.id} value={lang.id} label={lang.name} />
     ));
@@ -108,7 +108,7 @@ export default function LanguageSelector() {
       <FormSelect
         id="language"
         aria-label="language"
-        value={language}
+        value={formCurrent}
         onChange={v => dispatch({ type: "CHANGE", payload: v })}
       >
         {selectorOptions}
@@ -138,7 +138,7 @@ export default function LanguageSelector() {
       >
         <Form>
           <FormGroup fieldId="language" label="Language">
-            {buildSelector()}
+            {buildSelector(state.formCurrent)}
           </FormGroup>
         </Form>
       </Modal>

--- a/web/src/LanguageSelector.test.jsx
+++ b/web/src/LanguageSelector.test.jsx
@@ -67,3 +67,40 @@ describe("when the user changes the language", () => {
     expect(setLanguagesFn).toHaveBeenCalledWith(["de_DE"]);
   });
 });
+
+describe("when the user changes the language but cancels", () => {
+  it("does not change the selected language", async () => {
+    installerRender(<LanguageSelector />);
+    const button = await screen.findByRole("button", { name: "English" });
+    userEvent.click(button);
+
+    const languageSelector = await screen.findByLabelText("Language");
+    userEvent.selectOptions(languageSelector, ["German"]);
+    userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    await screen.findByRole("button", { name: "English" });
+    expect(setLanguagesFn).not.toHaveBeenCalled();
+  });
+});
+
+describe("when the user changes the language AND THEN cancels", () => {
+  it("reverts to the selected language, not English", async () => {
+    installerRender(<LanguageSelector />);
+    const button = await screen.findByRole("button", { name: "English" });
+    userEvent.click(button);
+
+    const languageSelector = await screen.findByLabelText("Language");
+    userEvent.selectOptions(languageSelector, ["German"]);
+    userEvent.click(screen.getByRole("button", { name: "Confirm" }));
+
+    const button2 = await screen.findByRole("button", { name: "German" });
+    userEvent.click(button2);
+
+    await screen.findByLabelText("Language");
+    userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    await screen.findByRole("button", { name: "German" });
+    expect(setLanguagesFn).toHaveBeenCalledTimes(1);
+    expect(setLanguagesFn).toHaveBeenCalledWith(["de_DE"]);
+  });
+});


### PR DESCRIPTION
## Problem

As #125 says:

> The language selector does not work properly. Picking a language works, but:
> 
> -    the language link changes its content before the confirm button is clicked.
> -    clicking the cancel button causes the selection to be reverted "English (US)".
> 
> Of course, that's not the behavior a user expects.

- https://trello.com/c/MSURGLiw

## Solution

- Learned ReactJS :rofl: https://reactjs.org/tutorial/tutorial.html
- The state transition logic in `reducer` needed fixing.
## Testing

- Tested manually
- Then added new test cases
  - Tip: `npm test -- -o` runs only the tests that have changes against git. <https://jestjs.io/docs/cli>


## Screenshots

(Statically it looks the same)

