### PR TITLE
Small UI fixes

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -7,8 +7,8 @@
       "name": "d-installer",
       "license": "LGPL-2.1",
       "dependencies": {
-        "@patternfly/patternfly": "4.183.1",
-        "@patternfly/react-core": "4.198.19",
+        "@patternfly/patternfly": "4.192.1",
+        "@patternfly/react-core": "4.207.0",
         "@patternfly/react-table": "^4.61.15",
         "core-js": "^3.21.1",
         "eos-ds": "^5.0.0",
@@ -2559,18 +2559,18 @@
       }
     },
     "node_modules/@patternfly/patternfly": {
-      "version": "4.183.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-4.183.1.tgz",
-      "integrity": "sha512-XJZIG/kcEbIPI/0Q6+Q5ax2m295IpQCppertUQ4RfOSkvJVfjQ4CUNmR/ycgjlGm1DItmYJe/NqVFerNlvzUeg=="
+      "version": "4.192.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-4.192.1.tgz",
+      "integrity": "sha512-eNJ3aI9mGfvwMtBwkI+CBJHPhZx1FoNN6QY36iYEvrEOIL5xuuKRDG2tbOzeucQOzNqZ1PO1Eoock5xTcCG86Q=="
     },
     "node_modules/@patternfly/react-core": {
-      "version": "4.198.19",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.198.19.tgz",
-      "integrity": "sha512-f46CIKwWCJ1UNL50TXnvarYUhr2KtxNFw/kGYtG6QwrQwKXscZiXMMtW//0Q08cyhLB0vfxHOLbCKxVaVJ3R3w==",
+      "version": "4.207.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.207.0.tgz",
+      "integrity": "sha512-1259BDhQzDI+0w0G7b2uWbdGU+BC+UWoJfkaz4RSVIUq5XU9E5cywR7103GgewFgdDEg6xnKLQ+jfPV7fITvmA==",
       "dependencies": {
-        "@patternfly/react-icons": "^4.49.19",
-        "@patternfly/react-styles": "^4.48.19",
-        "@patternfly/react-tokens": "^4.50.19",
+        "@patternfly/react-icons": "^4.58.0",
+        "@patternfly/react-styles": "^4.57.0",
+        "@patternfly/react-tokens": "^4.59.0",
         "focus-trap": "6.2.2",
         "react-dropzone": "9.0.0",
         "tippy.js": "5.1.2",
@@ -2582,18 +2582,18 @@
       }
     },
     "node_modules/@patternfly/react-icons": {
-      "version": "4.53.16",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.53.16.tgz",
-      "integrity": "sha512-QQOZwl9MR71uNaKUPKJUm2qjvol28evN7GgyiqGn7fr0p4FnPopm9F5GsnKMsE/764/HGwGLjYHulUo3Eb06dQ==",
+      "version": "4.58.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.58.0.tgz",
+      "integrity": "sha512-g1Kj7ztkSoA+PBZUxbon8o09WxyUvd236wKQeSfStXQnz5HJFwOY/YxKWure228R6Xbh21+mutx7ha29XFzIYQ==",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0",
         "react-dom": "^16.8.0 || ^17.0.0"
       }
     },
     "node_modules/@patternfly/react-styles": {
-      "version": "4.52.16",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-4.52.16.tgz",
-      "integrity": "sha512-i/xj+r0qVlhSoxrFOePxXoC8BudDPsEma0qwP+3Ry4hSZhN6XhSRSqjA5xmaLkgbfWCAiT/+mR9ilCaguxoLTA=="
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-4.57.0.tgz",
+      "integrity": "sha512-QXFciMps6v2xmQ1iAw6Xb1KEcXvUG2h4kSCp2LekmaooCmvqjR576OWsT6j3ODCAC2wqbctXvYioPJUr+4KqdQ=="
     },
     "node_modules/@patternfly/react-table": {
       "version": "4.71.16",
@@ -2612,28 +2612,10 @@
         "react-dom": "^16.8.0 || ^17.0.0"
       }
     },
