### PR TITLE
Added configuration reader

### DIFF
--- a/service/lib/dinstaller/cmdline_args.rb
+++ b/service/lib/dinstaller/cmdline_args.rb
@@ -45,7 +45,7 @@ module DInstaller
 
         key, value = option.split("=")
         key.gsub!(CMDLINE_PREFIX, "")
-        # Ommit config_url from Config options
+        # Omit config_url from Config options
         next args.config_url = value if key == "config_url"
 
         if key.include?(".")

--- a/service/lib/dinstaller/cmdline_args.rb
+++ b/service/lib/dinstaller/cmdline_args.rb
@@ -47,7 +47,7 @@ module DInstaller
 
         key, value = option.split("=")
         key.gsub!(CMDLINE_PREFIX, "")
-        # Ommit config_url from Config options
+        # Omit config_url from Config options
         next @config_url = value if key == "config_url"
 
         if key.include?(".")

--- a/service/lib/dinstaller/cmdline_args.rb
+++ b/service/lib/dinstaller/cmdline_args.rb
@@ -25,39 +25,39 @@ module DInstaller
     CMDLINE_PATH = "/proc/cmdline"
     CMDLINE_PREFIX = "dinst."
 
-    attr_reader :config_url
-    attr_reader :args
-    attr_reader :workdir
+    attr_accessor :config_url
+    attr_reader :data
 
     # Constructor
     #
-    # @param workdir [String] root directory to read the configuration from
-    def initialize(workdir: "/")
-      @workdir = workdir
+    # @param data [Hash]
+    def initialize(data = {})
+      @data = data
     end
 
     # Reads the kernel command line options
-    def read
-      options = File.read(File.join(workdir, CMDLINE_PATH))
-      @config_url = nil
-      @args = {}
+    def self.read_from(path)
+      options = File.read(path)
+      args = new({})
 
       options.split.each do |option|
         next unless option.start_with?(CMDLINE_PREFIX)
 
         key, value = option.split("=")
         key.gsub!(CMDLINE_PREFIX, "")
-        # Omit config_url from Config options
-        next @config_url = value if key == "config_url"
+        # Ommit config_url from Config options
+        next args.config_url = value if key == "config_url"
 
         if key.include?(".")
           section, key = key.split(".")
-          @args[section] = {} unless @args.keys.include?(section)
-          @args[section][key] = value
+          args.data[section] = {} unless args.data.keys.include?(section)
+          args.data[section][key] = value
         else
-          @args[key.gsub(CMDLINE_PREFIX, "")] = value
+          args.data[key.gsub(CMDLINE_PREFIX, "")] = value
         end
       end
+
+      args
     end
   end
 end

--- a/service/lib/dinstaller/cmdline_args.rb
+++ b/service/lib/dinstaller/cmdline_args.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+module DInstaller
+  # This class is responsible for reading DInstaller kernel cmdline options
+  class CmdlineArgs
+    CMDLINE_PATH = "/proc/cmdline"
+    CMDLINE_PREFIX = "dinst."
+
+    attr_reader :config_url
+    attr_reader :args
+    attr_reader :workdir
+
+    # Constructor
+    #
+    # @param workdir [String] root directory to read the configuration from
+    def initialize(workdir: "/")
+      @workdir = workdir
+    end
+
+    # Reads the kernel command line options
+    def read
+      options = File.read(File.join(workdir, CMDLINE_PATH))
+      @config_url = nil
+      @args = {}
+
+      options.split.each do |option|
+        next unless option.start_with?(CMDLINE_PREFIX)
+
+        key, value = option.split("=")
+        key.gsub!(CMDLINE_PREFIX, "")
+        # Ommit config_url from Config options
+        next @config_url = value if key == "config_url"
+
+        if key.include?(".")
+          section, key = key.split(".")
+          @args[section] = {} unless @args.keys.include?(section)
+          @args[section][key] = value
+        else
+          @args[key.gsub(CMDLINE_PREFIX, "")] = value
+        end
+      end
+    end
+  end
+end

