### PR TITLE
Keep `package-lock.json`

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -16,5 +16,5 @@ cd service; bundle config set --local path 'vendor/bundle'; bundle install; cd -
 cd web; make devel-install; cd -
 
 # Start the installer
-echo -e "Start the d-installer service:\n  cd service; sudo bundle exec bin/d-installer\n"
+echo -e "\nStart the d-installer service:\n  cd service; sudo bundle exec bin/d-installer\n"
 echo -e "Visit http://localhost:9090/cockpit/@localhost/d-installer/index.html"

--- a/web/Makefile
+++ b/web/Makefile
@@ -74,6 +74,9 @@ clean:
 	rm -rf dist/
 	rm -f po/LINGUAS
 
+clean_all: clean
+	rm -rf node_modules/
+
 install: $(WEBPACK_TEST) po/LINGUAS
 	mkdir -p $(DESTDIR)/usr/share/cockpit/$(PACKAGE_NAME)
 	cp -r dist/* $(DESTDIR)/usr/share/cockpit/$(PACKAGE_NAME)

--- a/web/Makefile
+++ b/web/Makefile
@@ -11,7 +11,7 @@ NODE_CACHE=$(RPM_NAME)-node-$(VERSION).tar.xz
 APPSTREAMFILE=org.opensuse.$(PACKAGE_NAME).metainfo.xml
 VM_IMAGE=$(CURDIR)/test/images/$(TEST_OS)
 # stamp file to check if/when npm install ran
-NODE_MODULES_TEST=package-lock.json
+NODE_MODULES_TEST=node_modules
 # one example file in dist/ from webpack to check if that already ran
 WEBPACK_TEST=dist/manifest.json
 # one example file in src/lib to check if it was already checked out
@@ -186,9 +186,7 @@ $(LIB_TEST):
 	    git reset -- ../pkg/lib'
 	mv ../pkg/lib src/ && rmdir ../pkg
 
-$(NODE_MODULES_TEST): package.json
-	# if it exists already, npm install won't update it; force that so that we always get up-to-date packages
-	rm -f package-lock.json
+$(NODE_MODULES_TEST):
 	# unset NODE_ENV, skips devDependencies otherwise
 	env -u NODE_ENV npm install
 	env -u NODE_ENV npm prune


### PR DESCRIPTION
We consider keeping the `package-lock.json` in the version control as a good practice. However, the Makefile removes that file to make sure that the dependencies are updated, which partially defeats the `package-lock.json` purpose.

This PR adapts the Makefile to not modify the `package-lock.json` when running `make`. Additionally, it adds a `clean_all` target to remove the `node_modules` directory in addition to the regular clean-up.