-    "node_modules/@patternfly/react-table/node_modules/@patternfly/react-core": {
-      "version": "4.202.16",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.202.16.tgz",
-      "integrity": "sha512-yWDf0x+YFFVxm72RC/BUaSOn2UsIirT77qif6DfAWdSODhdxTfaLCeBZ08uWgxJ1YZNCrankj60va+G5L+LVrg==",
-      "dependencies": {
-        "@patternfly/react-icons": "^4.53.16",
-        "@patternfly/react-styles": "^4.52.16",
-        "@patternfly/react-tokens": "^4.54.16",
-        "focus-trap": "6.2.2",
-        "react-dropzone": "9.0.0",
-        "tippy.js": "5.1.2",
-        "tslib": "^2.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
-      }
-    },
     "node_modules/@patternfly/react-tokens": {
-      "version": "4.54.16",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-4.54.16.tgz",
-      "integrity": "sha512-BBVg40L4gx0Gew2kDdGNxP+EtDwGeBuJwXewKrTjXlCa4uhOOj7TqJ5rxhS4GULfYiYbUGdYe7UMFVb+mKDVVg=="
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-4.59.0.tgz",
+      "integrity": "sha512-uqsKUs50qzxerl1fylzgjLMRReX5Xps8oLznT/Quis4mY/rKWCo1Sr16vPKfVOYk60QOxnePfK5H4a3Cqz8Yrw=="
     },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.3",
