### PR TITLE
Use a custom modal component

### DIFF
--- a/web/src/About.jsx
+++ b/web/src/About.jsx
@@ -38,9 +38,6 @@ export default function About() {
       <Popup
         isOpen={isOpen}
         title="About D-Installer"
-        autoFocusOn="confirm"
-        onConfirm={close}
-        confirmText="Close"
       >
         <Text>
           D-Installer is an <strong>experimental installer</strong> for (open)SUSE systems. It is
@@ -51,6 +48,9 @@ export default function About() {
           For more information, check{" "}
           <a href="https://github.com/yast/d-installer">the project's repository</a>.
         </Text>
+        <Popup.Actions>
+          <Popup.Confirm onClick={close} autoFocus>Close</Popup.Confirm>
+        </Popup.Actions>
       </Popup>
     </>
   );

--- a/web/src/About.jsx
+++ b/web/src/About.jsx
@@ -20,7 +20,8 @@
  */
 
 import React, { useState } from "react";
-import { Button, Modal, ModalVariant, Text } from "@patternfly/react-core";
+import { Button, Text } from "@patternfly/react-core";
+import Popup from "./Popup";
 
 export default function About() {
   const [isOpen, setIsOpen] = useState(false);
@@ -34,16 +35,12 @@ export default function About() {
         About
       </Button>
 
-      <Modal
+      <Popup
         isOpen={isOpen}
-        showClose={false}
-        variant={ModalVariant.small}
         title="About D-Installer"
-        actions={[
-          <Button key="confirm" variant="primary" onClick={close} autoFocus>
-            Close
-          </Button>
-        ]}
+        autoFocusOn="confirm"
+        onConfirm={close}
+        confirmText="Close"
       >
         <Text>
           D-Installer is an <strong>experimental installer</strong> for (open)SUSE systems. It is
@@ -54,7 +51,7 @@ export default function About() {
           For more information, check{" "}
           <a href="https://github.com/yast/d-installer">the project's repository</a>.
         </Text>
-      </Modal>
+      </Popup>
     </>
   );
 }

--- a/web/src/FirstUser.jsx
+++ b/web/src/FirstUser.jsx
@@ -6,12 +6,12 @@ import {
   Checkbox,
   Form,
   FormGroup,
-  Modal,
-  ModalVariant,
   Skeleton,
   Text,
   TextInput
 } from "@patternfly/react-core";
+
+import Popup from './Popup';
 
 const initialUser = {
   userName: "",
@@ -87,27 +87,15 @@ export default function Users() {
     <>
       {renderLink()}
 
-      <Modal
+      <Popup
         isOpen={isFormOpen}
-        showClose={false}
-        variant={ModalVariant.small}
         title="User account"
-        actions={[
-          <Button
-            key="confirm"
-            variant="primary"
-            onClick={accept}
-            isDisabled={formValues.userName === ""}
-          >
-            Confirm
-          </Button>,
-          <Button key="cancel" variant="secondary" onClick={cancel}>
-            Cancel
-          </Button>,
-          <Button key="remove" variant="link" onClick={remove} isDisabled={!userIsDefined}>
-            Do not create a user
-          </Button>
-        ]}
+        onConfirm={accept}
+        confirmDisabled={formValues.userName === ""}
+        onCancel={cancel}
+        onUnset={remove}
+        unsetText="Do not create a user"
+        unsetDisabled={!userIsDefined}
       >
         <Form>
           <FormGroup fieldId="userFullName" label="Full name">
@@ -153,7 +141,7 @@ export default function Users() {
             onChange={handleInputChange}
           />
         </Form>
-      </Modal>
+      </Popup>
     </>
   );
 }

--- a/web/src/FirstUser.jsx
+++ b/web/src/FirstUser.jsx
@@ -136,9 +136,9 @@ export default function Users() {
         <Popup.Actions>
           <Popup.Confirm onClick={accept} isDisabled={formValues.userName === ""} />
           <Popup.Cancel onClick={cancel} />
-          <Popup.TertiaryAction onClick={remove} isDisabled={!userIsDefined}>
+          <Popup.AncillaryAction onClick={remove} isDisabled={!userIsDefined}>
             Do not create a user
-          </Popup.TertiaryAction>
+          </Popup.AncillaryAction>
         </Popup.Actions>
       </Popup>
     </>

--- a/web/src/FirstUser.jsx
+++ b/web/src/FirstUser.jsx
@@ -136,7 +136,7 @@ export default function Users() {
         <Popup.Actions>
           <Popup.Confirm onClick={accept} isDisabled={formValues.userName === ""} />
           <Popup.Cancel onClick={cancel} />
-          <Popup.AncillaryAction onClick={remove} isDisabled={!userIsDefined}>
+          <Popup.AncillaryAction onClick={remove} isDisabled={!userIsDefined} key="unset">
             Do not create a user
           </Popup.AncillaryAction>
         </Popup.Actions>

--- a/web/src/FirstUser.jsx
+++ b/web/src/FirstUser.jsx
@@ -87,16 +87,7 @@ export default function Users() {
     <>
       {renderLink()}
 
-      <Popup
-        isOpen={isFormOpen}
-        title="User account"
-        onConfirm={accept}
-        confirmDisabled={formValues.userName === ""}
-        onCancel={cancel}
-        onUnset={remove}
-        unsetText="Do not create a user"
-        unsetDisabled={!userIsDefined}
-      >
+      <Popup isOpen={isFormOpen} title="User account">
         <Form>
           <FormGroup fieldId="userFullName" label="Full name">
             <TextInput
@@ -141,6 +132,14 @@ export default function Users() {
             onChange={handleInputChange}
           />
         </Form>
+
+        <Popup.Actions>
+          <Popup.Confirm onClick={accept} isDisabled={formValues.userName === ""} />
+          <Popup.Cancel onClick={cancel} />
+          <Popup.TertiaryAction onClick={remove} isDisabled={!userIsDefined}>
+            Do not create a user
+          </Popup.TertiaryAction>
+        </Popup.Actions>
       </Popup>
     </>
   );

--- a/web/src/LanguageSelector.jsx
+++ b/web/src/LanguageSelector.jsx
@@ -27,10 +27,10 @@ import {
   Form,
   FormGroup,
   FormSelect,
-  FormSelectOption,
-  Modal,
-  ModalVariant
+  FormSelectOption
 } from "@patternfly/react-core";
+
+import Popup from './Popup';
 
 const reducer = (state, action) => {
   switch (action.type) {
@@ -122,26 +122,18 @@ export default function LanguageSelector() {
         {label()}
       </Button>
 
-      <Modal
+      <Popup
         isOpen={isFormOpen}
-        showClose={false}
-        variant={ModalVariant.small}
+        onConfirm={accept}
+        onCancel={cancel}
         aria-label="Language Selector"
-        actions={[
-          <Button key="confirm" variant="primary" onClick={accept}>
-            Confirm
-          </Button>,
-          <Button key="cancel" variant="secondary" onClick={cancel}>
-            Cancel
-          </Button>
-        ]}
       >
         <Form>
           <FormGroup fieldId="language" label="Language">
             {buildSelector(state.formCurrent)}
           </FormGroup>
         </Form>
-      </Modal>
+      </Popup>
     </>
   );
 }

--- a/web/src/LanguageSelector.jsx
+++ b/web/src/LanguageSelector.jsx
@@ -124,8 +124,6 @@ export default function LanguageSelector() {
 
       <Popup
         isOpen={isFormOpen}
-        onConfirm={accept}
-        onCancel={cancel}
         aria-label="Language Selector"
       >
         <Form>
@@ -133,6 +131,10 @@ export default function LanguageSelector() {
             {buildSelector(state.formCurrent)}
           </FormGroup>
         </Form>
+        <Popup.Actions>
+          <Popup.Confirm onClick={accept} />
+          <Popup.Cancel onClick={cancel} />
+        </Popup.Actions>
       </Popup>
     </>
   );

--- a/web/src/Overview.jsx
+++ b/web/src/Overview.jsx
@@ -74,10 +74,6 @@ function Overview() {
         <Popup
           title="Confirm Installation"
           isOpen={isOpen}
-          autoFocusOn="cancel"
-          onConfirm={install}
-          confirmText="Install"
-          onCancel={close}
         >
           <Text>
             If you continue, partitions on your hard disk will be modified according to the
@@ -86,6 +82,11 @@ function Overview() {
           <Text>
             Please, cancel and check the settings if you are unsure.
           </Text>
+
+          <Popup.Actions>
+            <Popup.Confirm onClick={install}>Install</Popup.Confirm>
+            <Popup.Cancel onClick={close} autoFocus />
+          </Popup.Actions>
         </Popup>
       </>
     );

--- a/web/src/Overview.jsx
+++ b/web/src/Overview.jsx
@@ -22,7 +22,7 @@
 import React, { useState } from "react";
 import { useInstallerClient } from "./context/installer";
 
-import { Button, Modal, ModalVariant, Flex, FlexItem, Text } from "@patternfly/react-core";
+import { Button, Flex, FlexItem, Text } from "@patternfly/react-core";
 
 import Layout from "./Layout";
 import Category from "./Category";
@@ -30,6 +30,7 @@ import LanguageSelector from "./LanguageSelector";
 import ProductSelector from "./ProductSelector";
 import Storage from "./Storage";
 import Users from "./Users";
+import Popup from "./Popup";
 
 import {
   EOS_FACT_CHECK as OverviewIcon,
@@ -70,19 +71,13 @@ function Overview() {
           Install
         </Button>
 
-        <Modal
+        <Popup
           title="Confirm Installation"
           isOpen={isOpen}
-          showClose={false}
-          variant={ModalVariant.small}
-          actions={[
-            <Button key="accept" variant="primary" onClick={install}>
-              Install
-            </Button>,
-            <Button key="back" variant="secondary" onClick={close} autoFocus>
-              Cancel
-            </Button>
-          ]}
+          autoFocusOn="cancel"
+          onConfirm={install}
+          confirmText="Install"
+          onCancel={close}
         >
           <Text>
             If you continue, partitions on your hard disk will be modified according to the
@@ -91,7 +86,7 @@ function Overview() {
           <Text>
             Please, cancel and check the settings if you are unsure.
           </Text>
-        </Modal>
+        </Popup>
       </>
     );
   };

--- a/web/src/Popup.jsx
+++ b/web/src/Popup.jsx
@@ -31,6 +31,7 @@ import { Button, Modal } from "@patternfly/react-core";
  *
  * @example
  *   <Popup
+ *     title="User Settings"
  *     isOpen={showUserSettings}
  *     onConfirm={updateUsersSettings}
  *     onCancel={closeUserSettings}
@@ -38,7 +39,6 @@ import { Button, Modal } from "@patternfly/react-core";
  *     confirmDisabled={username === ""}
  *     confirmText={currentUser ? "Update" : "Confirm"}
  *     unsetText="Use default settings"
- *     sectionTitle="User Settings"
  *   >
  *     <UserSettingsForm />
  *   </Popup>

--- a/web/src/Popup.jsx
+++ b/web/src/Popup.jsx
@@ -23,100 +23,173 @@ import React from "react";
 import { Button, Modal } from "@patternfly/react-core";
 
 /**
+ * Wrapper component for holding Popup actions
+ *
+ * Useful and required for placing the components to be used as PF4/Modal actions, usually a
+ * Popup.Action or PF4/Button
+ *
+ * @see Popup examples.
+ *
+ * @param {React.ReactNode} [props.children] - a collection of Action components
+ */
+const Actions = ({ children }) => <>{children}</>;
+
+/**
+ * A convenient component representing a Popup action
+ *
+ * Built on top of { @link https://www.patternfly.org/v4/components/button PF4/Button }
+ *
+ * @see Popup examples.
+ *
+ * @param {React.ReactNode} props.children - content of the action
+ * @param {object} [props] - PF4/Button props, see { @link https://www.patternfly.org/v4/components/button#props }
+ */
+const Action = ({ children, ...props }) => (
+  <Button { ...props }>
+    {children}
+  </Button>
+);
+
+/**
+ * A Popup primary action
+ *
+ * It always set `variant` { @link https://www.patternfly.org/v4/components/button PF4/Button }
+ * prop to "primary", no matter what given in `props`.
+ *
+ * @example
+ *   <PrimaryAction onClick={doSomething}>Let's go</PrimaryAction>
+ *
+ * @example
+ *   <PrimaryAction onClick={upload}>
+ *     <UploadIcon />
+ *     <Text>Upload</Text>
+ *   </PrimaryAction>
+ *
+ * @param {React.ReactNode} props.children - content of the action
+ * @param {object} [props] - { @link Action } props
+ */
+const PrimaryAction = ({ children, ...props }) => (
+  <Action { ...props } variant="primary">{ children }</Action>
+);
+
+/**
+ * Shortcut for the primary "Confirm" action
+ *
+ * @example
+ *   <Confirm onClick={confirm} />
+ *
+ * @example
+ *   <Confirm onClick={accept}>Accept</Confirm>
+ *
+ * @param {React.ReactNode} [props.children="confirm"] - content of the action
+ * @param {object} [props] - { @link Action } props
+ */
+const Confirm = ({ children = "Confirm", ...props }) => (
+  <PrimaryAction key="confirm" { ...props }>{ children }</PrimaryAction>
+);
+
+/**
+ * A Popup secondary action
+ *
+ * It always set `variant` { @link https://www.patternfly.org/v4/components/button PF4/Button }
+ * prop to "secondary", no matter what given in `props`.
+ *
+ * @example
+ *   <SecondaryAction onClick={cancel}>Cancel</SecondaryAction>
+ *
+ * @example
+ *   <SecondaryAction onClick={upload}>
+ *     <DismissIcon />
+ *     <Text>Dismiss</Text>
+ *   </SecondaryAction>
+ *
+ * @param {React.ReactNode} props.children - content of the action
+ * @param {object} [props] - { @link Action } props
+ */
+const SecondaryAction = ({ children, ...props }) => (
+  <Action { ...props } variant="secondary">{ children }</Action>
+);
+
+/**
+ * Shortcut for the secondary "Cancel" action
+ *
+ * @example
+ *   <Cancel onClick={cancel} />
+ *
+ * @example
+ *   <Cancel onClick={dissmiss}>Dismiss</Confirm>
+ *
+ * @param {React.ReactNode} [props.children="Cancel"] - content of the action
+ * @param {object} [props] - { @link Action } props
+ */
+const Cancel = ({ children = "Cancel", ...props }) => (
+  <SecondaryAction key="cancel" { ...props }>{ children }</SecondaryAction>
+);
+
+/**
+ * A Popup tertiary action, rendered as a link
+ *
+ * It always set `variant` { @link https://www.patternfly.org/v4/components/button PF4/Button } prop
+ * to "link", no matter what is given in `props`
+ *
+ * @example
+ *   <TertiaryAction onClick={turnUserSeettingsOff}>Do not set this</TertiaryAction>
+ *
+ * @example
+ *   <TertiaryAction onClick={turnUserSettingsOff}>
+ *     <Removeicon />
+ *     <Text>Do not set</Text>
+ *   </TertiaryAction>
+ *
+ * @param {React.ReactNode} props.children - content of the action
+ * @param {object} [props] - { @link Action } props
+ */
+const TertiaryAction = ({ children, ...props }) => (
+  <Action { ...props } variant="link">{ children }</Action>
+);
+
+/**
  * D-Installer component for displaying a popup
  *
- * Built on top of { @link https://www.patternfly.org/v4/components/modal PF4/Modal }, it displays
- * up to three actions according to given params: "Confirm", "Cancel", and "Do not use". All of them
- * can be tweaked via corresponding params, but at least `onConfirm` callback must be provided
+ * Built on top of { @link https://www.patternfly.org/v4/components/modal PF4/Modal }, it manipulate
+ * the children object for extraction {Actions} from there.
  *
  * @example
  *   <Popup
  *     title="User Settings"
  *     isOpen={showUserSettings}
- *     onConfirm={updateUsersSettings}
- *     onCancel={closeUserSettings}
- *     onUnset={unsetUserSettings}
- *     confirmDisabled={username === ""}
- *     confirmText={currentUser ? "Update" : "Confirm"}
- *     unsetText="Use default settings"
  *   >
  *     <UserSettingsForm />
+ *     <Popup.Actions>
+ *       <Popup.PrimaryAction onClick={updateUserSetting}>Confirm</Popup.PrimaryAction>
+ *       <Popup.SecondaryAction onClick={cancel}>Cancel</Popup.SecondaryAction>
+ *     </Popup.Actions>
+ *   </Popup>
+ *
+ * @example
+ *   <Popup
+ *     title="User Settings"
+ *     isOpen={showUserSettings}
+ *   >
+ *     <UserSettingsForm />
+ *     <Popup.Actions>
+ *       <Popup.Confirm onClick={updateUserSetting} />
+ *       <Popup.Cancel onClick={cancel} />
+ *     </Popup.Actions>
  *   </Popup>
  *
  * @param {object} props - component props
  * @param {boolean} [props.isOpen=false] - whether the popup is displayed or not
  * @param {boolean} [props.showClose=false] - whether the popup should include a "X" action for closing it
- * @param {string} [props.variant="small"] - the popup size, based on Pf4/Modal variant prop
- * @param {"confirm" | "cancel" | "unset" } [props.autoFocusOn] - force autoFocus to the button with given key
- * @param {function} props.onConfirm - function to be triggered when user clicks on confirm action
- * @param {string} [props.confirmText="Confirm"] - text to be used for the confirm action
- * @param {boolean} [props.confirmDisabled=false] - whether the confirm action should be disabled
- * @param {function} [props.onCancel] - function to be triggered when user clicks on cancel action
- * @param {string} [props.cancelText="Cancel"] - text to be used for the cancel action
- * @param {boolean} [props.cancelDisabled=false] - whether the cancel action should be disabled
- * @param {function} [props.onUnset] - function to be triggered when user clicks on unset action
- * @param {string} [props.unsetText="Do not use"] - text to be used for the unset action
- * @param {boolean} [props.unsetDisabled=true] - whether the unset action should be disabled
- * @param {React.ReactNode} [props.children] - the popup content
- * @param {object} [pf4ModalProps] - PF4/Modal props, @see https://www.patternfly.org/v4/components/modal#props
+ * @param {string} [props.variant="small"] - the popup size, based on Pf4/Modal `variant` prop
+ * @param {React.ReactNode} props.children - the popup content and actions
+ * @param {object} [pf4ModalProps] - PF4/Modal props, See { @link https://www.patternfly.org/v4/components/modal#props }
  *
  */
-export default function Popup({
-  isOpen = false,
-  showClose = false,
-  variant = "small",
-  autoFocusOn,
-  onConfirm,
-  confirmText = "Confirm",
-  confirmDisabled = false,
-  onCancel,
-  cancelText = "Cancel",
-  cancelDisabled = false,
-  onUnset,
-  unsetText = "Do not use",
-  unsetDisabled = true,
-  children,
-  ...pf4ModalProps
-}) {
-  const actions = [
-    <Button
-      key="confirm"
-      variant="primary"
-      onClick={onConfirm}
-      autoFocus={autoFocusOn === "confirm"}
-      isDisabled={confirmDisabled}
-    >
-      {confirmText}
-    </Button>
-  ];
-
-  if (onCancel) {
-    actions.push(
-      <Button
-        key="cancel"
-        variant="secondary"
-        onClick={onCancel}
-        isDisabled={cancelDisabled}
-        autoFocus={autoFocusOn === "cancel"}
-      >
-        {cancelText}
-      </Button>
-    );
-  }
-
-  if (onUnset) {
-    actions.push(
-      <Button
-        key="unset"
-        variant="link"
-        onClick={onUnset}
-        isDisabled={unsetDisabled}
-        autoFocus={autoFocusOn === "unset"}
-      >
-        {unsetText}
-      </Button>
-    );
-  }
+const Popup = ({ isOpen = false, showClose = false, variant = "small", children, ...pf4ModalProps }) => {
+  const flattenChildren = React.Children.toArray(children);
+  const content = flattenChildren.filter(child => child.type !== Actions);
+  const actions = flattenChildren.filter(child => child.type === Actions);
 
   return (
     <Modal
@@ -126,7 +199,16 @@ export default function Popup({
       actions={actions}
       { ...pf4ModalProps }
     >
-      { children }
+      { content }
     </Modal>
   );
-}
+};
+
+Popup.Actions = Actions;
+Popup.PrimaryAction = PrimaryAction;
+Popup.Confirm = Confirm;
+Popup.SecondaryAction = SecondaryAction;
+Popup.Cancel = Cancel;
+Popup.TertiaryAction = TertiaryAction;
+
+export default Popup;

--- a/web/src/Popup.jsx
+++ b/web/src/Popup.jsx
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) [2022] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from "react";
+import { Button, Modal } from "@patternfly/react-core";
+
+/**
+ * D-Installer component for displaying a popup
+ *
+ * Built on top of { @link https://www.patternfly.org/v4/components/modal PF4/Modal }, it displays
+ * up to three actions according to given params: "Confirm", "Cancel", and "Do not use". All of them
+ * can be tweaked via corresponding params, but at least `onConfirm` callback must be provided
+ *
+ * @example
+ *   <Popup
+ *     isOpen={showUserSettings}
+ *     onConfirm={updateUsersSettings}
+ *     onCancel={closeUserSettings}
+ *     onUnset={unsetUserSettings}
+ *     confirmDisabled={username === ""}
+ *     confirmText={currentUser ? "Update" : "Confirm"}
+ *     unsetText="Use default settings"
+ *     sectionTitle="User Settings"
+ *   >
+ *     <UserSettingsForm />
+ *   </Popup>
+ *
+ * @param {object} props - component props
+ * @param {boolean} [props.isOpen=false] - whether the popup is displayed or not
+ * @param {boolean} [props.showClose=false] - whether the popup should include a "X" action for closing it
+ * @param {string} [props.variant="small"] - the popup size, based on Pf4/Modal variant prop
+ * @param {"confirm" | "cancel" | "unset" } [props.autoFocusOn] - force autoFocus to the button with given key
+ * @param {function} props.onConfirm - function to be triggered when user clicks on confirm action
+ * @param {string} [props.confirmText="Confirm"] - text to be used for the confirm action
+ * @param {boolean} [props.confirmDisabled=false] - whether the confirm action should be disabled
+ * @param {function} [props.onCancel] - function to be triggered when user clicks on cancel action
+ * @param {string} [props.cancelText="Cancel"] - text to be used for the cancel action
+ * @param {boolean} [props.cancelDisabled=false] - whether the cancel action should be disabled
+ * @param {function} [props.onUnset] - function to be triggered when user clicks on unset action
+ * @param {string} [props.unsetText="Do not use"] - text to be used for the unset action
+ * @param {boolean} [props.unsetDisabled=true] - whether the unset action should be disabled
+ * @param {React.ReactNode} [props.children] - the popup content
+ * @param {object} [pf4ModalProps] - PF4/Modal props, @see https://www.patternfly.org/v4/components/modal#props
+ *
+ */
+export default function Popup({
+  isOpen = false,
+  showClose = false,
+  variant = "small",
+  autoFocusOn,
+  onConfirm,
+  confirmText = "Confirm",
+  confirmDisabled = false,
+  onCancel,
+  cancelText = "Cancel",
+  cancelDisabled = false,
+  onUnset,
+  unsetText = "Do not use",
+  unsetDisabled = true,
+  children,
+  ...pf4ModalProps
+}) {
+  const actions = [
+    <Button
+      key="confirm"
+      variant="primary"
+      onClick={onConfirm}
+      autoFocus={autoFocusOn === "confirm"}
+      isDisabled={confirmDisabled}
+    >
+      {confirmText}
+    </Button>
+  ];
+
+  if (onCancel) {
+    actions.push(
+      <Button
+        key="cancel"
+        variant="secondary"
+        onClick={onCancel}
+        isDisabled={cancelDisabled}
+        autoFocus={autoFocusOn === "cancel"}
+      >
+        {cancelText}
+      </Button>
+    );
+  }
+
+  if (onUnset) {
+    actions.push(
+      <Button
+        key="unset"
+        variant="link"
+        onClick={onUnset}
+        isDisabled={unsetDisabled}
+        autoFocus={autoFocusOn === "unset"}
+      >
+        {unsetText}
+      </Button>
+    );
+  }
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      showClose={showClose}
+      variant={variant}
+      actions={actions}
+      { ...pf4ModalProps }
+    >
+      { children }
+    </Modal>
+  );
+}

--- a/web/src/Popup.jsx
+++ b/web/src/Popup.jsx
@@ -134,18 +134,18 @@ const Cancel = ({ children = "Cancel", ...props }) => (
  * to "link", no matter what is given in `props`
  *
  * @example
- *   <TertiaryAction onClick={turnUserSeettingsOff}>Do not set this</TertiaryAction>
+ *   <AncillaryAction onClick={turnUserSeettingsOff}>Do not set this</AncillaryAction>
  *
  * @example
- *   <TertiaryAction onClick={turnUserSettingsOff}>
+ *   <AncillaryAction onClick={turnUserSettingsOff}>
  *     <Removeicon />
  *     <Text>Do not set</Text>
- *   </TertiaryAction>
+ *   </AncillaryAction>
  *
  * @param {React.ReactNode} props.children - content of the action
  * @param {object} [props] - { @link Action } props
  */
-const TertiaryAction = ({ children, ...props }) => (
+const AncillaryAction = ({ children, ...props }) => (
   <Action { ...props } variant="link">{ children }</Action>
 );
 
@@ -208,6 +208,6 @@ Popup.PrimaryAction = PrimaryAction;
 Popup.Confirm = Confirm;
 Popup.SecondaryAction = SecondaryAction;
 Popup.Cancel = Cancel;
-Popup.TertiaryAction = TertiaryAction;
+Popup.AncillaryAction = AncillaryAction;
 
 export default Popup;

--- a/web/src/Popup.jsx
+++ b/web/src/Popup.jsx
@@ -57,10 +57,10 @@ const Action = ({ children, ...props }) => (
  * It always set `variant` { @link https://www.patternfly.org/v4/components/button PF4/Button }
  * prop to "primary", no matter what given in `props`.
  *
- * @example
+ * @example <caption>Simple usage</caption>
  *   <PrimaryAction onClick={doSomething}>Let's go</PrimaryAction>
  *
- * @example
+ * @example <caption>Advanced usage</caption>
  *   <PrimaryAction onClick={upload}>
  *     <UploadIcon />
  *     <Text>Upload</Text>
@@ -76,10 +76,10 @@ const PrimaryAction = ({ children, ...props }) => (
 /**
  * Shortcut for the primary "Confirm" action
  *
- * @example
+ * @example <caption>Using it with the default text</caption>
  *   <Confirm onClick={confirm} />
  *
- * @example
+ * @example <caption>Using it with a custom text</caption>
  *   <Confirm onClick={accept}>Accept</Confirm>
  *
  * @param {React.ReactNode} [props.children="confirm"] - content of the action
@@ -95,10 +95,10 @@ const Confirm = ({ children = "Confirm", ...props }) => (
  * It always set `variant` { @link https://www.patternfly.org/v4/components/button PF4/Button }
  * prop to "secondary", no matter what given in `props`.
  *
- * @example
+ * @example <caption>Simple usage</caption>
  *   <SecondaryAction onClick={cancel}>Cancel</SecondaryAction>
  *
- * @example
+ * @example <caption>Advanced usage</caption>
  *   <SecondaryAction onClick={upload}>
  *     <DismissIcon />
  *     <Text>Dismiss</Text>
@@ -114,10 +114,10 @@ const SecondaryAction = ({ children, ...props }) => (
 /**
  * Shortcut for the secondary "Cancel" action
  *
- * @example
+ * @example <caption>Using it with the default text</caption>
  *   <Cancel onClick={cancel} />
  *
- * @example
+ * @example <caption>Using it with a custom text</caption>
  *   <Cancel onClick={dissmiss}>Dismiss</Confirm>
  *
  * @param {React.ReactNode} [props.children="Cancel"] - content of the action
@@ -128,15 +128,15 @@ const Cancel = ({ children = "Cancel", ...props }) => (
 );
 
 /**
- * A Popup tertiary action, rendered as a link
+ * A Popup additional action, rendered as a link
  *
  * It always set `variant` { @link https://www.patternfly.org/v4/components/button PF4/Button } prop
  * to "link", no matter what is given in `props`
  *
- * @example
- *   <AncillaryAction onClick={turnUserSeettingsOff}>Do not set this</AncillaryAction>
+ * @example <caption>Simple usage</caption>
+ *   <AncillaryAction onClick={turnUserSettingsOff}>Do not set this</AncillaryAction>
  *
- * @example
+ * @example <caption>Advanced usage</caption>
  *   <AncillaryAction onClick={turnUserSettingsOff}>
  *     <Removeicon />
  *     <Text>Do not set</Text>
@@ -155,19 +155,22 @@ const AncillaryAction = ({ children, ...props }) => (
  * Built on top of { @link https://www.patternfly.org/v4/components/modal PF4/Modal }, it manipulate
  * the children object for extraction {Actions} from there.
  *
- * @example
+ * @example <caption>Usage example</caption>
  *   <Popup
  *     title="User Settings"
  *     isOpen={showUserSettings}
  *   >
  *     <UserSettingsForm />
  *     <Popup.Actions>
- *       <Popup.PrimaryAction onClick={updateUserSetting}>Confirm</Popup.PrimaryAction>
- *       <Popup.SecondaryAction onClick={cancel}>Cancel</Popup.SecondaryAction>
+ *       <Popup.PrimaryAction key="confirm" onClick={updateUserSetting}>Confirm</Popup.PrimaryAction>
+ *       <Popup.SecondaryAction key="cancel" onClick={cancel}>Cancel</Popup.SecondaryAction>
+ *       <Popup.AncillaryAction key="unset" onClick={turnUserSettingsOff}>
+ *         Do not set a user
+ *       </Popup.AncillaryAction>
  *     </Popup.Actions>
  *   </Popup>
  *
- * @example
+ * @example <caption>Usage example using shortcuts actions</caption>
  *   <Popup
  *     title="User Settings"
  *     isOpen={showUserSettings}
@@ -176,6 +179,9 @@ const AncillaryAction = ({ children, ...props }) => (
  *     <Popup.Actions>
  *       <Popup.Confirm onClick={updateUserSetting} />
  *       <Popup.Cancel onClick={cancel} />
+ *       <Popup.AncillaryAction key="unset" onClick={turnUserSettingsOff}>
+ *         Do not set a user
+ *       </Popup.AncillaryAction>
  *     </Popup.Actions>
  *   </Popup>
  *

--- a/web/src/Popup.jsx
+++ b/web/src/Popup.jsx
@@ -21,6 +21,7 @@
 
 import React from "react";
 import { Button, Modal } from "@patternfly/react-core";
+import { partition } from "./utils";
 
 /**
  * Wrapper component for holding Popup actions
@@ -187,9 +188,7 @@ const TertiaryAction = ({ children, ...props }) => (
  *
  */
 const Popup = ({ isOpen = false, showClose = false, variant = "small", children, ...pf4ModalProps }) => {
-  const flattenChildren = React.Children.toArray(children);
-  const content = flattenChildren.filter(child => child.type !== Actions);
-  const actions = flattenChildren.filter(child => child.type === Actions);
+  const [actions, content] = partition(React.Children.toArray(children), child => child.type === Actions);
 
   return (
     <Modal

--- a/web/src/Popup.test.jsx
+++ b/web/src/Popup.test.jsx
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) [2022] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React from "react";
+
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { installerRender } from "./test-utils";
+
+import Popup from "./Popup";
+
+let isOpen;
+const onConfirmFn = jest.fn();
+const confirmText = "Let's go";
+const onCancelFn = jest.fn();
+const cancelText = "Close without saving";
+const onUnsetFn = jest.fn();
+const unsetText = "Ignore this setting";
+
+const TestingPopup = (props) => (
+  <Popup
+    title="Testing Popup component"
+    isOpen={isOpen}
+    onConfirm={onConfirmFn}
+    confirmText={confirmText}
+    onCancel={onCancelFn}
+    cancelText={cancelText}
+    onUnset={onUnsetFn}
+    unsetText={unsetText}
+    { ...props }
+  >
+    <p>The Popup Content</p>
+  </Popup>
+);
+
+describe("Popup", () => {
+  describe("when it is not open", () => {
+    beforeEach(() => {
+      isOpen = false;
+    });
+
+    it("displays nothing", async () => {
+      installerRender(<TestingPopup />);
+
+      const dialog = await screen.queryByRole("dialog");
+      expect(dialog).toBeNull();
+    });
+  });
+
+  describe("when it is open", () => {
+    beforeEach(() => {
+      isOpen = true;
+    });
+
+    it("displays the popup content", async () => {
+      installerRender(<TestingPopup />);
+
+      const dialog = await screen.findByRole("dialog");
+
+      within(dialog).getByText("The Popup Content");
+    });
+
+    it.each([
+      { action: "confirm", actionText: confirmText },
+      { action: "cancel", actionText: cancelText },
+      { action: "unset", actionText: unsetText }
+    ])("honors autoFocusOn={'$action'} when $action is enabled", async ({ action, actionText }) => {
+      const actionDisabledProp = `${action}Disabled`;
+      const props = {
+        autoFocusOn: action,
+        [actionDisabledProp]: false
+      };
+
+      installerRender(<TestingPopup { ...props } />);
+
+      const dialog = await screen.findByRole("dialog");
+      const actionButton = within(dialog).queryByRole("button", { name: actionText });
+      expect(actionButton).toHaveFocus();
+    });
+
+    it.each([
+      { action: "confirm", actionText: confirmText },
+      { action: "cancel", actionText: cancelText },
+      { action: "unset", actionText: unsetText }
+    ])("does not honor autoFocusOn={'$action'} when $action is disabled", async ({ action, actionText }) => {
+      const actionDisabledProp = `${action}Disabled`;
+      const props = {
+        autoFocusOn: action,
+        [actionDisabledProp]: true
+      };
+
+      installerRender(<TestingPopup { ...props } />);
+
+      const dialog = await screen.findByRole("dialog");
+      const actionButton = within(dialog).queryByRole("button", { name: actionText });
+      expect(actionButton).not.toHaveFocus();
+    });
+
+    it.each([
+      { action: "Cancel", actionText: cancelText },
+      { action: "Unset", actionText: unsetText }
+    ])("includes the '$action' action when its callback is defined", async ({ action, actionText }) => {
+      installerRender(<TestingPopup />);
+
+      const dialog = await screen.findByRole("dialog");
+      const actionButton = within(dialog).queryByRole("button", { name: actionText });
+      expect(actionButton).not.toBeNull();
+    });
+
+    it.each([
+      { action: "Cancel", actionText: cancelText },
+      { action: "Unset", actionText: unsetText }
+    ])("does not include the '$action' action when its callback is not defined", async ({ action, actionText }) => {
+      const props = {
+        [`on${action}`]: undefined
+      };
+
+      installerRender(<TestingPopup { ...props } />);
+
+      const dialog = await screen.findByRole("dialog");
+      const actionButton = within(dialog).queryByRole("button", { name: actionText });
+      expect(actionButton).toBeNull();
+    });
+
+    it.each([
+      { action: "confirm", actionText: confirmText, actionFn: onConfirmFn },
+      { action: "cancel", actionText: cancelText, actionFn: onCancelFn },
+      { action: "unset", actionText: unsetText, actionFn: onUnsetFn }
+    ])("triggers the '$action' callback when action is enabled and the user clicks on it", async ({ action, actionFn, actionText }) => {
+      const props = {
+        [`${action}Disabled`]: false
+      };
+
+      installerRender(<TestingPopup { ...props } />);
+
+      const dialog = await screen.findByRole("dialog");
+      const actionButton = within(dialog).queryByRole("button", { name: actionText });
+      userEvent.click(actionButton);
+
+      expect(actionFn).toHaveBeenCalled();
+    });
+
+    it.each([
+      { action: "confirm", actionText: confirmText, actionFn: onConfirmFn },
+      { action: "cancel", actionText: cancelText, actionFn: onCancelFn },
+      { action: "unset", actionText: unsetText, actionFn: onUnsetFn }
+    ])("does not trigger the '$action' callback when action is disabled", async ({ action, actionFn, actionText }) => {
+      const props = {
+        [`${action}Disabled`]: true
+      };
+
+      installerRender(<TestingPopup { ...props } />);
+
+      const dialog = await screen.findByRole("dialog");
+      const actionButton = within(dialog).queryByRole("button", { name: actionText });
+      userEvent.click(actionButton);
+
+      expect(actionFn).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/web/src/Popup.test.jsx
+++ b/web/src/Popup.test.jsx
@@ -105,9 +105,9 @@ describe("Popup.SecondaryAction", () => {
   });
 });
 
-describe("Popup.TertiaryAction", () => {
+describe("Popup.AncillaryAction", () => {
   it("renders a 'link' button with given children as content", async () => {
-    installerRender(<Popup.TertiaryAction>Do not use</Popup.TertiaryAction>);
+    installerRender(<Popup.AncillaryAction>Do not use</Popup.AncillaryAction>);
 
     const button = screen.queryByRole("button", { name: "Do not use" });
     expect(button.classList.contains("pf-m-link")).toBe(true);

--- a/web/src/ProductSelector.jsx
+++ b/web/src/ProductSelector.jsx
@@ -122,17 +122,17 @@ export default function ProductSelector() {
         {label()}
       </Button>
 
-      <Popup
-        isOpen={isFormOpen}
-        aria-label="Product Selector"
-        onConfirm={accept}
-        onCancel={cancel}
-      >
+      <Popup isOpen={isFormOpen} aria-label="Product Selector">
         <Form>
           <FormGroup fieldId="product" label="Product">
             {buildSelector()}
           </FormGroup>
         </Form>
+
+        <Popup.Actions>
+          <Popup.Confirm onClick={accept} />
+          <Popup.Cancel onClick={cancel} />
+        </Popup.Actions>
       </Popup>
     </>
   );

--- a/web/src/ProductSelector.jsx
+++ b/web/src/ProductSelector.jsx
@@ -28,9 +28,9 @@ import {
   FormGroup,
   FormSelect,
   FormSelectOption,
-  Modal,
-  ModalVariant
 } from "@patternfly/react-core";
+
+import Popup from './Popup';
 
 const reducer = (state, action) => {
   switch (action.type) {
@@ -122,26 +122,18 @@ export default function ProductSelector() {
         {label()}
       </Button>
 
-      <Modal
+      <Popup
         isOpen={isFormOpen}
-        showClose={false}
-        variant={ModalVariant.small}
         aria-label="Product Selector"
-        actions={[
-          <Button key="confirm" variant="primary" onClick={accept}>
-            Confirm
-          </Button>,
-          <Button key="cancel" variant="secondary" onClick={cancel}>
-            Cancel
-          </Button>
-        ]}
+        onConfirm={accept}
+        onCancel={cancel}
       >
         <Form>
           <FormGroup fieldId="product" label="Product">
             {buildSelector()}
           </FormGroup>
         </Form>
-      </Modal>
+      </Popup>
     </>
   );
 }

--- a/web/src/RootPassword.jsx
+++ b/web/src/RootPassword.jsx
@@ -26,12 +26,12 @@ import {
   Button,
   Form,
   FormGroup,
-  Modal,
-  ModalVariant,
   Skeleton,
   Text,
   TextInput
 } from "@patternfly/react-core";
+
+import Popup from './Popup';
 
 export default function RootPassword() {
   const client = useInstallerClient();
@@ -86,22 +86,15 @@ export default function RootPassword() {
     <>
       {renderLink()}
 
-      <Modal
+      <Popup
         isOpen={isFormOpen}
-        showClose={false}
-        variant={ModalVariant.small}
         aria-label="Set new root password"
-        actions={[
-          <Button key="confirm" variant="primary" onClick={accept} isDisabled={rootPassword === ""}>
-            Confirm
-          </Button>,
-          <Button key="cancel" variant="secondary" onClick={close}>
-            Cancel
-          </Button>,
-          <Button key="remove" variant="link" onClick={remove} isDisabled={!isRootPasswordSet}>
-            Do not use a password
-          </Button>
-        ]}
+        onConfirm={accept}
+        confirmDisabled={rootPassword === ""}
+        onCancel={close}
+        onUnset={remove}
+        unsetText="Do not use a password"
+        unsetDisabled={!isRootPasswordSet}
       >
         <Form>
           <FormGroup fieldId="rootPassword" label="New root password">
@@ -114,7 +107,7 @@ export default function RootPassword() {
             />
           </FormGroup>
         </Form>
-      </Modal>
+      </Popup>
     </>
   );
 }

--- a/web/src/RootPassword.jsx
+++ b/web/src/RootPassword.jsx
@@ -105,9 +105,9 @@ export default function RootPassword() {
         <Popup.Actions>
           <Popup.Confirm onClick={accept} isDisabled={rootPassword === ""} />
           <Popup.Cancel onClick={close} />
-          <Popup.TertiaryAction onClick={remove} isDisabled={!isRootPasswordSet}>
+          <Popup.AncillaryAction onClick={remove} isDisabled={!isRootPasswordSet}>
             Do not use a password
-          </Popup.TertiaryAction>
+          </Popup.AncillaryAction>
         </Popup.Actions>
       </Popup>
     </>

--- a/web/src/RootPassword.jsx
+++ b/web/src/RootPassword.jsx
@@ -89,12 +89,6 @@ export default function RootPassword() {
       <Popup
         isOpen={isFormOpen}
         aria-label="Set new root password"
-        onConfirm={accept}
-        confirmDisabled={rootPassword === ""}
-        onCancel={close}
-        onUnset={remove}
-        unsetText="Do not use a password"
-        unsetDisabled={!isRootPasswordSet}
       >
         <Form>
           <FormGroup fieldId="rootPassword" label="New root password">
@@ -107,6 +101,14 @@ export default function RootPassword() {
             />
           </FormGroup>
         </Form>
+
+        <Popup.Actions>
+          <Popup.Confirm onClick={accept} isDisabled={rootPassword === ""} />
+          <Popup.Cancel onClick={close} />
+          <Popup.TertiaryAction onClick={remove} isDisabled={!isRootPasswordSet}>
+            Do not use a password
+          </Popup.TertiaryAction>
+        </Popup.Actions>
       </Popup>
     </>
   );

--- a/web/src/RootPassword.jsx
+++ b/web/src/RootPassword.jsx
@@ -105,7 +105,7 @@ export default function RootPassword() {
         <Popup.Actions>
           <Popup.Confirm onClick={accept} isDisabled={rootPassword === ""} />
           <Popup.Cancel onClick={close} />
-          <Popup.AncillaryAction onClick={remove} isDisabled={!isRootPasswordSet}>
+          <Popup.AncillaryAction onClick={remove} isDisabled={!isRootPasswordSet} key="unset">
             Do not use a password
           </Popup.AncillaryAction>
         </Popup.Actions>

--- a/web/src/RootSSHKey.jsx
+++ b/web/src/RootSSHKey.jsx
@@ -102,9 +102,9 @@ export default function RootSSHKey() {
         <Popup.Actions>
           <Popup.Confirm onClick={accept} />
           <Popup.Cancel onClick={cancel} />
-          <Popup.TertiaryAction onClick={remove} isDisabled={sshKey === ""}>
+          <Popup.AncillaryAction onClick={remove} isDisabled={sshKey === ""}>
             Do not use SSH public key
-          </Popup.TertiaryAction>
+          </Popup.AncillaryAction>
         </Popup.Actions>
       </Popup>
     </>

--- a/web/src/RootSSHKey.jsx
+++ b/web/src/RootSSHKey.jsx
@@ -25,12 +25,12 @@ import {
   Button,
   Form,
   FormGroup,
-  Modal,
-  ModalVariant,
   Skeleton,
   Text,
   FileUpload
 } from "@patternfly/react-core";
+
+import Popup from './Popup';
 
 export default function RootSSHKey() {
   const client = useInstallerClient();
@@ -80,22 +80,14 @@ export default function RootSSHKey() {
   return (
     <>
       {renderLink()}
-      <Modal
+      <Popup
         isOpen={isFormOpen}
-        showClose={false}
-        variant={ModalVariant.small}
         aria-label="Set root SSH public key"
-        actions={[
-          <Button key="confirm" variant="primary" onClick={accept}>
-            Confirm
-          </Button>,
-          <Button key="cancel" variant="secondary" onClick={cancel}>
-            Cancel
-          </Button>,
-          <Button key="remove" variant="link" onClick={remove} isDisabled={sshKey === ""}>
-            Do not use SSH public key
-          </Button>
-        ]}
+        onConfirm={accept}
+        onCancel={cancel}
+        onUnset={remove}
+        unsetText="Do not use SSH public key"
+        unsetDisabled={sshKey === ""}
       >
         <Form>
           <FormGroup fieldId="sshKey" label="Root SSH public key">
@@ -114,7 +106,7 @@ export default function RootSSHKey() {
             />
           </FormGroup>
         </Form>
-      </Modal>
+      </Popup>
     </>
   );
 }

--- a/web/src/RootSSHKey.jsx
+++ b/web/src/RootSSHKey.jsx
@@ -80,15 +80,7 @@ export default function RootSSHKey() {
   return (
     <>
       {renderLink()}
-      <Popup
-        isOpen={isFormOpen}
-        aria-label="Set root SSH public key"
-        onConfirm={accept}
-        onCancel={cancel}
-        onUnset={remove}
-        unsetText="Do not use SSH public key"
-        unsetDisabled={sshKey === ""}
-      >
+      <Popup isOpen={isFormOpen} aria-label="Set root SSH public key">
         <Form>
           <FormGroup fieldId="sshKey" label="Root SSH public key">
             <FileUpload
@@ -106,6 +98,14 @@ export default function RootSSHKey() {
             />
           </FormGroup>
         </Form>
+
+        <Popup.Actions>
+          <Popup.Confirm onClick={accept} />
+          <Popup.Cancel onClick={cancel} />
+          <Popup.TertiaryAction onClick={remove} isDisabled={sshKey === ""}>
+            Do not use SSH public key
+          </Popup.TertiaryAction>
+        </Popup.Actions>
       </Popup>
     </>
   );

--- a/web/src/RootSSHKey.jsx
+++ b/web/src/RootSSHKey.jsx
@@ -102,7 +102,7 @@ export default function RootSSHKey() {
         <Popup.Actions>
           <Popup.Confirm onClick={accept} />
           <Popup.Cancel onClick={cancel} />
-          <Popup.AncillaryAction onClick={remove} isDisabled={sshKey === ""}>
+          <Popup.AncillaryAction onClick={remove} isDisabled={sshKey === ""} key="unset">
             Do not use SSH public key
           </Popup.AncillaryAction>
         </Popup.Actions>

--- a/web/src/TargetSelector.jsx
+++ b/web/src/TargetSelector.jsx
@@ -27,9 +27,9 @@ import {
   FormGroup,
   FormSelect,
   FormSelectOption,
-  Modal,
-  ModalVariant
 } from "@patternfly/react-core";
+
+import Popup from './Popup';
 
 export default function TargetSelector({ target, targets, onAccept }) {
   const [value, setValue] = useState("");
@@ -66,26 +66,18 @@ export default function TargetSelector({ target, targets, onAccept }) {
         {target}
       </Button>
 
-      <Modal
+      <Popup
         isOpen={isFormOpen}
-        showClose={false}
-        variant={ModalVariant.small}
         aria-label="Target Selector"
-        actions={[
-          <Button key="confirm" variant="primary" onClick={accept}>
-            Confirm
-          </Button>,
-          <Button key="cancel" variant="secondary" onClick={cancel}>
-            Cancel
-          </Button>
-        ]}
+        onConfirm={accept}
+        onCancel={cancel}
       >
         <Form>
           <FormGroup fieldId="target" label="Device to install into">
             {buildSelector()}
           </FormGroup>
         </Form>
-      </Modal>
+      </Popup>
     </>
   );
 }

--- a/web/src/TargetSelector.jsx
+++ b/web/src/TargetSelector.jsx
@@ -66,17 +66,17 @@ export default function TargetSelector({ target, targets, onAccept }) {
         {target}
       </Button>
 
-      <Popup
-        isOpen={isFormOpen}
-        aria-label="Target Selector"
-        onConfirm={accept}
-        onCancel={cancel}
-      >
+      <Popup isOpen={isFormOpen} aria-label="Target Selector">
         <Form>
           <FormGroup fieldId="target" label="Device to install into">
             {buildSelector()}
           </FormGroup>
         </Form>
+
+        <Popup.Actions>
+          <Popup.Confirm onClick={accept} />
+          <Popup.Cancel onClick={cancel} />
+        </Popup.Actions>
       </Popup>
     </>
   );

--- a/web/src/utils.js
+++ b/web/src/utils.js
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) [2022] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+/**
+ * Returns a new array with collection split into two groups, the first holdings element which do
+ * satisfy the given filter and the second with those which not.
+ *
+ * @param {Array} collection - the collection to be filtered
+ * @param {function} filter - the function to be used as filter
+ * @returns {[Array, Array]} the new array with grouped elements
+ */
+const partition = (collection, filter) => {
+  const pass = [];
+  const fail = [];
+
+  collection.forEach(element => {
+    filter(element) ? pass.push(element) : fail.push(element);
+  });
+
+  return [pass, fail];
+};
+
+export {
+  partition
+};

--- a/web/src/utils.test.js
+++ b/web/src/utils.test.js
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) [2022] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import { partition } from "./utils";
+
+describe("partition", () => {
+  it("returns two groups of elements that do and do not satisfy provided filter", async () => {
+    const numbers = [1, 2, 3, 4, 5, 6];
+    const [odd, even] = partition(numbers, number => number % 2);
+
+    expect(odd).toEqual([1, 3, 5]);
+    expect(even).toEqual([2, 4, 6]);
+  });
+});


### PR DESCRIPTION
## Problem

There is quite some _duplication_ while building an _overview popup_

## Solution

To use a custom _Popup_ component built on top of PF4/Modal that allows using some default settings.

## Testing

* Added unit test
* Tested manually

## Screenshots

There are no changes at the UI level. Everything remains as it was. See it anyway:

| Before | After |
|-|-|
| ![popup-before](https://user-images.githubusercontent.com/1691872/165080768-d04dae2e-2c7d-434c-9164-71c2b32844a4.png) | ![popup-after](https://user-images.githubusercontent.com/1691872/165080786-13c2f412-3924-4942-a83e-56f7c141d0f0.png) |

## Notes for reviewers

~~Real changes are only the last two commits. Other changes you can see are actually related to #133 since this PR was created on top of the branch used there. We can either, adapt this PR or mark #133 as ready and merge it first.~~ 

^^^ Already _fixed_.