--- a/service/lib/dinstaller/config.rb
+++ b/service/lib/dinstaller/config.rb
@@ -24,7 +24,7 @@ require "yaml"
 require "dinstaller/config_reader"
 
 module DInstaller
-  # class responsible for getting current configuration.
+  # Class responsible for getting current configuration.
   # It is smarter then just plain yaml reader as it also evaluates
   # conditions in it, so it is result of all conditions in file.
   # This also means that config needs to be re-evaluated if conditions

--- a/service/lib/dinstaller/config_reader.rb
+++ b/service/lib/dinstaller/config_reader.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+require "yast"
+require "logger"
+require "dinstaller/config"
+require "transfer/file_from_url"
+
+Yast.import "URL"
+Yast.import "Directory"
+
+module DInstaller
+  # This class is responsible for reading DInstaller configuration from different locations
+  # including kernel cmdline options
+  class ConfigReader
+    include Yast::Transfer::FileFromUrl
+    include Yast::I18n
+
+    # Default DInstaller configuration wich should define all the possible values
+    SYSTEM_PATH = "/etc/d-installer.yaml"
+    GIT_PATH = File.expand_path("#{__dir__}/../../etc/d-installer.yaml")
+    CMDLINE_PATH = "/proc/cmdline"
+    REMOTE_BOOT_CONFIG = "d-installer_boot.yaml"
+    CMDLINE_PREFIX = "dinst."
+
+    PATHS = [
+      "/usr/lib/d-installer.d",
+      "/etc/d-installer.d",
+      "/run/d-installer.d"
+    ].freeze
+
+    attr_reader :logger
+    attr_reader :workdir
+
+    # Constructor
+    #
+    # @param logger [Logger]
+    def initialize(logger: nil, workdir: "/")
+      @logger = logger || ::Logger.new($stdout)
+      @workdir = workdir
+    end
+
+    # Return an {Array} with the different {Config} objects read from the different locations
+    #
+    # TODO: handle precedence correctly
+    #
+    # @returm [Array<Config>] an array with all the configurations read from the system
+    def configs
+      @configs ||= config_paths.map { |path| config_from_file(path) }.concat(boot_configs)
+    end
+
+    # Return a {Config} oject
+    # @return [Config] resultant Config after merging all the configurations
+    def config
+      config = configs.first || Config.new
+      (configs[1..-1] || []).each { |c| config = config.merge(c) }
+      config
+    end
+
+  private
+
+    # Copy a file from a potentially remote location
+    #
+    # @param location [String] File location. It might be an URL-like string (e.g.,
+    #   "http://example.net/example.yml").
+    # @param target [String] Path to copy the file to.
+    # @return [Boolean] Whether the file was sucessfully copied or not
+    def copy_file(location, target)
+      url = Yast::URL.Parse(location)
+
+      res = get_file_from_url(
+        scheme: url["scheme"],
+        host: url["host"],
+        urlpath: url["path"],
+        localfile: target,
+        urltok: url,
+        destdir: "/"
+      )
+
+      # TODO: exception?
+      logger.error "script #{location} could not be retrieved" unless res
+      res
+    end
+
+    # @return [Hash] Cmdline DInstaller options
+    def cmdline_opts
+      options = File.read(File.join(workdir, CMDLINE_PATH))
+
+      options.split.each_with_object({}) do |option, result|
+        next unless option.start_with?(CMDLINE_PREFIX)
+
+        key, value = option.split("=")
+        key.gsub!(CMDLINE_PREFIX, "")
+        if key.include?(".")
+          section, key = key.split(".")
+          result[section] = {} unless result.keys.include?(section)
+          result[section][key] = value
+        else
+          result[key.gsub(CMDLINE_PREFIX, "")] = value
+        end
+      end
+    end
+
+    # @return [Array<Config>]
+    def boot_configs
+      options = (cmdline_opts || {})
+      return [] if options.empty?
+
+      result =  [Config.new.tap { |c| c.pure_data = options }]
+      return result if options.fetch("config_url", "").empty?
+
+      file_path = File.join(Yast::Directory.tmpdir, REMOTE_BOOT_CONFIG)
+      logger.info "Copying boot config to #{file_path}"
+
+      copy_file(options.fetch("config_url"), file_path)
+      result.prepend(config_from_file(file_path))
+      result
+    end
+
+    # loads correct yaml file
+    def config_from_file(path = nil)
+      raise "Missing config file at #{path}" unless File.exist?(path)
+
+      Config.new.tap { |c| c.pure_data = YAML.safe_load(File.read(path)) }
+    end
+
+    def default_path
+      File.exist?(GIT_PATH) ? GIT_PATH : SYSTEM_PATH
+    end
+
+    def config_paths
+      paths = PATHS.each_with_object([]) do |path, all|
+        all.concat(file_paths_in(File.join(workdir, path)))
+      end
+
+      paths.uniq! { |f| File.basename(f) }
+      # Sort files lexicographic
+      paths.sort_by! { |f| File.basename(f) }
+      paths.prepend(default_path)
+
+      paths
+    end
+
+    def file_paths_in(path)
+      if File.file?(path)
+        [path]
+      elsif File.directory?(path)
+        Dir.glob("#{path}/*.{yml,yaml}")
+      else
+        logger.debug("Ignoring not valid path: #{path}")
+
+        []
+      end
+    end
+  end
+end

