### PR TITLE
Adapt JavaScript clients to ruby-dbus 0.18.0-beta.5

### DIFF
--- a/service/Gemfile.lock
+++ b/service/Gemfile.lock
@@ -9,7 +9,7 @@ PATH
       fast_gettext (~> 2.2.0)
       nokogiri (~> 1.13.1)
       rexml (~> 3.2.5)
-      ruby-dbus (>= 0.17.0)
+      ruby-dbus (>= 0.18.0.beta5)
 
 GEM
   remote: https://rubygems.org/
@@ -51,7 +51,7 @@ GEM
       rspec-support (~> 3.11.0)
     rspec-support (3.11.0)
     ruby-augeas (0.5.0)
-    ruby-dbus (0.17.0)
+    ruby-dbus (0.18.0.beta5)
       rexml
     simplecov (0.21.2)
       docile (~> 1.1)

--- a/service/d-installer.gemspec
+++ b/service/d-installer.gemspec
@@ -47,5 +47,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "fast_gettext", "~> 2.2.0"
   spec.add_dependency "nokogiri", "~> 1.13.1"
   spec.add_dependency "rexml", "~> 3.2.5"
-  spec.add_dependency "ruby-dbus", ">= 0.17.0"
+  spec.add_dependency "ruby-dbus", ">= 0.18.0.beta5"
 end

--- a/web/src/client/language.js
+++ b/web/src/client/language.js
@@ -36,7 +36,7 @@ export default class LanguageClient {
   async getLanguages() {
     const proxy = await this.proxy(LANGUAGE_IFACE);
     return proxy.AvailableLanguages.map(lang => {
-      const [{ v: id }, { v: name }] = lang.v;
+      const [id, name] = lang;
       return { id, name };
     });
   }
@@ -48,7 +48,7 @@ export default class LanguageClient {
    */
   async getSelectedLanguages() {
     const proxy = await this.proxy(LANGUAGE_IFACE);
-    return proxy.MarkedForInstall.map(lang => lang.v);
+    return proxy.MarkedForInstall;
   }
 
   /**

--- a/web/src/client/language.test.js
+++ b/web/src/client/language.test.js
@@ -27,14 +27,7 @@ const dbusClient = {};
 const langProxy = {
   wait: jest.fn(),
   AvailableLanguages: [
-    {
-      t: "av",
-      v: [
-        { t: "s", v: "cs_CZ" },
-        { t: "s", v: "Cestina" },
-        { t: "a{sv}", v: {} }
-      ]
-    }
+    ["cs_CZ", "Cestina", {}]
   ]
 };
 

--- a/web/src/client/software.js
+++ b/web/src/client/software.js
@@ -36,7 +36,7 @@ export default class SoftwareClient {
   async getProducts() {
     const proxy = await this.proxy(SOFTWARE_IFACE);
     return proxy.AvailableBaseProducts.map(product => {
-      const [{ v: id }, { v: name }] = product.v;
+      const [id, name] = product;
       return { id, name };
     });
   }

--- a/web/src/client/software.test.js
+++ b/web/src/client/software.test.js
@@ -27,14 +27,7 @@ const dbusClient = {};
 const softProxy = {
   wait: jest.fn(),
   AvailableBaseProducts: [
-    {
-      t: "av",
-      v: [
-        { t: "s", v: "MicroOS" },
-        { t: "s", v: "openSUSE MicroOS" },
-        { t: "a{sv}", v: {} }
-      ]
-    }
+    ["MicroOS", "openSUSE MicroOS", {}]
   ],
   SelectedBaseProduct: "microos"
 };

--- a/web/src/client/storage.test.js
+++ b/web/src/client/storage.test.js
@@ -29,24 +29,10 @@ const dbusClient = {};
 const storageProposalProxy = {
   wait: jest.fn(),
   AvailableDevices: [
-    {
-      t: "av",
-      v: [
-        { t: "s", v: "/dev/sda" },
-        { t: "s", v: "/dev/sda, 950 GiB, Windows" },
-        { t: "a{sv}", v: {} }
-      ]
-    },
-    {
-      t: "av",
-      v: [
-        { t: "s", v: "/dev/sdb" },
-        { t: "s", v: "/dev/sdb, 500 GiB" },
-        { t: "a{sv}", v: {} }
-      ]
-    }
+    ["/dev/sda", "/dev/sda, 950 GiB, Windows"],
+    ["/dev/sdb", "/dev/sdb, 500 GiB"]
   ],
-  CandidateDevices: [{ t: "s", v: "/dev/sda" }],
+  CandidateDevices: ["/dev/sda"],
   LVM: true
 };
 
@@ -54,12 +40,9 @@ const storageActionsProxy = {
   wait: jest.fn(),
   All: [
     {
-      t: "a{sv}",
-      v: {
-        Text: { t: "s", v: "Mount /dev/sdb1 as root" },
-        Subvol: { t: "b", v: false },
-        Delete: { t: "b", v: false }
-      }
+      Text: { t: "v", v: { t: "s", v: "Mount /dev/sdb1 as root" } },
+      Subvol: { t: "v", v: { t: "b", v: false } },
+      Delete: { t: "v", v: { t: "b", v: false } }
     }
   ]
 };

--- a/web/src/client/users.js
+++ b/web/src/client/users.js
@@ -35,7 +35,7 @@ export default class UsersClient {
    */
   async getUser() {
     const proxy = await this.proxy(USERS_IFACE);
-    const [fullName, userName, autologin] = proxy.FirstUser.map(u => u.v);
+    const [fullName, userName, autologin] = proxy.FirstUser;
     return { fullName, userName, autologin };
   }
 

--- a/web/src/client/users.test.js
+++ b/web/src/client/users.test.js
@@ -27,11 +27,7 @@ const dbusClient = {};
 
 const usersProxy = {
   wait: jest.fn(),
-  FirstUser: [
-    { t: "s", v: "Jane Doe" },
-    { t: "s", v: "jane" },
-    { t: "b", v: false }
-  ],
+  FirstUser: ["Jane Doe", "jane", false, {}],
   SetFirstUser: jest.fn().mockResolvedValue(0),
   RemoveFirstUser: jest.fn().mockResolvedValue(0),
   SetRootPassword: jest.fn().mockResolvedValue(0),


### PR DESCRIPTION
## Problem

The UI does not work with the latest changes in ruby-dbus. Related to #126.

## Solution

Adapt the JavaScript code to work with ruby-dbus 0.18.0.beta4.


## Testing

- [x] *Adapted unit test*
- [x] *Tested manually*

## To do

- [x] Check changes in storage. It works, but the shape of the data we get through D-Bus looks a bit tricky. The problem is fixed in https://github.com/mvidner/ruby-dbus/pull/111.
- [ ] Release once beta.5 is available.