### PR TITLE
Handle correctly cmdline boolean values

### DIFF
--- a/service/lib/dinstaller/cmdline_args.rb
+++ b/service/lib/dinstaller/cmdline_args.rb
@@ -48,7 +48,7 @@ module DInstaller
         # Omit config_url from Config options
         next args.config_url = value if key == "config_url"
 
-        # TODO: Add some kind of schema or 'knowdlege' of attribute types to convert them properly
+        # TODO: Add some kind of schema or 'knowledge' of attribute types to convert them properly
         # by now we will just convert Boolean values
         value = normalize(value)
         if key.include?(".")

--- a/service/lib/dinstaller/cmdline_args.rb
+++ b/service/lib/dinstaller/cmdline_args.rb
@@ -50,7 +50,7 @@ module DInstaller
 
         # TODO: Add some kind of schema or 'knowdlege' of attribute types to convert them properly
         # by now we will just convert Boolean values
-        value = (value == "true") if ["false", "true"].include?(value.to_s.downcase)
+        value = normalize(value)
         if key.include?(".")
           section, key = key.split(".")
           args.data[section] = {} unless args.data.keys.include?(section)
@@ -62,5 +62,19 @@ module DInstaller
 
       args
     end
+
+    # Convenience method to normalize the given value by now it just convert "true" and "false"
+    # strings to {Boolean}s
+    #
+    # @param value [String]
+    # @return [Object] normalized value
+    def self.normalize(value)
+      val = value.to_s.downcase
+      return value unless ["false", "true"].include?(val)
+
+      (val == "true")
+    end
+
+    private_class_method :normalize
   end
 end

--- a/service/lib/dinstaller/cmdline_args.rb
+++ b/service/lib/dinstaller/cmdline_args.rb
@@ -48,6 +48,9 @@ module DInstaller
         # Omit config_url from Config options
         next args.config_url = value if key == "config_url"
 
+        # TODO: Add some kind of schema or 'knowdlege' of attribute types to convert them properly
+        # by now we will just convert Boolean values
+        value = (value == "true") if ["false", "true"].include?(value.to_s.downcase)
         if key.include?(".")
           section, key = key.split(".")
           args.data[section] = {} unless args.data.keys.include?(section)

--- a/service/test/dinstaller/cmdline_args_test.rb
+++ b/service/test/dinstaller/cmdline_args_test.rb
@@ -29,7 +29,7 @@ describe DInstaller::CmdlineArgs do
   describe ".read_from" do
     it "reads the kernel command line options and return a CmdlineArgs object" do
       args = described_class.read_from(File.join(workdir, "/proc/cmdline"))
-      expect(args.data).to eql({ "web" => { "ssl" => "MODIFIED" } })
+      expect(args.data).to eql("web" => { "ssl" => true })
       expect(args.config_url).to eql("http://example.org/d-installer.yaml")
     end
   end

--- a/service/test/dinstaller/config_reader_test.rb
+++ b/service/test/dinstaller/config_reader_test.rb
@@ -41,7 +41,7 @@ describe DInstaller::ConfigReader do
   describe "#config" do
     it "returns the resultant config after merging all found configurations" do
       config = subject.config
-      expect(config.data.dig("web", "ssl")).to eql("MODIFIED")
+      expect(config.data.dig("web", "ssl")).to eql(true)
     end
   end
 
@@ -51,8 +51,8 @@ describe DInstaller::ConfigReader do
       # Default, RemoteBootConfig, CmdlineConfig
       expect(configs.size).to eql(3)
       expect(configs[0].data.dig("web", "ssl")).to eql(nil)
-      expect(configs[1].data.dig("web", "ssl")).to eql("WHATEVER")
-      expect(configs[2].data.dig("web", "ssl")).to eql("MODIFIED")
+      expect(configs[1].data.dig("web", "ssl")).to eql(false)
+      expect(configs[2].data.dig("web", "ssl")).to eql(true)
     end
   end
 end

--- a/service/test/fixtures/root_dir/proc/cmdline
+++ b/service/test/fixtures/root_dir/proc/cmdline
@@ -1,1 +1,1 @@
-dinst.config_url=http://example.org/d-installer.yaml dinst.web.ssl=MODIFIED
+dinst.config_url=http://example.org/d-installer.yaml dinst.web.ssl=true

--- a/service/test/fixtures/root_dir/tmpdir/d-installer_boot.yaml
+++ b/service/test/fixtures/root_dir/tmpdir/d-installer_boot.yaml
@@ -9,6 +9,6 @@ distributions:
   - Tumbleweed
 
 web:
-  ssl: WHATEVER
+  ssl: false
   ssl_cert: null
   ssl_key: null


### PR DESCRIPTION
## Problem

In - https://github.com/yast/d-installer/pull/158
 we extended the installer configuration supporting to override the default values through the kernel command line options but as we do not have an schema or the type of the attributes that we are defining the override could be problematic in some cases. Current problem is the **web.ssl** option which is boolean and which default value is not initialized.


## Solution

By now we have decided to just convert **false** and **true** strings to **Booleans**

## Testing

- *Added a new unit test*
