### PR TITLE
Add D-Bus questions

### DIFF
--- a/service/lib/dinstaller/dbus/question.rb
+++ b/service/lib/dinstaller/dbus/question.rb
@@ -1,0 +1,179 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "dbus"
+require "pathname"
+require "dinstaller/dbus/questions"
+require "dinstaller/question"
+require "dinstaller/luks_question"
+
+module DInstaller
+  module DBus
+    # Class to represent a question on D-Bus
+    #
+    # Questions are dynamically exported on D-Bus. All questions are exported as children of
+    # {DBus::Questions} object to mimic ObjectManager behavior. Note that ruby-dbus does not support
+    # ObjectManager yet.
+    #
+    # Clients should provide an answer for each question.
+    class Question < ::DBus::Object
+      # This module contains the D-Bus interfaces that question D-Bus object can implement. The
+      # interfaces that a question implements are dynamically determined while creating a new
+      # D-Bus question.
+      module Interfaces
+        # Generic interface for a question
+        module Question
+          QUESTION_INTERFACE = "org.opensuse.DInstaller.Question1"
+          private_constant :QUESTION_INTERFACE
+
+          # @!method backend
+          #   @note Classes including this mixin must define a #backend method
+          #   @return [DInstaller::Question]
+
+          # Unique id of the question
+          #
+          # @return [Integer]
+          def id
+            backend.id
+          end
+
+          # Text of the question
+          #
+          # @return [String]
+          def text
+            backend.text
+          end
+
+          # Options the question admits as answer
+          #
+          # @note Clients are responsible of generating the proper label for each option.
+          #
+          # @return [Array<String>]
+          def options
+            backend.options.map(&:to_s)
+          end
+
+          # Default option a client should offer as answer
+          #
+          # @return [String]
+          def default_option
+            backend.default_option.to_s
+          end
+
+          # Answer selected for a client
+          #
+          # @return [String]
+          def answer
+            backend.answer.to_s
+          end
+
+          # Selects an option as answer
+          #
+          # @param option [String]
+          def answer=(option)
+            backend.answer = option.to_sym
+          end
+
+          def self.included(base)
+            base.class_eval do
+              dbus_interface QUESTION_INTERFACE do
+                dbus_reader :id, "u"
+                dbus_reader :text, "s"
+                dbus_reader :options, "as"
+                dbus_reader :default_option, "s"
+                dbus_accessor :answer, "s"
+              end
+            end
+          end
+        end
+
+        # Interface to request a LUKS password
+        module LuksPassword
+          LUKS_PASSWORD_INTERFACE = "org.opensuse.DInstaller.Question.LuksPassword1"
+          private_constant :LUKS_PASSWORD_INTERFACE
+
+          # @!method backend
+          #   @note Classes including this mixin must define a #backend method
+          #   @return [DInstaller::Question]
+
+          # Given password
+          #
+          # @return [String]
+          def luks_password
+            backend.password || ""
+          end
+
+          # Sets a password
+          #
+          # @param value [String]
+          def luks_password=(value)
+            backend.password = value
+          end
+
+          def self.included(base)
+            base.class_eval do
+              dbus_interface LUKS_PASSWORD_INTERFACE do
+                dbus_accessor :luks_password, "s", dbus_name: "Value"
+              end
+            end
+          end
+        end
+      end
+
+      # Defines the interfaces to implement according to the backend type
+      INTERFACES_TO_INCLUDE = {
+        DInstaller::Question     => [Interfaces::Question],
+        DInstaller::LuksQuestion => [Interfaces::Question, Interfaces::LuksPassword]
+      }.freeze
+      private_constant :INTERFACES_TO_INCLUDE
+
+      # Constructor
+      #
+      # @param backend [DInstaller::Question]
+      # @param logger [Logger]
+      def initialize(backend, logger)
+        @backend = backend
+        @logger = logger
+
+        super(build_path)
+
+        add_interfaces
+      end
+
+    private
+
+      # @return [DInstaller::Question]
+      attr_reader :backend
+
+      # Builds the question path under {DBus::Questions} path (e.g., o.o.DInstaller/Questions1/1)
+      #
+      # @return [String]
+      def build_path
+        Pathname.new(Questions.path).join(backend.id.to_s).to_s
+      end
+
+      # Adds interfaces to the question
+      def add_interfaces
+        INTERFACES_TO_INCLUDE[backend.class].each { |i| singleton_class.include(i) }
+      end
+    end
+  end
+end

--- a/service/lib/dinstaller/dbus/question.rb
+++ b/service/lib/dinstaller/dbus/question.rb
@@ -20,8 +20,6 @@
 # find current contact information at www.suse.com.
 
 require "dbus"
-require "pathname"
-require "dinstaller/dbus/questions"
 require "dinstaller/question"
 require "dinstaller/luks_question"
 
@@ -30,8 +28,7 @@ module DInstaller
     # Class to represent a question on D-Bus
     #
     # Questions are dynamically exported on D-Bus. All questions are exported as children of