--- a/service/lib/dinstaller/config_reader.rb
+++ b/service/lib/dinstaller/config_reader.rb
@@ -59,7 +59,7 @@ module DInstaller
     end
 
     # loads correct yaml file
-    def self.from_file(path = nil)
+    def config_from_file(path = nil)
       raise "Missing config file at #{path}" unless File.exist?(path)
 
       Config.new(YAML.safe_load(File.read(path)))
@@ -73,7 +73,7 @@ module DInstaller
     def configs
       return @configs if @configs
 
-      @configs = config_paths.map { |path| self.class.from_file(path) }
+      @configs = config_paths.map { |path| config_from_file(path) }
       @configs << remote_config if remote_config
       @configs << cmdline_config if cmdline_config
       @configs
@@ -130,7 +130,7 @@ module DInstaller
       logger.info "Copying boot config to #{file_path}"
 
       copy_file(cmdline_args.config_url, file_path)
-      self.class.from_file(file_path)
+      config_from_file(file_path)
     end
 
     def default_path

--- a/service/lib/dinstaller/config_reader.rb
+++ b/service/lib/dinstaller/config_reader.rb
@@ -68,12 +68,12 @@ module DInstaller
       url = Yast::URL.Parse(location)
 
       res = get_file_from_url(
-        scheme: url["scheme"],
-        host: url["host"],
-        urlpath: url["path"],
+        scheme:    url["scheme"],
+        host:      url["host"],
+        urlpath:   url["path"],
         localfile: target,
-        urltok: url,
-        destdir: "/"
+        urltok:    url,
+        destdir:   "/"
       )
 
       # TODO: exception?

--- a/service/lib/dinstaller/manager.rb
+++ b/service/lib/dinstaller/manager.rb
@@ -127,9 +127,8 @@ module DInstaller
 
     # Configuration
     def config
-      return Config.current if Config.current
+      Config.load unless Config.current
 
-      Config.load
       Config.current
     end
 

--- a/service/lib/dinstaller/manager.rb
+++ b/service/lib/dinstaller/manager.rb
@@ -127,7 +127,10 @@ module DInstaller
 
     # Configuration
     def config
-      @config ||= Config.new(logger)
+      return Config.current if Config.current
+
+      Config.load
+      Config.current
     end
 
     # Software manager