@@ -13967,18 +13949,18 @@
       }
     },
     "@patternfly/patternfly": {
-      "version": "4.183.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-4.183.1.tgz",
-      "integrity": "sha512-XJZIG/kcEbIPI/0Q6+Q5ax2m295IpQCppertUQ4RfOSkvJVfjQ4CUNmR/ycgjlGm1DItmYJe/NqVFerNlvzUeg=="
+      "version": "4.192.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-4.192.1.tgz",
+      "integrity": "sha512-eNJ3aI9mGfvwMtBwkI+CBJHPhZx1FoNN6QY36iYEvrEOIL5xuuKRDG2tbOzeucQOzNqZ1PO1Eoock5xTcCG86Q=="
     },
     "@patternfly/react-core": {
-      "version": "4.198.19",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.198.19.tgz",
-      "integrity": "sha512-f46CIKwWCJ1UNL50TXnvarYUhr2KtxNFw/kGYtG6QwrQwKXscZiXMMtW//0Q08cyhLB0vfxHOLbCKxVaVJ3R3w==",
+      "version": "4.207.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.207.0.tgz",
+      "integrity": "sha512-1259BDhQzDI+0w0G7b2uWbdGU+BC+UWoJfkaz4RSVIUq5XU9E5cywR7103GgewFgdDEg6xnKLQ+jfPV7fITvmA==",
       "requires": {
-        "@patternfly/react-icons": "^4.49.19",
-        "@patternfly/react-styles": "^4.48.19",
-        "@patternfly/react-tokens": "^4.50.19",
+        "@patternfly/react-icons": "^4.58.0",
+        "@patternfly/react-styles": "^4.57.0",
+        "@patternfly/react-tokens": "^4.59.0",
         "focus-trap": "6.2.2",
         "react-dropzone": "9.0.0",
         "tippy.js": "5.1.2",
@@ -13986,15 +13968,15 @@
       }
     },
     "@patternfly/react-icons": {
-      "version": "4.53.16",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.53.16.tgz",
-      "integrity": "sha512-QQOZwl9MR71uNaKUPKJUm2qjvol28evN7GgyiqGn7fr0p4FnPopm9F5GsnKMsE/764/HGwGLjYHulUo3Eb06dQ==",
+      "version": "4.58.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.58.0.tgz",
+      "integrity": "sha512-g1Kj7ztkSoA+PBZUxbon8o09WxyUvd236wKQeSfStXQnz5HJFwOY/YxKWure228R6Xbh21+mutx7ha29XFzIYQ==",
       "requires": {}
     },
     "@patternfly/react-styles": {
-      "version": "4.52.16",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-4.52.16.tgz",
-      "integrity": "sha512-i/xj+r0qVlhSoxrFOePxXoC8BudDPsEma0qwP+3Ry4hSZhN6XhSRSqjA5xmaLkgbfWCAiT/+mR9ilCaguxoLTA=="
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-4.57.0.tgz",
+      "integrity": "sha512-QXFciMps6v2xmQ1iAw6Xb1KEcXvUG2h4kSCp2LekmaooCmvqjR576OWsT6j3ODCAC2wqbctXvYioPJUr+4KqdQ=="
     },
     "@patternfly/react-table": {
       "version": "4.71.16",
@@ -14007,28 +13989,12 @@
         "@patternfly/react-tokens": "^4.54.16",
         "lodash": "^4.17.19",
         "tslib": "^2.0.0"
-      },
-      "dependencies": {
-        "@patternfly/react-core": {
-          "version": "4.202.16",
-          "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.202.16.tgz",
-          "integrity": "sha512-yWDf0x+YFFVxm72RC/BUaSOn2UsIirT77qif6DfAWdSODhdxTfaLCeBZ08uWgxJ1YZNCrankj60va+G5L+LVrg==",
-          "requires": {
-            "@patternfly/react-icons": "^4.53.16",
-            "@patternfly/react-styles": "^4.52.16",
-            "@patternfly/react-tokens": "^4.54.16",
-            "focus-trap": "6.2.2",
-            "react-dropzone": "9.0.0",
-            "tippy.js": "5.1.2",
-            "tslib": "^2.0.0"
-          }
-        }
       }
     },
     "@patternfly/react-tokens": {
-      "version": "4.54.16",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-4.54.16.tgz",
-      "integrity": "sha512-BBVg40L4gx0Gew2kDdGNxP+EtDwGeBuJwXewKrTjXlCa4uhOOj7TqJ5rxhS4GULfYiYbUGdYe7UMFVb+mKDVVg=="
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-4.59.0.tgz",
+      "integrity": "sha512-uqsKUs50qzxerl1fylzgjLMRReX5Xps8oLznT/Quis4mY/rKWCo1Sr16vPKfVOYk60QOxnePfK5H4a3Cqz8Yrw=="
     },
     "@sinonjs/commons": {
       "version": "1.8.3",

--- a/web/package.json
+++ b/web/package.json
@@ -56,8 +56,8 @@
     "webpack-cli": "^4.9.1"
   },
   "dependencies": {
-    "@patternfly/patternfly": "4.183.1",
-    "@patternfly/react-core": "4.198.19",
+    "@patternfly/patternfly": "4.192.1",
+    "@patternfly/react-core": "4.207.0",
     "@patternfly/react-table": "^4.61.15",
     "core-js": "^3.21.1",
     "eos-ds": "^5.0.0",

--- a/web/src/Popup.jsx
+++ b/web/src/Popup.jsx
@@ -152,8 +152,8 @@ const AncillaryAction = ({ children, ...props }) => (
 /**
  * D-Installer component for displaying a popup
  *
- * Built on top of { @link https://www.patternfly.org/v4/components/modal PF4/Modal }, it manipulate
- * the children object for extraction {Actions} from there.
+ * Built on top of { @link https://www.patternfly.org/v4/components/modal PF4/Modal }, it
+ * manipulates the children object for extracting {Actions}.
  *
  * @example <caption>Usage example</caption>
  *   <Popup

--- a/web/src/app.scss
+++ b/web/src/app.scss
@@ -23,9 +23,24 @@
 
 // Style focus as proposed by EOS
 // https://eosdesignsystem.herokuapp.com/focus#scss-code
+// but making use of :focus-visible, see https://matthiasott.com/notes/focus-visible-is-here
 *:focus {
- box-shadow: 0 0 0 1px branding.$eos-bc-cerulean-500;
- outline: none;
+  outline: none;
+}
+
+*:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+*:focus-visible {
+  box-shadow: 0 0 0 1px branding.$eos-bc-cerulean-500;
+}
+
+// Adds a tiny "padding" when focusing a primary or secondary action to avoid
+// https://github.com/yast/d-installer/issues/115#issuecomment-1087375598
+.pf-c-button.pf-m-primary:focus-visible,
+.pf-c-button.pf-m-secondary:focus-visible {
+  box-shadow: 0 0 0 1px white, 0 0 0 2px branding.$eos-bc-cerulean-500;
 }
 
 // NOTE: commented it out because looks like those

--- a/web/src/patternfly.scss
+++ b/web/src/patternfly.scss
@@ -99,13 +99,6 @@
   // for the :last-child too.
   // See https://github.com/patternfly/patternfly/blob/9c8cb7c8609613ab53eef3fe05addda16bc63233/src/patternfly/components/ModalBox/modal-box.scss#L211
   > .pf-c-button {
-    margin-inline-end: 1ch;
-  }
-
-  // But avoid the gap between buttons and links. We keep using a link
-  // variant for a "Do not XYZ" actions, which are not destructive in the
-  // context of the installer.
-  > .pf-m-link {
-    margin-inline-end: 0;
+    margin-inline-end: var(--pf-c-modal-box__footer--c-button--MarginRight);
   }
 }

--- a/web/src/patternfly.scss
+++ b/web/src/patternfly.scss
@@ -103,11 +103,12 @@
   }
 }
 
-// Do not use "cursor: pointer" for labels because it is not common and confusing)
-// https://github.com/yast/d-installer/issues/115#issuecomment-1090205696
-// https://github.com/patternfly/patternfly/blob/dc6cf07d69cbb80026dca7fe43dc28704aabea64/src/patternfly/components/Form/form.scss#L262-L281
+// Do not change the default cursor for labels forms because it is confusing
+//
+// See:
+//  * https://github.com/yast/d-installer/issues/115#issuecomment-1090205696
+//  * https://github.com/patternfly/patternfly/issues/4777#issuecomment-1092090484
 .pf-c-form__label {
-  &:not(.pf-m-disabled):hover {
-    cursor: default !important;
-  }
+  --pf-c-form__label--hover--Cursor: default;
+  --pf-c-form__label--m-disabled--hover--Cursor: default;
 }

--- a/web/src/patternfly.scss
+++ b/web/src/patternfly.scss
@@ -102,3 +102,12 @@
     margin-inline-end: var(--pf-c-modal-box__footer--c-button--MarginRight);
   }
 }
+
+// Do not use "cursor: pointer" for labels because it is not common and confusing)
+// https://github.com/yast/d-installer/issues/115#issuecomment-1090205696
+// https://github.com/patternfly/patternfly/blob/dc6cf07d69cbb80026dca7fe43dc28704aabea64/src/patternfly/components/Form/form.scss#L262-L281
+.pf-c-form__label {
+  &:not(.pf-m-disabled):hover {
+    cursor: default !important;
+  }
+}

--- a/web/src/utils.js
+++ b/web/src/utils.js
@@ -20,8 +20,8 @@
  */
 
 /**
- * Returns a new array with collection split into two groups, the first holdings element which do
- * satisfy the given filter and the second with those which not.
+ * Returns a new array with a given collection split into two groups, the first holding elements
+ * satisfying the filter and the second with those which do not.
  *
  * @param {Array} collection - the collection to be filtered
  * @param {function} filter - the function to be used as filter


### PR DESCRIPTION
Apply fixes for solving some reported UI issues, namely

* Do not remove margin of _ancillary_ actions in the popup (visible when focusing the element)

  | Before | After |
  | - | - |
  | ![ancillary-action-wrong-placement](https://user-images.githubusercontent.com/1691872/166292255-b756a99d-6153-45c2-8900-2383dffeeaee.png) | ![improved-ancillary-action-placement](https://user-images.githubusercontent.com/1691872/166292291-bea697c4-d954-427b-ae95-b2f96032abdc.png) |

 
* Do not use a `cursor: pointer` for the form labels

  Implies a @patternfly/patternfly and @patternfly/react-core dependencies update to their latest version 

  | Before | After |
  | - | - |
  | ![Form labels using cursor pointer](https://user-images.githubusercontent.com/1691872/166292379-f4ee7a30-d37c-4eb6-96de-ce2cd499aea2.png) | ![Form labels using default cursor](https://user-images.githubusercontent.com/1691872/166292464-15f3edd7-8301-4181-8fcb-1f4698d55f07.png) |

* Improves the focus style for primary and secondary actions by adding a kind of padding in order to make it more visible

  Also start making use of :focus-visible, https://matthiasott.com/notes/focus-visible-is-here

  | Before | After |
  | - | - |
  | ![primary-button-confusing-focus](https://user-images.githubusercontent.com/1691872/166292724-e352ca29-5e4b-447c-833b-067a77c4a93f.png) | ![improved-primary-button-focus](https://user-images.githubusercontent.com/1691872/166292758-162ec511-54b7-4e76-8d7e-75afa01928d7.png) |


---

~~It also performs a node packages update following https://nodejs.dev/learn/update-all-the-nodejs-dependencies-to-their-latest-version instructions. More specifically, by running an `ncu -u -x 'react,react-dom,jest,@testing-library/react' && npm install` to avoid upgrading to React 18.~~ 

^^^ Postponed to be done in a separated PR(s) 