-    # {DBus::Questions} object to mimic ObjectManager behavior. Note that ruby-dbus does not support
-    # ObjectManager yet.
+    # {DBus::Questions} object.
     #
     # Clients should provide an answer for each question.
     class Question < ::DBus::Object
@@ -147,13 +144,14 @@ module DInstaller
 
       # Constructor
       #
+      # @param path [::DBus::ObjectPath]
       # @param backend [DInstaller::Question]
       # @param logger [Logger]
-      def initialize(backend, logger)
+      def initialize(path, backend, logger)
         @backend = backend
         @logger = logger
 
-        super(build_path)
+        super(path)
 
         add_interfaces
       end
@@ -162,13 +160,6 @@ module DInstaller
 
       # @return [DInstaller::Question]
       attr_reader :backend
-
-      # Builds the question path under {DBus::Questions} path (e.g., o.o.DInstaller/Questions1/1)
-      #
-      # @return [String]
-      def build_path
-        Pathname.new(Questions.path).join(backend.id.to_s).to_s
-      end
 
       # Adds interfaces to the question
       def add_interfaces

--- a/service/lib/dinstaller/dbus/questions.rb
+++ b/service/lib/dinstaller/dbus/questions.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "dbus"
+require "dinstaller/dbus/question"
+
+module DInstaller
+  module DBus
+    # This class mimics the basic functionality of ObjectManager. Note that ruby-dbus does not
+    # support ObjectManager yet.
+    #
+    # What does a {DBus::Questions} object do:
+    #
+    # * Uses a {QuestionsManager} as backend.
+    # * Exports a {DBus::Question} object when a {DInstaller::Question} is added to the questions
+    #   manager.
+    # * Unexports a {DBus::Question} object when a {DInstaller::Question} is deleted from the
+    #   questions manager.
+    # * Ensures that D-Bus messages are dispatched while questions manager waits for all questions
+    #   be answered.
+    #
+    # Questions are exported in D-Bus in a tree form similar to ObjectManager. For example:
+    #
+    # /org/opensuse/DInstaller/Questions1
+    #   /org/opensuse/DInstaller/Questions1/1
+    #   /org/opensuse/DInstaller/Questions1/2
+    #   /org/opensuse/DInstaller/Questions1/3
+    #
+    # This class configures the callbacks of {QuestionsManager} to ensure that the proper D-Bus
+    # actions are performed when adding, deleting or waiting for answers.
+    class Questions < ::DBus::Object
+      PATH = "/org/opensuse/DInstaller/Questions1"
+      private_constant :PATH
+
+      QUESTIONS_INTERFACE = "org.opensuse.DInstaller.Questions1"
+      private_constant :QUESTIONS_INTERFACE
+
+      # Path of the object
+      #
+      # {DBus::Question} objects are dynamically exported under this path.
+      #
+      # @return [String]
+      def self.path
+        PATH
+      end
+
+      # Constructor
+      #
+      # The callbacks of the backend are configured to perform the proper D-Bus actions, see
+      # {#register_callbacks}.
+      #
+      # @param backend [DInstaller::QuestionsManager]
+      # @param logger [Logger]
+      def initialize(backend, logger)
+        @backend = backend
+        @logger = logger
+        @exported_questions = []
+
+        register_callbacks
+
+        super(PATH)
+      end
+
+      # Paths of all currently exported questions
+      #
+      # @warn This method is used to implement a D-Bus reader method. Do not use it to recover all
+      #   the {Question} objects.
+      #
+      # @return [Array<::DBus::ObjectPath>]
+      def all
+        exported_questions.map(&:path)
+      end
+
+      dbus_interface QUESTIONS_INTERFACE do
+        dbus_reader :all, "as"
+      end
+
+    private
+
+      # @return [DInstaller::QuestionsManager]
+      attr_reader :backend
+
+      # @return [Logger]
+      attr_reader :logger
+
+      # Currently exported questions
+      #
+      # @return [Array<DBus::Question>]
+      attr_reader :exported_questions
+
+      # Callbacks with actions to do when adding, deleting or waiting for questions
+      def register_callbacks
+        # When adding a question, a new question is exported on D-Bus.
+        backend.on_add do |question|
+          dbus_object = DBus::Question.new(question, logger)
+          @service.export(dbus_object)
+          exported_questions << dbus_object
+          PropertiesChanged(QUESTIONS_INTERFACE, { "All" => all }, [])
+        end
+
+        # When removing a question, the question is unexported from D-Bus.
+        backend.on_delete do |question|
+          dbus_object = exported_questions.find { |q| q.id == question.id }
+          if dbus_object
+            @service.unexport(dbus_object)
+            exported_questions.delete(dbus_object)
+            PropertiesChanged(QUESTIONS_INTERFACE, { "All" => all }, [])
+          end
+        end
+
+        # Bus dispatches messages while waiting for questions to be answered
+        backend.on_wait { @service.bus.dispatch_message_queue }
+      end
+    end
+  end
+end