--- a/service/test/dinstaller/cmdline_args_test.rb
+++ b/service/test/dinstaller/cmdline_args_test.rb
@@ -26,10 +26,11 @@ describe DInstaller::CmdlineArgs do
   let(:workdir) { File.join(FIXTURES_PATH, "root_dir") }
   subject { described_class.new(workdir: workdir) }
 
-  describe "#read" do
-    it "reads the kernel command line options" do
-      expect { subject.read }.to change { subject.args }.to({ "web" => { "ssl" => "MODIFIED" } })
-        .and change { subject.config_url }.to("http://example.org/d-installer.yaml")
+  describe ".read_from" do
+    it "reads the kernel command line options and return a CmdlineArgs object" do
+      args = described_class.read_from(File.join(workdir, "/proc/cmdline"))
+      expect(args.data).to eql({ "web" => { "ssl" => "MODIFIED" } })
+      expect(args.config_url).to eql("http://example.org/d-installer.yaml")
     end
   end
 end

--- a/service/test/dinstaller/cmdline_args_test.rb
+++ b/service/test/dinstaller/cmdline_args_test.rb
@@ -20,31 +20,16 @@
 # find current contact information at www.suse.com.
 
 require_relative "../test_helper"
-require "dinstaller/config_reader"
+require "dinstaller/cmdline_args"
 
-describe DInstaller::ConfigReader do
+describe DInstaller::CmdlineArgs do
   let(:workdir) { File.join(FIXTURES_PATH, "root_dir") }
   subject { described_class.new(workdir: workdir) }
-  before do
-    allow(Yast::Directory).to receive(:tmpdir).and_return(File.join(workdir, "tmpdir"))
-    allow(subject).to receive(:copy_file)
-  end
 
-  describe "#config" do
-    it "returns the resultant config after merging all found configurations" do
-      config = subject.config
-      expect(config.data.dig("web", "ssl")).to eql("MODIFIED")
-    end
-  end
-
-  describe "#configs" do
-    it "returns an array with all the Configs present in the system" do
-      configs = subject.configs
-      # Default, RemoteBootConfig, CmdlineConfig
-      expect(configs.size).to eql(3)
-      expect(configs[0].data.dig("web", "ssl")).to eql(nil)
-      expect(configs[1].data.dig("web", "ssl")).to eql("WHATEVER")
-      expect(configs[2].data.dig("web", "ssl")).to eql("MODIFIED")
+  describe "#read" do
+    it "reads the kernel command line options" do
+      expect { subject.read }.to change { subject.args }.to({ "web" => { "ssl" => "MODIFIED" } })
+        .and change { subject.config_url }.to("http://example.org/d-installer.yaml")
     end
   end
 end

--- a/service/test/dinstaller/config_reader_test.rb
+++ b/service/test/dinstaller/config_reader_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+require "dinstaller/config_reader"
+
+describe DInstaller::ConfigReader do
+  let(:workdir) { File.join(FIXTURES_PATH, "root_dir") }
+  subject { described_class.new(workdir: workdir) }
+  before do
+    allow(Yast::Directory).to receive(:tmpdir).and_return(File.join(workdir, "tmpdir"))
+    allow(subject).to receive(:copy_file)
+  end
+
+  describe "#config" do
+    it "returns the resultant config after merging all found configurations" do
+      config = subject.config
+      expect(config.data.dig("web", "ssl")).to eql("MODIFIED")
+    end
+  end
+
+  describe "#configs" do
+    it "returns an array with all the Configs present in the system" do
+      configs = subject.configs
+      # Default, RemoteBootConfig, CmdlineConfig
+      expect(configs.size).to eql(3)
+      expect(configs[0].data.dig("web", "ssl")).to eql(nil)
+      expect(configs[1].data.dig("web", "ssl")).to eql("WHATEVER")
+      expect(configs[2].data.fetch("config_url")).to eql("http://example.org/dud/dinstaller.yml")
+      expect(configs[2].data.dig("web", "ssl")).to eql("MODIFIED")
+    end
+  end
+end

