### PR TITLE
Fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,4 +100,4 @@ Point your browser to http://localhost:9090/cockpit/@localhost/d-installer.index
 
 ## References
 
-* [Development Notes](./DEVELOPMENT.md)
+* [Development Notes](./web/README.md)

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The web-based UI is a Cockpit module. To build the application, just type:
     cd web
     make devel-install
 
-Point your browser to http://localhost:9090/cockpit/@localhost/d-installer.index.html and happy hacking!
+Point your browser to http://localhost:9090/cockpit/@localhost/d-installer/index.html and happy hacking!
 
 ## References
 


### PR DESCRIPTION
Link to _Development notes_ was broken. Now it points to _web/README.md_ until we restore the _DEVELOPMENT.md_ document. Additionally, it fixes a D-installer URL  too.