--- a/service/lib/dinstaller/dbus/service.rb
+++ b/service/lib/dinstaller/dbus/service.rb
@@ -26,6 +26,7 @@ require "dinstaller/dbus/software"
 require "dinstaller/dbus/users"
 require "dinstaller/dbus/storage/proposal"
 require "dinstaller/dbus/storage/actions"
+require "dinstaller/dbus/questions"
 
 module DInstaller
   module DBus
@@ -89,7 +90,8 @@ module DInstaller
           software_dbus,
           users_dbus,
           storage_proposal_dbus,
-          storage_actions_dbus
+          storage_actions_dbus,
+          questions_dbus
         ]
       end
 
@@ -118,6 +120,10 @@ module DInstaller
       def storage_actions_dbus
         @storage_actions_dbus ||=
           DInstaller::DBus::Storage::Actions.new(manager.storage.actions, logger)
+      end
+
+      def questions_dbus
+        @questions_dbus ||= DInstaller::DBus::Questions.new(manager.questions_manager, logger)
       end
     end
   end

--- a/service/lib/dinstaller/luks_question.rb
+++ b/service/lib/dinstaller/luks_question.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "dinstaller/question"
+
+module DInstaller
+  # This class represent a question to ask whether to activate a LUKS device
+  #
+  # @example
+  #   question = LuksQuestion.new("/dev/sda1", label: "mydata", size: "10 GiB")
+  #   question.password = "n0ts3cr3t"
+  #
+  #   question.answer = :skip    # in case you do not want to activate the device
+  #
+  #   question.answer = :decrypt # in case you want to decrypt with the given password
+  class LuksQuestion < Question
+    # Constructor
+    #
+    # @param device [String] name of the device to be activated (e.g., "/dev/sda1")
+    # @param label [String, nil] label of the device
+    # @param size [String, nil] size of the device (e.g., "5 GiB")
+    def initialize(device, label: nil, size: nil)
+      @device = device
+      @label = label
+      @size = size
+
+      # Clients should answer either skip activation (:skip) or decrypt (:decrypt) with the given
+      # password (see {#password}).
+      super(generate_text, options: [:skip, :decrypt])
+    end
+
+    # Password to activate the LUKS device
+    #
+    # @return [String, nil] nil means a password has not been provided yet
+    attr_accessor :password
+
+  private
+
+    # @return [String]
+    attr_reader :device
+
+    # @return [String, nil]
+    attr_reader :label
+
+    # @return [String, nil]
+    attr_reader :size
+
+    # Generate the text for the question
+    #
+    # @return [String]
+    def generate_text
+      "The device #{device_info} is encrypted. Do you want to decrypt it?"
+    end
+
+    # Device information to include in the question
+    #
+    # @return [String]
+    def device_info
+      info = [device]
+      info << label unless label.to_s.empty?
+      info << "(#{size})" unless size.to_s.empty?
+
+      info.join(" ")
+    end
+  end
+end

--- a/service/lib/dinstaller/luks_question.rb
+++ b/service/lib/dinstaller/luks_question.rb
@@ -24,6 +24,10 @@ require "dinstaller/question"
 module DInstaller
   # This class represent a question to ask whether to activate a LUKS device
   #
+  # Clients have to answer one of these options:
+  #   * skip: to skip the activation of the LUKS device
+  #   * decrypt: to activate the device using the provided password
+  #
   # @example
   #   question = LuksQuestion.new("/dev/sda1", label: "mydata", size: "10 GiB")
   #   question.password = "n0ts3cr3t"
@@ -42,8 +46,6 @@ module DInstaller
       @label = label
       @size = size
 
-      # Clients should answer either skip activation (:skip) or decrypt (:decrypt) with the given
-      # password (see {#password}).
       super(generate_text, options: [:skip, :decrypt])
     end
 

--- a/service/lib/dinstaller/manager.rb
+++ b/service/lib/dinstaller/manager.rb
@@ -31,6 +31,7 @@ require "dinstaller/software"
 require "dinstaller/status_manager"
 require "dinstaller/storage"
 require "dinstaller/users"
+require "dinstaller/questions_manager"
 
 Yast.import "Stage"
 
@@ -47,6 +48,9 @@ module DInstaller
     # @return [StatusManager]
     attr_reader :status_manager
 
+    # @return [QuestionsManager]
+    attr_reader :questions_manager
+
     # @return [Progress]
     attr_reader :progress
 
@@ -56,6 +60,7 @@ module DInstaller
     def initialize(logger)
       @logger = logger
       @status_manager = StatusManager.new(Status::Error.new) # temporary status until probing starts
+      @questions_manager = QuestionsManager.new(logger)
       @progress = Progress.new
 
       initialize_yast