--- a/service/test/dinstaller/config_reader_test.rb
+++ b/service/test/dinstaller/config_reader_test.rb
@@ -30,9 +30,9 @@ describe DInstaller::ConfigReader do
     allow(subject).to receive(:copy_file)
   end
 
-  describe ".from_file" do
+  describe "#config_from_file" do
     it "returns a Config object with the configuration read from the given file" do
-      config = described_class.from_file(File.join(workdir, "etc", "d-installer.yaml"))
+      config = subject.config_from_file(File.join(workdir, "etc", "d-installer.yaml"))
       expect(config).to be_a(DInstaller::Config)
       expect(config.data["distributions"]).to eql(["Tumbleweed"])
     end

--- a/service/test/dinstaller/config_reader_test.rb
+++ b/service/test/dinstaller/config_reader_test.rb
@@ -30,6 +30,14 @@ describe DInstaller::ConfigReader do
     allow(subject).to receive(:copy_file)
   end
 
+  describe ".from_file" do
+    it "returns a Config object with the configuration read from the given file" do
+      config = described_class.from_file(File.join(workdir, "etc", "d-installer.yaml"))
+      expect(config).to be_a(DInstaller::Config)
+      expect(config.data["distributions"]).to eql(["Tumbleweed"])
+    end
+  end
+
   describe "#config" do
     it "returns the resultant config after merging all found configurations" do
       config = subject.config

--- a/service/test/dinstaller/config_test.rb
+++ b/service/test/dinstaller/config_test.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+require "dinstaller/config"
+
+describe DInstaller::Config do
+  let(:config) { described_class.new("web" => { "ssl" => "SOMETHING" }) }
+  before do
+    allow_any_instance_of(DInstaller::ConfigReader).to receive(:config).and_return(config)
+  end
+
+  describe ".load" do
+    before do
+      described_class.reset
+    end
+
+    it "reads the configuration from different locations" do
+      expect_any_instance_of(DInstaller::ConfigReader).to receive(:config)
+      described_class.load
+    end
+
+    it "stores the read configuration and set it as the current one" do
+      allow_any_instance_of(DInstaller::ConfigReader).to receive(:config).and_return(config)
+      expect { described_class.load }.to change { described_class.base }.from(nil).to(config)
+      expect(described_class.base).to_not eql(described_class.current)
+      expect(described_class.base.data).to eql(described_class.current.data)
+    end
+  end
+
+  describe ".reset" do
+    it "resets base and current configuration" do
+      described_class.load
+      expect { described_class.reset }.to change { described_class.base }.from(config).to(nil)
+        .and change { described_class.current }.to(nil)
+    end
+  end
+
+  describe "#data" do
+    it "returns memoized configuration data" do
+      expect(config.data).to eql("web" => { "ssl" => "SOMETHING" })
+    end
+  end
+
+  describe "#merge" do
+    let(:config_to_merge) { described_class.new("web" => { "ssl" => "MERGED" }) }
+    it "returns a new Config with the object data merged with the given Config data" do
+      merged_config = config.merge(config_to_merge)
+      expect(merged_config.object_id).to_not eql(config.object_id)
+      expect(merged_config.object_id).to_not eql(config_to_merge.object_id)
+      expect(merged_config.data).to eql(config_to_merge.data)
+    end
+  end
+
+  describe "#copy" do
+    it "returns a copy of the object" do
+      copy = subject.copy
+      expect(copy.object_id).to_not eq(subject.object_id)
+      expect(copy.data).to eql(subject.data)
+    end
+  end
+end

--- a/service/test/dinstaller/software_test.rb
+++ b/service/test/dinstaller/software_test.rb
@@ -28,7 +28,7 @@ describe DInstaller::Software do
   subject { described_class.new(logger, config) }
 
   let(:logger) { Logger.new($stdout) }
