### PR TITLE
Add an RSpec configuration to simplify running tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
       run: bundle config set --local with 'development' && bundle install
 
     - name: Run the tests and generate coverage report
-      run: bundle exec rspec test/**/*_test.rb
+      run: bundle exec rspec
 
     - name: Coveralls GitHub Action
       uses: coverallsapp/github-action@1.1.3

--- a/service/.rspec
+++ b/service/.rspec
@@ -1,0 +1,1 @@
+--pattern **/*_test.rb --default-path test


### PR DESCRIPTION
Add RSpec configuration, so running the tests is just a matter of typing: `bundle exec rspec`.