--- a/service/lib/dinstaller/question.rb
+++ b/service/lib/dinstaller/question.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+module DInstaller
+  # This class represents a question
+  #
+  # Questions are used when some information needs to be asked. For example, a question could be
+  # created for asking whether to continue or not when an error is detected.
+  #
+  # Questions are managed by a questions manager, see {QuestionsManager}.
+  class Question
+    # Each question is identified by an unique id
+    #
+    # @return [Integer]
+    attr_reader :id
+
+    # Text of the question
+    #
+    # @return [String]
+    attr_reader :text
+
+    # Options the question offers
+    #
+    # The question must be answered with one of that options.
+    #
+    # @return [Array<Symbol>]
+    attr_reader :options
+
+    # Default option to use as answer
+    #
+    # @return [Symbol, nil]
+    attr_reader :default_option
+
+    # Answer of the question
+    #
+    # @return [Symbol, nil] nil if the question is not answered yet
+    attr_reader :answer
+
+    def initialize(text, options: [], default_option: nil)
+      @id = IdGenerator.next
+      @text = text
+      @options = options
+      @default_option = default_option
+    end
+
+    # Answers the question with an option
+    #
+    # @raise [ArgumentError] if the given value is not a valid answer.
+    #
+    # @param value [Symbol]
+    def answer=(value)
+      raise ArgumentError, "Invalid answer. Options: #{options}" unless valid_answer?(value)
+
+      @answer = value
+    end
+
+    # Whether the question is already answered
+    #
+    # @return [Boolean]
+    def answered?
+      !answer.nil?
+    end
+
+  private
+
+    # Checks whether the given value is a valid answer
+    #
+    # @param value [Symbol]
+    # @return [Boolean]
+    def valid_answer?(value)
+      options.include?(value)
+    end
+
+    # Helper class for generating unique ids
+    class IdGenerator
+      # Generates the next id to be used
+      #
+      # @return [Integer]
+      def self.next
+        @last_id ||= 0
+        @last_id += 1
+      end
+    end
+  end
+end

--- a/service/lib/dinstaller/questions_manager.rb
+++ b/service/lib/dinstaller/questions_manager.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+module DInstaller
+  # Manager for questions
+  #
+  # Allows to configure callbacks with the actions to perform when adding, deleting or waiting for
+  # questions.
+  class QuestionsManager
+    # @return [Array<Question>]
+    attr_reader :questions
+
+    # Constructor
+    #
+    # @params logger [Logger]
+    def initialize(logger)
+      @logger = logger
+      @questions = []
+      @on_add_callbacks = []
+      @on_delete_callbacks = []
+      @on_wait_callbacks = []
+    end
+
+    # Adds a question
+    #
+    # Callbacks are called after adding the question, see {#on_add}.
+    #
+    # @yieldparam question [Question] added question
+    #
+    # @param question [Question]
+    # @return [Boolean] whether the question was added
+    def add(question)
+      return false if include?(question)
+
+      questions << question
+      on_add_callbacks.each { |c| c.call(question) }
+
+      true
+    end
+
+    # Deletes the given question
+    #
+    # Callbacks are called after deleting the question, see {#on_delete}.
+    #
+    # @yieldparam question [Question] deleted question
+    #
+    # @param question [Question]
+    # @return [Boolean] whether the question was deleted
+    def delete(question)
+      return false unless include?(question)
+
+      questions.delete(question)
+      on_delete_callbacks.each { |c| c.call(question) }
+
+      true
+    end
+
+    # Waits until all questions are answered
+    #
+    # Callbacks are periodically called while waiting, see {#on_wait}.
+    def wait
+      logger.info "Waiting for questions to be answered"
+
+      loop do
+        on_wait_callbacks.each(&:call)
+        sleep(0.1)
+        break if questions_answered?
+      end
+    end
+
+    # Registers a callback to be called when a new question is added
+    #
+    # @param block [Proc]
+    def on_add(&block)
+      on_add_callbacks << block
+    end
+
+    # Registers a callback to be called when a question is deleted
+    #
+    # @param block [Proc]
+    def on_delete(&block)
+      on_delete_callbacks << block
+    end
+
+    # Registers a callback to be called while waiting for questions be answered
+    #
+    # @param block [Proc]
+    def on_wait(&block)
+      on_wait_callbacks << block
+    end
+
+  private
+
+    # @return [Logger]
+    attr_reader :logger
+
+    # Callbacks to be called when the a new question is added
+    #
+    # @return [Array<Proc>]
+    attr_reader :on_add_callbacks
+
+    # Callbacks to be called when the a question is deleted
+    #
+    # @return [Array<Proc>]
+    attr_reader :on_delete_callbacks
+
+    # Callbacks to be called when waiting for answers
+    #
+    # @return [Array<Proc>]
+    attr_reader :on_wait_callbacks
+
+    # Whether a question with the same id as the given question is already in the list of questions
+    #
+    # @param question [Question]
+    # @return [Boolean]
+    def include?(question)
+      questions.any? { |q| q.id == question.id }
+    end
+
+    # Whether all questions are already answered
+    #
+    # @return [Boolean]
+    def questions_answered?
+      questions.all?(&:answered?)
+    end
+  end
+end