-  let(:config) { DInstaller::Config.new(logger) }
+  let(:config) { DInstaller::Config.new }
   let(:progress) { DInstaller::Progress.new }
   let(:products) { [tw_prod] }
   let(:tw_prod) { instance_double(Y2Packager::Product, name: "openSUSE") }
@@ -38,6 +38,7 @@ describe DInstaller::Software do
   let(:gpg_keys) { [] }
 
   before do
+    allow(config).to receive(:data).and_return({ "software" => { "installation_repositories" => [] } })
     allow(Yast::Pkg).to receive(:TargetInitialize)
     allow(Yast::Pkg).to receive(:ImportGPGKey)
     allow(Dir).to receive(:glob).with(/keys/).and_return(gpg_keys)

--- a/service/test/dinstaller/software_test.rb
+++ b/service/test/dinstaller/software_test.rb
@@ -38,7 +38,8 @@ describe DInstaller::Software do
   let(:gpg_keys) { [] }
 
   before do
-    allow(config).to receive(:data).and_return({ "software" => { "installation_repositories" => [] } })
+    allow(config).to receive(:data)
+      .and_return({ "software" => { "installation_repositories" => [] } })
     allow(Yast::Pkg).to receive(:TargetInitialize)
     allow(Yast::Pkg).to receive(:ImportGPGKey)
     allow(Dir).to receive(:glob).with(/keys/).and_return(gpg_keys)

--- a/service/test/fixtures/root_dir/etc/d-installer.yaml
+++ b/service/test/fixtures/root_dir/etc/d-installer.yaml
@@ -1,0 +1,14 @@
+software:
+  installation_repositories:
+    - https://download.opensuse.org/tumbleweed/repo/oss/
+    - https://download.opensuse.org/tumbleweed/repo/non-oss/
+    - https://download.opensuse.org/update/tumbleweed/
+
+distributions:
+  # TODO replace simple id with better description of distributions
+  - Tumbleweed
+
+web:
+  ssl: null
+  ssl_cert: null
+  ssl_key: null

--- a/service/test/fixtures/root_dir/proc/cmdline
+++ b/service/test/fixtures/root_dir/proc/cmdline
@@ -1,0 +1,1 @@
+dinst.config_url=http://example.org/dud/dinstaller.yml dinst.web.ssl=MODIFIED

--- a/service/test/fixtures/root_dir/proc/cmdline
+++ b/service/test/fixtures/root_dir/proc/cmdline
@@ -1,1 +1,1 @@
-dinst.config_url=http://example.org/dud/dinstaller.yml dinst.web.ssl=MODIFIED
+dinst.config_url=http://example.org/d-installer.yaml dinst.web.ssl=MODIFIED

--- a/service/test/fixtures/root_dir/tmpdir/d-installer_boot.yaml
+++ b/service/test/fixtures/root_dir/tmpdir/d-installer_boot.yaml
@@ -1,0 +1,14 @@
+software:
+  installation_repositories:
+    - https://download.opensuse.org/tumbleweed/repo/oss/
+    - https://download.opensuse.org/tumbleweed/repo/non-oss/
+    - https://download.opensuse.org/update/tumbleweed/
+
+distributions:
+  # TODO replace simple id with better description of distributions
+  - Tumbleweed
+
+web:
+  ssl: WHATEVER
+  ssl_cert: null
+  ssl_key: null


### PR DESCRIPTION
## Problem

In https://github.com/yast/d-installer/pull/132 we added support for an initial **d-installer** configuration through a **YAML** file. This PR aims to extended it allowing the user to customize some of the default settings using the kernel command line options.

- https://trello.com/c/UiD9jUCS/2951-5-d-installer-add-a-mechanism-to-modify-d-installer-configuration

## Solution

We have moved the logic for reading the configuration from the **Config** class to a separate class and also a class for parsing the kernel command line options has been added.

The reader can return a **Config** object merging all the configurations present in the system.

## Testing

- Added unit tests