--- a/service/test/dinstaller/dbus/question_test.rb
+++ b/service/test/dinstaller/dbus/question_test.rb
@@ -26,11 +26,13 @@ require "dinstaller/luks_question"
 require "dbus"
 
 describe DInstaller::DBus::Question do
-  subject { described_class.new(backend, logger) }
+  subject { described_class.new(path, backend, logger) }
 
   before do
     subject.instance_variable_set(:@service, service)
   end
+
+  let(:path) { "/org/test" }
 
   let(:logger) { instance_double(Logger, warn: nil, info: nil, error: nil) }
 
@@ -118,6 +120,8 @@ describe DInstaller::DBus::Question do
         end
       end
     end
+
+    let(:backend) { DInstaller::Question.new("test") }
 
     context "for a generic question" do
       let(:backend) do

--- a/service/test/dinstaller/dbus/question_test.rb
+++ b/service/test/dinstaller/dbus/question_test.rb
@@ -1,0 +1,177 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "dinstaller/dbus/question"
+require "dinstaller/question"
+require "dinstaller/luks_question"
+require "dbus"
+
+describe DInstaller::DBus::Question do
+  subject { described_class.new(backend, logger) }
+
+  before do
+    subject.instance_variable_set(:@service, service)
+  end
+
+  let(:logger) { instance_double(Logger, warn: nil, info: nil, error: nil) }
+
+  let(:service) { instance_double(DBus::Service, bus: system_bus) }
+
+  let(:system_bus) { instance_double(DBus::SystemBus, emit: nil) }
+
+  describe ".new" do
+    shared_examples "Interfaces::Question" do
+      it "defines #id, #text, #options, #default_option, #answer" do
+        expect(subject).to respond_to(:id, :text, :options, :default_option, :answer)
+      end
+
+      describe "#id" do
+        it "returns the question id" do
+          expect(subject.id).to eq(backend.id)
+        end
+      end
+
+      describe "#text" do
+        it "returns the question text" do
+          expect(subject.text).to eq(backend.text)
+        end
+      end
+
+      describe "#answer" do
+        context "if the question has no answer" do
+          it "returns an empty string" do
+            expect(subject.answer).to eq("")
+          end
+        end
+
+        context "if the question has an answer" do
+          before do
+            backend.answer = answer
+          end
+
+          let(:answer) { backend.options.first }
+
+          it "returns the answer as string" do
+            expect(subject.answer).to eq(answer.to_s)
+          end
+        end
+      end
+
+      describe "#answer=" do
+        let(:answer) { backend.options.first.to_s }
+
+        it "sets the given option as answer" do
+          subject.answer = answer
+
+          expect(backend.answer).to eq(answer.to_sym)
+        end
+      end
+    end
+
+    shared_examples "Interfaces::LuksPassword" do
+      it "defines #luks_password" do
+        expect(subject).to respond_to(:luks_password)
+      end
+
+      describe "#luks_password" do
+        context "if the question has no password" do
+          it "returns an empty string" do
+            expect(subject.luks_password).to eq("")
+          end
+        end
+
+        context "if the question has a password" do
+          before do
+            backend.password = "n0ts3cr3t"
+          end
+
+          it "returns the password" do
+            expect(subject.luks_password).to eq("n0ts3cr3t")
+          end
+        end
+      end
+
+      describe "#luks_password=" do
+        it "sets the given password" do
+          subject.luks_password = "n0ts3cr3t"
+
+          expect(backend.password).to eq("n0ts3cr3t")
+        end
+      end
+    end
+
+    context "for a generic question" do
+      let(:backend) do
+        DInstaller::Question.new("test", options: options, default_option: default_option)
+      end
+
+      let(:options) { [:yes, :no] }
+
+      let(:default_option) { nil }
+
+      include_examples "Interfaces::Question"
+
+      describe "#options" do
+        it "returns the question options as strings" do
+          expect(subject.options).to contain_exactly("yes", "no")
+        end
+      end
+
+      describe "#default_option" do
+        context "if the question has no default option" do
+          let(:default_option) { nil }
+
+          it "returns an empty string" do
+            expect(subject.default_option).to eq("")
+          end
+        end
+
+        context "if the question has a default option" do
+          let(:default_option) { :yes }
+
+          it "returns the default option as string" do
+            expect(subject.default_option).to eq("yes")
+          end
+        end
+      end
+    end
+
+    context "for a question to activate a LUKS device" do
+      let(:backend) { DInstaller::LuksQuestion.new("/dev/sda1") }
+
+      include_examples "Interfaces::Question"
+      include_examples "Interfaces::LuksPassword"
+
+      describe "#options" do
+        it "returns 'skip' and 'decrypt'" do
+          expect(subject.options).to contain_exactly("skip", "decrypt")
+        end
+      end
+
+      describe "#default_option" do
+        it "returns an empty string" do
+          expect(subject.default_option).to eq("")
+        end
+      end
+    end
+  end
+end

--- a/service/test/dinstaller/dbus/questions_test.rb
+++ b/service/test/dinstaller/dbus/questions_test.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "dinstaller/dbus/questions"
+require "dinstaller/questions_manager"
+require "dinstaller/question"
+require "dbus"
+
+describe DInstaller::DBus::Questions do
+  subject { described_class.new(backend, logger) }
+
+  before do
+    subject.instance_variable_set(:@service, service)
+  end
+
+  let(:backend) { DInstaller::QuestionsManager.new(logger) }
+
+  let(:logger) { instance_double(Logger, warn: nil, info: nil, error: nil) }
+
+  let(:service) { instance_double(DBus::Service, export: nil, unexport: nil, bus: system_bus) }
+
+  let(:system_bus) { instance_double(DBus::SystemBus) }
+
+  it "configures callbacks for exporting a D-Bus question when a new question is added" do
+    question1 = DInstaller::Question.new("test1")
+    question2 = DInstaller::Question.new("test2")
+
+    expect(service).to receive(:export) do |dbus_object|
+      id = dbus_object.path.split("/").last.to_i
+      expect(id).to eq(question1.id)
+    end
+
+    expect(service).to receive(:export) do |dbus_object|
+      id = dbus_object.path.split("/").last.to_i
+      expect(id).to eq(question2.id)
+    end
+
+    expect(subject).to receive(:PropertiesChanged).twice
+
+    backend.add(question1)
+    backend.add(question2)
+
+    expect(subject.all.size).to eq(2)
+  end
+
+  it "configures callbacks for unexporting a D-Bus question when a question is deleted" do
+    question1 = DInstaller::Question.new("test1")
+    question2 = DInstaller::Question.new("test2")
+
+    allow(subject).to receive(:PropertiesChanged)
+
+    backend.add(question1)
+    backend.add(question2)
+
+    expect(service).to receive(:unexport) do |dbus_object|
+      id = dbus_object.path.split("/").last.to_i
+      expect(id).to eq(question1.id)
+    end
+
+    expect(subject).to receive(:PropertiesChanged).once
+
+    backend.delete(question1)
+
+    expect(subject.all.size).to eq(1)
+  end
+
+  it "configures callbacks to dispatch D-Bus messages while waiting for answers" do
+    allow(backend).to receive(:loop).and_yield
+    allow(backend).to receive(:sleep)
+
+    expect(system_bus).to receive(:dispatch_message_queue)
+
+    backend.wait
+  end
+end

--- a/service/test/dinstaller/dbus/questions_test.rb
+++ b/service/test/dinstaller/dbus/questions_test.rb
@@ -23,6 +23,7 @@ require_relative "../../test_helper"
 require "dinstaller/dbus/questions"
 require "dinstaller/questions_manager"
 require "dinstaller/question"
+require "dinstaller/luks_question"
 require "dbus"
 
 describe DInstaller::DBus::Questions do
@@ -54,19 +55,19 @@ describe DInstaller::DBus::Questions do
       expect(id).to eq(question2.id)
     end
 
-    expect(subject).to receive(:PropertiesChanged).twice
+    expect(subject).to receive(:InterfacesAdded).twice
 
     backend.add(question1)
     backend.add(question2)
 
-    expect(subject.all.size).to eq(2)
+    expect(subject.managed_objects.keys.size).to eq(2)
   end
 
   it "configures callbacks for unexporting a D-Bus question when a question is deleted" do
     question1 = DInstaller::Question.new("test1")
     question2 = DInstaller::Question.new("test2")
 
-    allow(subject).to receive(:PropertiesChanged)
+    allow(subject).to receive(:InterfacesAdded)
 
     backend.add(question1)
     backend.add(question2)
@@ -76,11 +77,11 @@ describe DInstaller::DBus::Questions do
       expect(id).to eq(question1.id)
     end
 
-    expect(subject).to receive(:PropertiesChanged).once
+    expect(subject).to receive(:InterfacesRemoved).once
 
     backend.delete(question1)
 
-    expect(subject.all.size).to eq(1)
+    expect(subject.managed_objects.keys.size).to eq(1)
   end
 
   it "configures callbacks to dispatch D-Bus messages while waiting for answers" do
@@ -90,5 +91,44 @@ describe DInstaller::DBus::Questions do
     expect(system_bus).to receive(:dispatch_message_queue)
 
     backend.wait
+  end
+
+  describe "#managed_objects" do
+    before do
+      allow(subject).to receive(:InterfacesAdded)
+
+      backend.add(question1)
+      backend.add(question2)
+    end
+
+    let(:question1) { DInstaller::Question.new("test1") }
+    let(:question2) { DInstaller::LuksQuestion.new("/dev/sda1") }
+
+    it "returns interfaces and properties for each exported question" do
+      result = subject.managed_objects
+
+      path1 = "/org/opensuse/DInstaller/Questions1/#{question1.id}"
+      path2 = "/org/opensuse/DInstaller/Questions1/#{question2.id}"
+
+      expect(result.keys).to contain_exactly(path1, path2)
+
+      expect(result[path1].keys).to contain_exactly(
+        "org.freedesktop.DBus.Properties",
+        "org.opensuse.DInstaller.Question1"
+      )
+
+      expect(result[path2].keys).to contain_exactly(
+        "org.freedesktop.DBus.Properties",
+        "org.opensuse.DInstaller.Question1",
+        "org.opensuse.DInstaller.Question.LuksPassword1"
+      )
+
+      expect(result[path1]["org.freedesktop.DBus.Properties"].keys).to be_empty
+      expect(result[path1]["org.opensuse.DInstaller.Question1"].keys).to contain_exactly(
+        "Id", "Text", "Options", "DefaultOption", "Answer"
+      )
+      expect(result[path2]["org.opensuse.DInstaller.Question.LuksPassword1"].keys)
+        .to contain_exactly("Value")
+    end
   end
 end

--- a/service/test/dinstaller/dbus/service_test.rb
+++ b/service/test/dinstaller/dbus/service_test.rb
@@ -19,7 +19,7 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require_relative "../test_helper"
+require_relative "../../test_helper"
 require "dinstaller/dbus/service"
 require "dinstaller/manager"
 
@@ -82,6 +82,15 @@ describe DInstaller::DBus::Service do
         .with(manager.users, logger).and_return(users_obj)
 
       expect(bus_service).to receive(:export).with(users_obj)
+      service.export
+    end
+
+    it "exports the questions object" do
+      dbus_object = instance_double(DInstaller::DBus::Questions, path: nil)
+      allow(DInstaller::DBus::Questions).to receive(:new)
+        .with(manager.questions_manager, logger).and_return(dbus_object)
+
+      expect(bus_service).to receive(:export).with(dbus_object)
       service.export
     end
   end

--- a/service/test/dinstaller/luks_question_test.rb
+++ b/service/test/dinstaller/luks_question_test.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+require "dinstaller/luks_question"
+
+describe DInstaller::LuksQuestion do
+  describe ".new" do
+    it "creates a question with the text to ask for a LUKS password" do
+      question = described_class.new("/dev/sda1")
+      expect(question.text).to match(/device \/dev\/sda1 is encrypted/)
+
+      question = described_class.new("/dev/sda1", label: "mydata")
+      expect(question.text).to match(/device \/dev\/sda1 mydata is encrypted/)
+
+      question = described_class.new("/dev/sda1", size: "5 GiB")
+      expect(question.text).to match(/device \/dev\/sda1 \(5 GiB\) is encrypted/)
+
+      question = described_class.new("/dev/sda1", label: "mydata", size: "5 GiB")
+      expect(question.text).to match(/device \/dev\/sda1 mydata \(5 GiB\) is encrypted/)
+    end
+  end
+end

--- a/service/test/dinstaller/question_test.rb
+++ b/service/test/dinstaller/question_test.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+require "dinstaller/question"
+
+describe DInstaller::Question do
+  describe ".new" do
+    it "creates a question with unique id" do
+      question1 = described_class.new("test1")
+      question2 = described_class.new("test2")
+      question3 = described_class.new("test3")
+
+      ids = [question1, question2, question3].map(&:id).uniq
+
+      expect(ids.size).to eq(3)
+    end
+  end
+
+  subject { described_class.new("test", options: options, default_option: default_option) }
+
+  let(:options) { [:yes, :no] }
+
+  let(:default_option) { :yes }
+
+  describe "#answer=" do
+    context "when the given value is a valid option" do
+      let(:value) { :no }
+
+      it "sets the given option as answer" do
+        subject.answer = value
+
+        expect(subject.answer).to eq(value)
+      end
+    end
+
+    context "when the given value is not a valid option" do
+      let(:value) { :other }
+
+      it "raises an error" do
+        expect { subject.answer = value }.to raise_error(ArgumentError, /Invalid answer/)
+      end
+    end
+  end
+
+  describe "#answered?" do
+    context "if the question has no answer yet" do
+      it "returns false" do
+        expect(subject.answered?).to eq(false)
+      end
+    end
+
+    context "if the question has an answer" do
+      before do
+        subject.answer = :yes
+      end
+
+      it "returns true" do
+        expect(subject.answered?).to eq(true)
+      end
+    end
+  end
+end

--- a/service/test/dinstaller/questions_manager_test.rb
+++ b/service/test/dinstaller/questions_manager_test.rb
@@ -1,0 +1,165 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+require "dinstaller/questions_manager"
+require "dinstaller/question"
+
+describe DInstaller::QuestionsManager do
+  subject { described_class.new(logger) }
+
+  let(:logger) { instance_double(Logger, warn: nil, info: nil, error: nil) }
+
+  let(:callback) { proc {} }
+
+  let(:question1) { DInstaller::Question.new("test1", options: [:yes, :no]) }
+  let(:question2) { DInstaller::Question.new("test2", options: [:yes, :no]) }
+
+  describe "#add" do
+    before do
+      subject.on_add(&callback)
+    end
+
+    context "if it does not contain the given question yet" do
+      it "adds the question" do
+        subject.add(question1)
+
+        expect(subject.questions).to include(question1)
+      end
+
+      it "calls the #on_add callbacks" do
+        expect(callback).to receive(:call)
+
+        subject.add(question1)
+      end
+
+      it "returns true" do
+        expect(subject.add(question1)).to eq(true)
+      end
+    end
+
+    context "if it already contains the given question" do
+      before do
+        subject.add(question1)
+      end
+
+      it "does not add the question" do
+        subject.add(question1)
+
+        expect(subject.questions.size).to eq(1)
+      end
+
+      it "does not call the #on_add callbacks" do
+        expect(callback).to_not receive(:call)
+
+        subject.add(question1)
+      end
+
+      it "returns false" do
+        expect(subject.add(question1)).to eq(false)
+      end
+    end
+  end
+
+  describe "#delete" do
+    before do
+      subject.on_delete(&callback)
+    end
+
+    context "if it contains the given question" do
+      before do
+        subject.add(question1)
+      end
+
+      it "deletes the question" do
+        subject.delete(question1)
+
+        expect(subject.questions).to_not include(question1)
+      end
+
+      it "calls the #on_delete callbacks" do
+        expect(callback).to receive(:call)
+
+        subject.delete(question1)
+      end
+
+      it "returns true" do
+        expect(subject.delete(question1)).to eq(true)
+      end
+    end
+
+    context "if it does not contain the given question" do
+      before do
+        subject.add(question2)
+      end
+
+      it "does not delete any question" do
+        subject.delete(question1)
+
+        expect(subject.questions).to contain_exactly(question2)
+      end
+
+      it "does not call the #on_delete callbacks" do
+        expect(callback).to_not receive(:call)
+
+        subject.delete(question1)
+      end
+
+      it "returns false" do
+        expect(subject.delete(question1)).to eq(false)
+      end
+    end
+  end
+
+  describe "#wait" do
+    # This callback ensures that both questions are answered after calling it for third time
+    let(:callback) do
+      times = 0
+
+      proc do
+        times += 1
+        question1.answer = :yes if times == 2
+        question2.answer = :no if times == 3
+      end
+    end
+
+    before do
+      subject.on_wait(&callback)
+
+      subject.add(question1)
+      subject.add(question2)
+
+      allow(subject).to receive(:sleep)
+    end
+
+    it "waits until all questions are answered" do
+      expect(subject).to receive(:sleep).exactly(3).times
+
+      subject.wait
+    end
+
+    it "calls the #on_wait callbacks while waiting" do
+      expect(callback).to receive(:call).and_call_original.exactly(3).times
+
+      subject.wait
+    end
+  end
+end


### PR DESCRIPTION
## Problem

Sometimes the service needs to ask some information to the clients. For example, the password to activate a LUKS while probing the storage devices. D-Installer does not provide how to require such information from clients.  

- https://github.com/yast/d-installer/issues/123
- https://gist.github.com/joseivanlopez/a7568408a6bf9defcaa7a92faea9654d `dinstaller-questions-dbus.md`


## Solution

D-Installer now provides a D-Bus mechanism to ask questions. The questions are exported on D-Bus in a ObjectManager tree. 

Note: ObjectManager is not supported ruby-dbus yet. The implementation is directly provided by the `DInstaller::DBus::Questions` object.

Example:

~~~
/org/opensuse/DInstaller/Questions1
    /org/opensuse/DInstaller/Questions1/1
    /org/opensuse/DInstaller/Questions1/2
    /org/opensuse/DInstaller/Questions1/3
~~~

Note that question objects are exported and unexported dynamically, see the following code snippet: 

~~~ruby
questions_manager = DInstaller::QuestionsManager.new(logger)

DInstaller::DBus::Questions.new(questions_manager, logger) # This configures QuestionsManager callbacks to work with D-Bus

question1 = DInstaller::Question.new("Do you want to continue?", options: [:yes, :no], default_option: :no)
question2 = DInstaller::LuksQuestion.new("/dev/sda1", label: "mydata", size: "3 GiB")

# Questions are exported on DBus here (#on_add callbacks)
questions_manager.add(question1)
questions_manager.add(question2)

# Process waits until all questions are answered. Bus dispatches messages while waiting (#on_wait callbacks) 
questions_manager.wait

# Get answers
continue = question1.answer == :yes

# Question is unexported from D-Bus (#on_delete callbacks)
questions_manager.delete(question1)
~~~


## Testing

- Added new unit tests
- Tested manually


## Screenshots

![Screenshot from 2022-04-26 00-52-18](https://user-images.githubusercontent.com/1112304/165192721-aebf080c-1557-48d6-be1a-2aba6c4e101a.png)
