### PR TITLE
Add CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
         flag-name: backend
         parallel: true
 
-  backend-linter:
+  backend_linter:
     runs-on: ubuntu-latest
 
     defaults:
@@ -109,10 +109,73 @@ jobs:
     - name: Rubocop
       run: /usr/bin/rubocop.*-1.24.1
 
+  cli_tests:
+    runs-on: ubuntu-latest
+    env:
+      COVERAGE: 1
+
+    defaults:
+      run:
+        working-directory: ./cli
+
+    strategy:
+      fail-fast: false
+      matrix:
+        distro: [ "tumbleweed" ]
+
+    container:
+      image: registry.opensuse.org/yast/head/containers_${{matrix.distro}}/yast-ruby
+
+    steps:
+
+    - name: Git Checkout
+      uses: actions/checkout@v2
+
+    - name: Install Ruby development files
+      run: zypper --non-interactive install gcc gcc-c++ make openssl-devel ruby-devel npm augeas-devel
+
+    - name: Install RubyGems dependencies
+      run: bundle config set --local with 'development' && bundle install
+
+    - name: Run the tests and generate coverage report
+      run: bundle exec rspec
+
+    - name: Coveralls GitHub Action
+      uses: coverallsapp/github-action@1.1.3
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        base-path: ./cli
+        path-to-lcov: ./cli/coverage/lcov.info
+        flag-name: cli
+        parallel: true
+
+  cli_linter:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: ./cli
+
+    strategy:
+      fail-fast: false
+      matrix:
+        distro: [ "leap_latest" ]
+
+    container:
+      image: registry.opensuse.org/yast/head/containers_${{matrix.distro}}/yast-ruby
+
+    steps:
+
+    - name: Git Checkout
+      uses: actions/checkout@v2
+
+    - name: Rubocop
+      run: /usr/bin/rubocop.*-1.24.1
+
   finish:
     runs-on: ubuntu-latest
 
-    needs: [frontend_build, backend_tests]
+    needs: [frontend_build, backend_tests, cli_tests]
 
     steps:
 

--- a/cli/.gitignore
+++ b/cli/.gitignore
@@ -1,0 +1,56 @@
+*.gem
+*.rbc
+/.config
+/coverage/
+/InstalledFiles
+/pkg/
+/spec/reports/
+/spec/examples.txt
+/test/tmp/
+/test/version_tmp/
+/tmp/
+
+# Used by dotenv library to load environment variables.
+# .env
+
+# Ignore Byebug command history file.
+.byebug_history
+
+## Specific to RubyMotion:
+.dat*
+.repl_history
+build/
+*.bridgesupport
+build-iPhoneOS/
+build-iPhoneSimulator/
+
+## Specific to RubyMotion (use of CocoaPods):
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+#
+# vendor/Pods/
+
+## Documentation cache and generated files:
+/.yardoc/
+/_yardoc/
+/doc/
+/rdoc/
+
+## Environment normalization:
+/.bundle/
+/vendor/bundle
+/lib/bundler/man/
+
+# for a library or gem, you might want to ignore these files since the code is
+# intended to run in multiple environments; otherwise, check them in:
+# Gemfile.lock
+# .ruby-version
+# .ruby-gemset
+
+# unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
+.rvmrc
+
+# Used by RuboCop. Remote config files pulled in from inherit_from directive.
+# .rubocop-https?--*

--- a/cli/.rspec
+++ b/cli/.rspec
@@ -1,0 +1,1 @@
+--pattern **/*_test.rb --default-path test

--- a/cli/.rubocop.yml
+++ b/cli/.rubocop.yml
@@ -1,0 +1,11 @@
+# use the shared Yast defaults
+inherit_from:
+  /usr/share/YaST2/data/devtools/data/rubocop-1.24.1_yast_style.yml
+
+AllCops:
+  Exclude:
+    - vendor/**/*
+
+# assignment in method calls is used to document some params
+Lint/UselessAssignment:
+  Enabled: false

--- a/cli/Gemfile
+++ b/cli/Gemfile
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+source "https://rubygems.org"
+
+gemspec
+
+group :development do
+  gem "byebug"
+end

--- a/cli/Gemfile.lock
+++ b/cli/Gemfile.lock
@@ -1,0 +1,57 @@
+PATH
+  remote: .
+  specs:
+    d-installer-cli (0.2)
+      fast_gettext (~> 2.2.0)
+      ruby-dbus (>= 0.18.0.beta5)
+      thor (>= 1.2.1)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    byebug (11.1.3)
+    diff-lcs (1.5.0)
+    docile (1.4.0)
+    fast_gettext (2.2.0)
+    packaging_rake_tasks (1.5.1)
+      rake
+    rake (13.0.6)
+    rexml (3.2.5)
+    rspec (3.11.0)
+      rspec-core (~> 3.11.0)
+      rspec-expectations (~> 3.11.0)
+      rspec-mocks (~> 3.11.0)
+    rspec-core (3.11.0)
+      rspec-support (~> 3.11.0)
+    rspec-expectations (3.11.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.11.0)
+    rspec-mocks (3.11.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.11.0)
+    rspec-support (3.11.0)
+    ruby-dbus (0.18.0.beta6)
+      rexml
+    simplecov (0.21.2)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov-lcov (0.8.0)
+    simplecov_json_formatter (0.1.4)
+    thor (1.2.1)
+
+PLATFORMS
+  x86_64-linux
+
+DEPENDENCIES
+  byebug
+  d-installer-cli!
+  packaging_rake_tasks (~> 1.5.1)
+  rake (~> 13.0.6)
+  rspec (~> 3.11.0)
+  simplecov (~> 0.21.2)
+  simplecov-lcov (~> 0.8.0)
+
+BUNDLED WITH
+   2.3.3

--- a/cli/bin/dinstallerctl
+++ b/cli/bin/dinstallerctl
@@ -1,0 +1,26 @@
+#!/usr/bin/env ruby
+
+# frozen_string_literal: true
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "dinstaller_cli/commands/main"
+
+DInstallerCli::Commands::Main.start(ARGV)

--- a/cli/d-installer-cli.gemspec
+++ b/cli/d-installer-cli.gemspec
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+Gem::Specification.new do |spec|
+  spec.name = "d-installer-cli"
+  spec.version = File.read(File.expand_path("VERSION", File.join(__dir__, ".."))).chomp
+  spec.summary = "Command line interface for D-Installer service"
+  spec.description = "Command line interface for D-Installer service"
+  spec.author = "YaST Team"
+  spec.email = "yast-devel@opensuse.org"
+  spec.homepage = "https://github.com/yast/d-installer"
+  spec.license = "GPL-2.0-only"
+  spec.files = Dir["lib/**/*.rb", "bin/*", "share/*", "etc/*", "[A-Z]*"]
+  spec.executables << "dinstallerctl"
+  spec.metadata = { "rubygems_mfa_required" => "true" }
+
+  spec.required_ruby_version = ">= 2.5.0"
+
+  spec.add_development_dependency "packaging_rake_tasks", "~> 1.5.1"
+  spec.add_development_dependency "rake", "~> 13.0.6"
+  spec.add_development_dependency "rspec", "~> 3.11.0"
+  spec.add_development_dependency "simplecov", "~> 0.21.2"
+  spec.add_development_dependency "simplecov-lcov", "~> 0.8.0"
+  spec.add_dependency "fast_gettext", "~> 2.2.0"
+  spec.add_dependency "ruby-dbus", ">= 0.18.0.beta5"
+  spec.add_dependency "thor", ">= 1.2.1"
+end

--- a/cli/lib/dinstaller_cli.rb
+++ b/cli/lib/dinstaller_cli.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+# DInstaller CLI module
+module DInstallerCli
+end
+
+require "dinstaller_cli/commands"

--- a/cli/lib/dinstaller_cli/clients.rb
+++ b/cli/lib/dinstaller_cli/clients.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+module DInstallerCli
+  # D-Bus clients
+  module Clients
+  end
+end
+
+require "dinstaller_cli/clients/manager"
+require "dinstaller_cli/clients/language"
+require "dinstaller_cli/clients/software"
+require "dinstaller_cli/clients/storage"
+require "dinstaller_cli/clients/users"

--- a/cli/lib/dinstaller_cli/clients/language.rb
+++ b/cli/lib/dinstaller_cli/clients/language.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "dbus"
+
+module DInstallerCli
+  module Clients
+    # D-Bus client for language configuration
+    class Language
+      def initialize
+        @dbus_object = service.object("/org/opensuse/DInstaller/Language1")
+        @dbus_object.introspect
+      end
+
+      # Available languages for the installation
+      #
+      # @return [Array<Array<String, String>>] id and name of each language
+      def available_languages
+        dbus_object["org.opensuse.DInstaller.Language1"]["AvailableLanguages"].map { |l| l[0..1] }
+      end
+
+      # Languages selected to install
+      #
+      # @return [Array<String>] ids of the languages
+      def selected_languages
+        dbus_object["org.opensuse.DInstaller.Language1"]["MarkedForInstall"]
+      end
+
+      # Selects the languages to install
+      #
+      # @param ids [Array<String>]
+      def select_languages(ids)
+        dbus_object.ToInstall(ids)
+      end
+
+    private
+
+      # @return [::DBus::Object]
+      attr_reader :dbus_object
+
+      # @return [::DBus::Service]
+      def service
+        @service ||= bus.service("org.opensuse.DInstaller")
+      end
+
+      def bus
+        @bus ||= DBus::SystemBus.instance
+      end
+    end
+  end
+end

--- a/cli/lib/dinstaller_cli/clients/manager.rb
+++ b/cli/lib/dinstaller_cli/clients/manager.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "dbus"
+
+module DInstallerCli
+  module Clients
+    # D-Bus client for DInstaller service
+    class Manager
+      def initialize
+        @dbus_object = service.object("/org/opensuse/DInstaller/Manager1")
+        @dbus_object.introspect
+
+        register_callbacks
+      end
+
+      # Starts the installation
+      def commit
+        dbus_object.Commit
+      end
+
+      # Current status of the installation
+      #
+      # @return [Integer]
+      def status
+        dbus_object["org.opensuse.DInstaller.Manager1"]["Status"]
+      end
+
+    private
+
+      # @return [::DBus::Object]
+      attr_reader :dbus_object
+
+      def register_callbacks
+        dbus_properties = dbus_object["org.freedesktop.DBus.Properties"]
+
+        dbus_properties.on_signal("PropertiesChanged") do |_, properties, _|
+          report_progress(properties["Progress"])
+        end
+      end
+
+      def report_progress(progress)
+        return if progress.nil?
+
+        message, total, current, total_minor, = progress
+
+        if total_minor == 0
+          puts "(#{current + 1}/#{total + 1}) #{message}"
+        else
+          puts "\t#{message}"
+        end
+      end
+
+      # @return [::DBus::Service]
+      def service
+        @service ||= bus.service("org.opensuse.DInstaller")
+      end
+
+      def bus
+        @bus ||= DBus::SystemBus.instance
+      end
+    end
+  end
+end

--- a/cli/lib/dinstaller_cli/clients/software.rb
+++ b/cli/lib/dinstaller_cli/clients/software.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "dbus"
+
+module DInstallerCli
+  module Clients
+    # D-Bus client for software configuration
+    class Software
+      def initialize
+        @dbus_object = service.object("/org/opensuse/DInstaller/Software1")
+        @dbus_object.introspect
+      end
+
+      # Available products for the installation
+      #
+      # @return [Array<Array<String, String>>] name and display name of each product
+      def available_products
+        dbus_object["org.opensuse.DInstaller.Software1"]["AvailableBaseProducts"].map do |l|
+          l[0..1]
+        end
+      end
+
+      # Product selected to install
+      #
+      # @return [String] name of the product
+      def selected_product
+        dbus_object["org.opensuse.DInstaller.Software1"]["SelectedBaseProduct"]
+      end
+
+      # Selects the product to install
+      #
+      # @param name [String]
+      def select_product(name)
+        dbus_object.SelectProduct(name)
+      end
+
+    private
+
+      # @return [::DBus::Object]
+      attr_reader :dbus_object
+
+      # @return [::DBus::Service]
+      def service
+        @service ||= bus.service("org.opensuse.DInstaller")
+      end
+
+      def bus
+        @bus ||= DBus::SystemBus.instance
+      end
+    end
+  end
+end

--- a/cli/lib/dinstaller_cli/clients/storage.rb
+++ b/cli/lib/dinstaller_cli/clients/storage.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "dbus"
+
+module DInstallerCli
+  module Clients
+    # D-Bus client for storage configuration
+    class Storage
+      def initialize
+        @dbus_proposal = service.object("/org/opensuse/DInstaller/Storage/Proposal1")
+        @dbus_proposal.introspect
+
+        @dbus_actions = service.object("/org/opensuse/DInstaller/Storage/Actions1")
+        @dbus_actions.introspect
+      end
+
+      # Devices available for the installation
+      #
+      # @return [Array<String>] name of the devices
+      def available_devices
+        dbus_proposal["org.opensuse.DInstaller.Storage.Proposal1"]["AvailableDevices"].map(&:first)
+      end
+
+      # Devices selected for the installation
+      #
+      # @return [Array<String>] name of the devices
+      def candidate_devices
+        dbus_proposal["org.opensuse.DInstaller.Storage.Proposal1"]["CandidateDevices"]
+      end
+
+      # Calculates the storage proposal with the given devices
+      #
+      # @param candidate_devices [Array<String>] name of the new candidate devices
+      def calculate(candidate_devices)
+        dbus_proposal.Calculate({ "CandidateDevices" => candidate_devices })
+      end
+
+      # Actions to perform in the storage devices
+      #
+      # @return [Array<String>]
+      def actions
+        dbus_actions["org.opensuse.DInstaller.Storage.Actions1"]["All"].map { |a| a["Text"] }
+      end
+
+    private
+
+      # @return [::DBus::Object]
+      attr_reader :dbus_proposal
+
+      # @return [::DBus::Object]
+      attr_reader :dbus_actions
+
+      # @return [::DBus::Service]
+      def service
+        @service ||= bus.service("org.opensuse.DInstaller")
+      end
+
+      def bus
+        @bus ||= DBus::SystemBus.instance
+      end
+    end
+  end
+end

--- a/cli/lib/dinstaller_cli/clients/users.rb
+++ b/cli/lib/dinstaller_cli/clients/users.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "dbus"
+
+module DInstallerCli
+  module Clients
+    # D-Bus client for users configuration
+    class Users
+      def initialize
+        @dbus_object = service.object("/org/opensuse/DInstaller/Users1")
+        @dbus_object.introspect
+      end
+
+      # Configuration of the first user to create during the installation
+      #
+      # @return [Array<String, String, Boolean>] full name, name and autologin
+      def first_user
+        dbus_object["org.opensuse.DInstaller.Users1"]["FirstUser"][0..2]
+      end
+
+      # Configures the first user to create during the installation
+      #
+      # @param name [String]
+      # @param fullname [String, nil]
+      # @param password [String, nil]
+      # @param autologin [Boolean]
+      def create_first_user(name, fullname: nil, password: nil, autologin: false)
+        dbus_object.SetFirstUser(fullname.to_s, name, password.to_s, !!autologin, {})
+      end
+
+      # Removes the configuration of the first user
+      def remove_first_user
+        dbus_object.RemoveFirstUser
+      end
+
+      # SSH key for root
+      #
+      # @return [String] empty if no SSH key set
+      def root_ssh_key
+        dbus_object["org.opensuse.DInstaller.Users1"]["RootSSHKey"]
+      end
+
+      # Sets the SSH key for root
+      #
+      # @param value [String]
+      def root_ssh_key=(value)
+        dbus_object.SetRootSSHKey(value)
+      end
+
+      # Whether the root password is set
+      #
+      # @return [Boolean]
+      def root_password?
+        dbus_object["org.opensuse.DInstaller.Users1"]["RootPasswordSet"]
+      end
+
+      # Sets the root password
+      #
+      # @param value [String]
+      def root_password=(value)
+        dbus_object.SetRootPassword(value, false)
+      end
+
+      # Removes the SSH key and password for root
+      def remove_root_info
+        dbus_object.RemoveRootPassword
+        dbus_object.SetRootSSHKey("")
+      end
+
+    private
+
+      # @return [::DBus::Object]
+      attr_reader :dbus_object
+
+      # @return [::DBus::Service]
+      def service
+        @service ||= bus.service("org.opensuse.DInstaller")
+      end
+
+      def bus
+        @bus ||= DBus::SystemBus.instance
+      end
+    end
+  end
+end

--- a/cli/lib/dinstaller_cli/commands.rb
+++ b/cli/lib/dinstaller_cli/commands.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+module DInstallerCli
+  # Module containing all commands
+  module Commands
+  end
+end
+
+require "dinstaller_cli/commands/main"

--- a/cli/lib/dinstaller_cli/commands/language.rb
+++ b/cli/lib/dinstaller_cli/commands/language.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "thor"
+require "dinstaller_cli/clients/language"
+
+module DInstallerCli
+  module Commands
+    # Subcommand to manage language settings
+    class Language < Thor
+      desc "available", "List available languages for the installation"
+      def available
+        languages = client.available_languages.map { |l| l.join(" - ") }
+
+        puts languages
+      end
+
+      desc "selected [<id>...]", "Select the languages to install in the target system"
+      long_desc "Use without arguments to see the currectly selected languages."
+      def selected(*ids)
+        client.select_languages(ids) if ids.any?
+        puts client.selected_languages
+      end
+
+    private
+
+      def client
+        @client ||= Clients::Language.new
+      end
+    end
+  end
+end

--- a/cli/lib/dinstaller_cli/commands/language.rb
+++ b/cli/lib/dinstaller_cli/commands/language.rb
@@ -34,7 +34,7 @@ module DInstallerCli
       end
 
       desc "selected [<id>...]", "Select the languages to install in the target system"
-      long_desc "Use without arguments to see the currectly selected languages."
+      long_desc "Use without arguments to see the currently selected languages."
       def selected(*ids)
         client.select_languages(ids) if ids.any?
         puts client.selected_languages

--- a/cli/lib/dinstaller_cli/commands/main.rb
+++ b/cli/lib/dinstaller_cli/commands/main.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "thor"
+require "dinstaller_cli/commands/language"
+require "dinstaller_cli/commands/software"
+require "dinstaller_cli/commands/storage"
+require "dinstaller_cli/commands/root_user"
+require "dinstaller_cli/commands/user"
+require "dinstaller_cli/clients/manager"
+
+module DInstallerCli
+  module Commands
+    # Main command
+    class Main < Thor
+      def self.exit_on_failure?
+        true
+      end
+
+      desc "install", "Perform the installation into the selected devices"
+      def install
+        answer = ask("Do you want to start the installation?", limited_to: ["y", "n"])
+        return unless answer == "y"
+
+        puts "Installing, this could take a while ..."
+        manager_client.commit
+      end
+
+      desc "status", "Get installation status"
+      def status
+        status = case manager_client.status
+        when 0
+          "error"
+        when 1
+          "probing"
+        when 2
+          "probed"
+        when 3
+          "installing"
+        when 4
+          "installed"
+        else
+          "unknown"
+        end
+
+        puts status
+      end
+
+      desc "language SUBCOMMAND", "Manage language configuration"
+      subcommand "language", Language
+
+      desc "software SUBCOMMAND", "Manage software configuration"
+      subcommand "software", Software
+
+      desc "storage SUBCOMMAND", "Manage storage configuration"
+      subcommand "storage", Storage
+
+      desc "rootuser SUBCOMMAND", "Manage root user configuration"
+      subcommand "rootuser", RootUser
+
+      desc "user SUBCOMMAND", "Manage first user configuration"
+      subcommand "user", User
+
+    private
+
+      def manager_client
+        @manager_client ||= Clients::Manager.new
+      end
+    end
+  end
+end

--- a/cli/lib/dinstaller_cli/commands/root_user.rb
+++ b/cli/lib/dinstaller_cli/commands/root_user.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "thor"
+require "dinstaller_cli/clients/users"
+
+module DInstallerCli
+  module Commands
+    # Subcommand to manage root user settings
+    class RootUser < Thor
+      desc "ssh_key [<key>]", "Set the SSH key for root"
+      long_desc "Use without arguments to see the current SSH key value."
+      def ssh_key(key = nil)
+        client.root_ssh_key = key if key
+        puts client.root_ssh_key
+      end
+
+      desc "password [<plain password>]", "Set the root password"
+      def password(password = nil)
+        client.root_password = password if password
+        puts "<secret>" if client.root_password?
+      end
+
+      desc "clear", "Clear root configuration"
+      def clear
+        client.remove_root_info
+      end
+
+    private
+
+      def client
+        @client ||= Clients::Users.new
+      end
+    end
+  end
+end

--- a/cli/lib/dinstaller_cli/commands/software.rb
+++ b/cli/lib/dinstaller_cli/commands/software.rb
@@ -55,7 +55,7 @@ module DInstallerCli
       end
 
       desc "selected_product [<id>]", "Select the product to install in the target system"
-      long_desc "Use without arguments to see the currectly selected product."
+      long_desc "Use without arguments to see the currently selected product."
       def selected_product(id = nil)
         client.select_product(id) if id
         puts client.selected_product

--- a/cli/lib/dinstaller_cli/commands/software.rb
+++ b/cli/lib/dinstaller_cli/commands/software.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+# frozen_string_literal: true
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "thor"
+require "dinstaller_cli/clients/software"
+
+module DInstallerCli
+  module Commands
+    # Subcommand to manage software settings
+    class Software < Thor
+      desc "available_products", "List available products for the installation"
+      def available_products
+        products = client.available_products.map { |l| l.join(" - ") }
+
+        puts products
+      end
+
+      desc "selected_product [<id>]", "Select the product to install in the target system"
+      long_desc "Use without arguments to see the currectly selected product."
+      def selected_product(id = nil)
+        client.select_product(id) if id
+        puts client.selected_product
+      end
+
+    private
+
+      def client
+        @client ||= Clients::Software.new
+      end
+    end
+  end
+end

--- a/cli/lib/dinstaller_cli/commands/storage.rb
+++ b/cli/lib/dinstaller_cli/commands/storage.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "thor"
+require "dinstaller_cli/clients/storage"
+
+module DInstallerCli
+  module Commands
+    # Subcommand to manage storage settings
+    class Storage < Thor
+      desc "available_devices", "List available devices for the installation"
+      def available_devices
+        puts client.available_devices
+      end
+
+      desc "selected_devices [<device>...]", "Select devices for the installation"
+      long_desc "Use without arguments to see the currectly selected devices."
+      def selected_devices(*devices)
+        client.calculate(devices) if devices.any?
+        puts client.candidate_devices
+      end
+
+      desc "actions", "List the storage actions to perform"
+      def actions
+        puts client.actions
+      end
+
+    private
+
+      def client
+        @client ||= Clients::Storage.new
+      end
+    end
+  end
+end

--- a/cli/lib/dinstaller_cli/commands/storage.rb
+++ b/cli/lib/dinstaller_cli/commands/storage.rb
@@ -32,7 +32,7 @@ module DInstallerCli
       end
 
       desc "selected_devices [<device>...]", "Select devices for the installation"
-      long_desc "Use without arguments to see the currectly selected devices."
+      long_desc "Use without arguments to see the currently selected devices."
       def selected_devices(*devices)
         client.calculate(devices) if devices.any?
         puts client.candidate_devices

--- a/cli/lib/dinstaller_cli/commands/user.rb
+++ b/cli/lib/dinstaller_cli/commands/user.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "thor"
+require "dinstaller_cli/clients/users"
+
+module DInstallerCli
+  module Commands
+    # Subcommand to manage first user settings
+    class User < Thor
+      desc "set <name>", "Configure the user that will be created during the installation"
+      option :fullname, banner: "<full-name>", desc: "Set the user's full name"
+      option :password, banner: "<plain-password>", desc: "Set the user's password"
+      option :autologin, type: :boolean, default: false,
+        desc: "Enable/disable user autologin (disabled by default)"
+      def set(name)
+        client.create_first_user(name,
+          fullname:  options[:fullname],
+          password:  options[:password],
+          autologin: options[:autologin])
+      end
+
+      desc "show", "Show the user configuration"
+      def show
+        user = client.first_user
+
+        return if user[1].empty?
+
+        puts "Full Name: #{user[0]}"
+        puts "Name: #{user[1]}"
+        puts "Autologin: #{user[2] ? "yes" : "no"}"
+        puts "Password: <secret>"
+      end
+
+      desc "clear", "Clear the user configuration"
+      def clear
+        client.remove_first_user
+      end
+
+    private
+
+      def client
+        @client ||= Clients::Users.new
+      end
+    end
+  end
+end

--- a/cli/lib/dinstaller_cli/commands/user.rb
+++ b/cli/lib/dinstaller_cli/commands/user.rb
@@ -40,13 +40,13 @@ module DInstallerCli
 
       desc "show", "Show the user configuration"
       def show
-        user = client.first_user
+        full_name, name, autologin = client.first_user
 
-        return if user[1].empty?
+        return if name.empty?
 
-        puts "Full Name: #{user[0]}"
-        puts "Name: #{user[1]}"
-        puts "Autologin: #{user[2] ? "yes" : "no"}"
+        puts "Full Name: #{full_name}"
+        puts "Name: #{name}"
+        puts "Autologin: #{autologin ? "yes" : "no"}"
         puts "Password: <secret>"
       end
 

--- a/cli/package/d-installer-cli.changes
+++ b/cli/package/d-installer-cli.changes
@@ -1,0 +1,4 @@
+-------------------------------------------------------------------
+Fri May 27 11:57:29 UTC 2022 - José Iván López González <jlopez@suse.com>
+
+- Initial CLI

--- a/cli/package/gem2rpm.yml
+++ b/cli/package/gem2rpm.yml
@@ -1,0 +1,5 @@
+---
+# ## used by gem2rpm
+:preamble: |-
+  BuildRequires:  libdbus-1-3
+  Requires:       libdbus-1-3

--- a/cli/test/dinstaller_cli/clients/language_test.rb
+++ b/cli/test/dinstaller_cli/clients/language_test.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "dinstaller_cli/clients/language"
+require "dbus"
+
+describe DInstallerCli::Clients::Language do
+  before do
+    allow(::DBus::SystemBus).to receive(:instance).and_return(bus)
+    allow(bus).to receive(:service).with("org.opensuse.DInstaller").and_return(service)
+    allow(service).to receive(:object).with("/org/opensuse/DInstaller/Language1")
+      .and_return(dbus_object)
+    allow(dbus_object).to receive(:introspect)
+    allow(dbus_object).to receive(:[]).with("org.opensuse.DInstaller.Language1")
+      .and_return(lang_iface)
+  end
+
+  let(:bus) { instance_double(::DBus::SystemBus) }
+  let(:service) { instance_double(::DBus::Service) }
+  let(:dbus_object) { instance_double(::DBus::ProxyObject) }
+  let(:lang_iface) { instance_double(::DBus::ProxyObjectInterface) }
+
+  subject { described_class.new }
+
+  describe "#available_languages" do
+    before do
+      allow(lang_iface).to receive(:[]).with("AvailableLanguages").and_return(
+        [
+          ["en_US", "English (US)", {}],
+          ["en_GB", "English (UK)", {}],
+          ["es_ES", "Español", {}]
+        ]
+      )
+    end
+
+    it "returns the id and name for all available languages" do
+      expect(subject.available_languages).to contain_exactly(
+        ["en_US", "English (US)"],
+        ["en_GB", "English (UK)"],
+        ["es_ES", "Español"]
+      )
+    end
+  end
+
+  describe "#selected_languages" do
+    before do
+      allow(lang_iface).to receive(:[]).with("MarkedForInstall").and_return(["en_US", "es_ES"])
+    end
+
+    it "returns the name of the selected languages" do
+      expect(subject.selected_languages).to contain_exactly("en_US", "es_ES")
+    end
+  end
+
+  describe "#select_languages" do
+    # Using partial double because methods are dynamically added to the proxy object
+    let(:dbus_object) { double(::DBus::ProxyObject) }
+
+    it "selects the given languages" do
+      expect(dbus_object).to receive(:ToInstall).with(["en_GB"])
+
+      subject.select_languages(["en_GB"])
+    end
+  end
+end

--- a/cli/test/dinstaller_cli/clients/manager_test.rb
+++ b/cli/test/dinstaller_cli/clients/manager_test.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "dinstaller_cli/clients/manager"
+require "dbus"
+
+describe DInstallerCli::Clients::Manager do
+  before do
+    allow(::DBus::SystemBus).to receive(:instance).and_return(bus)
+    allow(bus).to receive(:service).with("org.opensuse.DInstaller").and_return(service)
+    allow(service).to receive(:object).with("/org/opensuse/DInstaller/Manager1")
+      .and_return(dbus_object)
+    allow(dbus_object).to receive(:introspect)
+    allow(dbus_object).to receive(:[]).with("org.opensuse.DInstaller.Manager1")
+      .and_return(manager_iface)
+    allow(dbus_object).to receive(:[]).with("org.freedesktop.DBus.Properties")
+      .and_return(properties_iface)
+  end
+
+  let(:bus) { instance_double(::DBus::SystemBus) }
+  let(:service) { instance_double(::DBus::Service) }
+  let(:dbus_object) { instance_double(::DBus::ProxyObject) }
+  let(:manager_iface) { instance_double(::DBus::ProxyObjectInterface) }
+  let(:properties_iface) { instance_double(::DBus::ProxyObjectInterface, on_signal: nil) }
+
+  subject { described_class.new }
+
+  describe "#commit" do
+    # Using partial double because methods are dynamically added to the proxy object
+    let(:dbus_object) { double(::DBus::ProxyObject) }
+
+    it "starts the installation" do
+      expect(dbus_object).to receive(:Commit)
+
+      subject.commit
+    end
+  end
+
+  describe "#status" do
+    before do
+      allow(manager_iface).to receive(:[]).with("Status").and_return(2)
+    end
+
+    it "returns the installation status" do
+      expect(subject.status).to eq(2)
+    end
+  end
+end

--- a/cli/test/dinstaller_cli/clients/software_test.rb
+++ b/cli/test/dinstaller_cli/clients/software_test.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "dinstaller_cli/clients/software"
+require "dbus"
+
+describe DInstallerCli::Clients::Software do
+  before do
+    allow(::DBus::SystemBus).to receive(:instance).and_return(bus)
+    allow(bus).to receive(:service).with("org.opensuse.DInstaller").and_return(service)
+    allow(service).to receive(:object).with("/org/opensuse/DInstaller/Software1")
+      .and_return(dbus_object)
+    allow(dbus_object).to receive(:introspect)
+    allow(dbus_object).to receive(:[]).with("org.opensuse.DInstaller.Software1")
+      .and_return(software_iface)
+  end
+
+  let(:bus) { instance_double(::DBus::SystemBus) }
+  let(:service) { instance_double(::DBus::Service) }
+  let(:dbus_object) { instance_double(::DBus::ProxyObject) }
+  let(:software_iface) { instance_double(::DBus::ProxyObjectInterface) }
+
+  subject { described_class.new }
+
+  describe "#available_products" do
+    before do
+      allow(software_iface).to receive(:[]).with("AvailableBaseProducts").and_return(
+        [
+          ["Tumbleweed", "openSUSE Tumbleweed", {}],
+          ["Leap15.3", "openSUSE Leap 15.3", {}]
+        ]
+      )
+    end
+
+    it "returns the name and display name for all available products" do
+      expect(subject.available_products).to contain_exactly(
+        ["Tumbleweed", "openSUSE Tumbleweed"],
+        ["Leap15.3", "openSUSE Leap 15.3"]
+      )
+    end
+  end
+
+  describe "#selected_product" do
+    before do
+      allow(software_iface).to receive(:[]).with("SelectedBaseProduct").and_return("Tumbleweed")
+    end
+
+    it "returns the name of the selected product" do
+      expect(subject.selected_product).to eq("Tumbleweed")
+    end
+  end
+
+  describe "#select_product" do
+    # Using partial double because methods are dynamically added to the proxy object
+    let(:dbus_object) { double(::DBus::ProxyObject) }
+
+    it "selects the given product" do
+      expect(dbus_object).to receive(:SelectProduct).with("Tumbleweed")
+
+      subject.select_product("Tumbleweed")
+    end
+  end
+end

--- a/cli/test/dinstaller_cli/clients/storage_test.rb
+++ b/cli/test/dinstaller_cli/clients/storage_test.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "dinstaller_cli/clients/storage"
+require "dbus"
+
+describe DInstallerCli::Clients::Storage do
+  before do
+    allow(::DBus::SystemBus).to receive(:instance).and_return(bus)
+    allow(bus).to receive(:service).with("org.opensuse.DInstaller").and_return(service)
+    allow(service).to receive(:object).with("/org/opensuse/DInstaller/Storage/Proposal1")
+      .and_return(dbus_proposal)
+    allow(dbus_proposal).to receive(:introspect)
+    allow(service).to receive(:object).with("/org/opensuse/DInstaller/Storage/Actions1")
+      .and_return(dbus_actions)
+    allow(dbus_actions).to receive(:introspect)
+    allow(dbus_proposal).to receive(:[]).with("org.opensuse.DInstaller.Storage.Proposal1")
+      .and_return(proposal_iface)
+    allow(dbus_actions).to receive(:[]).with("org.opensuse.DInstaller.Storage.Actions1")
+      .and_return(actions_iface)
+  end
+
+  let(:bus) { instance_double(::DBus::SystemBus) }
+  let(:service) { instance_double(::DBus::Service) }
+  let(:dbus_proposal) { instance_double(::DBus::ProxyObject) }
+  let(:dbus_actions) { instance_double(::DBus::ProxyObject) }
+  let(:proposal_iface) { instance_double(::DBus::ProxyObjectInterface) }
+  let(:actions_iface) { instance_double(::DBus::ProxyObjectInterface) }
+
+  subject { described_class.new }
+
+  describe "#available_devices" do
+    before do
+      allow(proposal_iface).to receive(:[]).with("AvailableDevices").and_return(
+        [
+          ["/dev/sda", "/dev/sda (50 GiB)"],
+          ["/dev/sdb", "/dev/sda (20 GiB)"]
+        ]
+      )
+    end
+
+    it "returns the name of all available devices for the installation" do
+      expect(subject.available_devices).to contain_exactly("/dev/sda", "/dev/sdb")
+    end
+  end
+
+  describe "#candidate_devices" do
+    before do
+      allow(proposal_iface).to receive(:[]).with("CandidateDevices").and_return(["/dev/sda"])
+    end
+
+    it "returns the name of the candidate devices for the installation" do
+      expect(subject.candidate_devices).to contain_exactly("/dev/sda")
+    end
+  end
+
+  describe "#calculate" do
+    # Using partial double because methods are dynamically added to the proxy object
+    let(:dbus_proposal) { double(::DBus::ProxyObject) }
+
+    it "calculates the proposal with the given devices" do
+      expect(dbus_proposal).to receive(:Calculate).with({ "CandidateDevices" => ["/dev/sdb"] })
+
+      subject.calculate(["/dev/sdb"])
+    end
+  end
+
+  describe "#actions" do
+    before do
+      allow(actions_iface).to receive(:[]).with("All").and_return(
+        [
+          {
+            "Text"      => "Create GPT on /dev/vdc",
+            "Subvolume" => false
+          },
+          {
+            "Text"      => "Create partition /dev/vdc1 (8.00 MiB) as BIOS Boot Partition",
+            "Subvolume" => false
+          },
+          {
+            "Text"      => "Create partition /dev/vdc2 (27.99 GiB) for / with btrfs",
+            "Subvolume" => false
+          },
+          {
+            "Text"      => "Create partition /dev/vdc3 (2.00 GiB) for swap",
+            "Subvolume" => false
+          }
+        ]
+      )
+    end
+
+    it "returns the actions to perform" do
+      expect(subject.actions).to include(/Create GPT/)
+      expect(subject.actions).to include(/Create partition \/dev\/vdc1/)
+      expect(subject.actions).to include(/Create partition \/dev\/vdc2/)
+      expect(subject.actions).to include(/Create partition \/dev\/vdc3/)
+    end
+  end
+end

--- a/cli/test/dinstaller_cli/clients/users_test.rb
+++ b/cli/test/dinstaller_cli/clients/users_test.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "dinstaller_cli/clients/users"
+require "dbus"
+
+describe DInstallerCli::Clients::Users do
+  before do
+    allow(::DBus::SystemBus).to receive(:instance).and_return(bus)
+    allow(bus).to receive(:service).with("org.opensuse.DInstaller").and_return(service)
+    allow(service).to receive(:object).with("/org/opensuse/DInstaller/Users1")
+      .and_return(dbus_object)
+    allow(dbus_object).to receive(:introspect)
+    allow(dbus_object).to receive(:[]).with("org.opensuse.DInstaller.Users1")
+      .and_return(users_iface)
+  end
+
+  let(:bus) { instance_double(::DBus::SystemBus) }
+  let(:service) { instance_double(::DBus::Service) }
+  let(:dbus_object) { instance_double(::DBus::ProxyObject) }
+  let(:users_iface) { instance_double(::DBus::ProxyObjectInterface) }
+
+  subject { described_class.new }
+
+  describe "#first_user" do
+    before do
+      allow(users_iface).to receive(:[]).with("FirstUser").and_return(
+        ["Test user", "user", true, {}]
+      )
+    end
+
+    it "returns the configuration of the first user" do
+      expect(subject.first_user).to contain_exactly("Test user", "user", true)
+    end
+  end
+
+  describe "#create_first_user" do
+    # Using partial double because methods are dynamically added to the proxy object
+    let(:dbus_object) { double(::DBus::ProxyObject) }
+
+    it "configures the first user" do
+      expect(dbus_object).to receive(:SetFirstUser).with("Test user", "user", "n0ts3cr3t", true, {})
+
+      subject.create_first_user("user",
+        fullname: "Test user", password: "n0ts3cr3t", autologin: true)
+    end
+  end
+
+  describe "#remove_first_user" do
+    # Using partial double because methods are dynamically added to the proxy object
+    let(:dbus_object) { double(::DBus::ProxyObject) }
+
+    it "removes the configuration of the first user" do
+      expect(dbus_object).to receive(:RemoveFirstUser)
+
+      subject.remove_first_user
+    end
+  end
+
+  describe "#root_ssh_key" do
+    before do
+      allow(users_iface).to receive(:[]).with("RootSSHKey").and_return("1234-abcd")
+    end
+
+    it "returns SSH key for root" do
+      expect(subject.root_ssh_key).to eq("1234-abcd")
+    end
+  end
+
+  describe "#root_ssh_key=" do
+    # Using partial double because methods are dynamically added to the proxy object
+    let(:dbus_object) { double(::DBus::ProxyObject) }
+
+    it "sets the SSH key for root" do
+      expect(dbus_object).to receive(:SetRootSSHKey).with("1234-abcd")
+
+      subject.root_ssh_key = "1234-abcd"
+    end
+  end
+
+  describe "#root_password?" do
+    before do
+      allow(users_iface).to receive(:[]).with("RootPasswordSet").and_return(true)
+    end
+
+    it "returns whether the root password is set" do
+      expect(subject.root_password?).to eq(true)
+    end
+  end
+
+  describe "#root_password=" do
+    # Using partial double because methods are dynamically added to the proxy object
+    let(:dbus_object) { double(::DBus::ProxyObject) }
+
+    it "sets the password for root" do
+      expect(dbus_object).to receive(:SetRootPassword).with("n0ts3cr3t", false)
+
+      subject.root_password = "n0ts3cr3t"
+    end
+  end
+
+  describe "#remove_root_info" do
+    # Using partial double because methods are dynamically added to the proxy object
+    let(:dbus_object) { double(::DBus::ProxyObject) }
+
+    it "removes the SSH key and password for root" do
+      expect(dbus_object).to receive(:RemoveRootPassword)
+      expect(dbus_object).to receive(:SetRootSSHKey).with("")
+
+      subject.remove_root_info
+    end
+  end
+end

--- a/cli/test/dinstaller_cli/commands/language_test.rb
+++ b/cli/test/dinstaller_cli/commands/language_test.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "dinstaller_cli/commands/language"
+require "dinstaller_cli/clients/language"
+
+describe DInstallerCli::Commands::Language do
+  subject { described_class.new }
+
+  before do
+    allow(subject).to receive(:puts)
+    allow(DInstallerCli::Clients::Language).to receive(:new).and_return(client)
+  end
+
+  let(:client) { instance_double(DInstallerCli::Clients::Language) }
+
+  describe "available" do
+    before do
+      allow(client).to receive(:available_languages).and_return(languages)
+    end
+
+    let(:languages) { [["en_GB", "English (UK)"], ["en_US", "English (US)"], ["es_ES", "Español"]] }
+
+    it "shows the available languages" do
+      expect(subject).to receive(:puts).with([
+                                               "en_GB - English (UK)",
+                                               "en_US - English (US)",
+                                               "es_ES - Español"
+                                             ])
+
+      subject.available
+    end
+  end
+
+  describe "#selected" do
+    before do
+      allow(client).to receive(:selected_languages).and_return(languages)
+    end
+
+    let(:languages) { ["en_GB"] }
+
+    context "when no language ids are given" do
+      it "shows the currently selected languages" do
+        expect(subject).to receive(:puts).with(languages)
+
+        subject.selected
+      end
+    end
+
+    context "when a language id is given" do
+      it "selects the given language" do
+        expect(client).to receive(:select_languages).with(["es_ES"])
+
+        subject.selected("es_ES")
+      end
+    end
+  end
+end

--- a/cli/test/dinstaller_cli/commands/main_test.rb
+++ b/cli/test/dinstaller_cli/commands/main_test.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "dinstaller_cli/commands/main"
+require "dinstaller_cli/clients/manager"
+
+describe DInstallerCli::Commands::Main do
+  it "includes a 'language' command" do
+    expect(described_class.subcommands).to include("language")
+  end
+
+  it "includes a 'software' command" do
+    expect(described_class.subcommands).to include("software")
+  end
+
+  it "includes a 'storage' command" do
+    expect(described_class.subcommands).to include("storage")
+  end
+
+  it "includes a 'rootuser' command" do
+    expect(described_class.subcommands).to include("rootuser")
+  end
+
+  it "includes a 'user' command" do
+    expect(described_class.subcommands).to include("user")
+  end
+
+  before do
+    allow(DInstallerCli::Clients::Manager).to receive(:new).and_return(client)
+  end
+
+  let(:client) { instance_double(DInstallerCli::Clients::Manager) }
+
+  subject { described_class.new }
+
+  describe "#install" do
+    before do
+      allow(subject).to receive(:ask).and_return(answer)
+      allow(subject).to receive(:puts)
+      allow(client).to receive(:commit)
+    end
+
+    let(:answer) { "n" }
+
+    it "asks for confirmation" do
+      expect(subject).to receive(:ask).with(/start the installation/, anything)
+
+      subject.install
+    end
+
+    context "if the user does not confirm" do
+      let(:answer) { "n" }
+
+      it "does not perform the installation" do
+        expect(client).to_not receive(:commit)
+
+        subject.install
+      end
+    end
+
+    context "if the user confirms" do
+      let(:answer) { "y" }
+
+      it "performs the installation" do
+        expect(client).to receive(:commit)
+
+        subject.install
+      end
+    end
+  end
+
+  describe "#status" do
+    before do
+      allow(client).to receive(:status).and_return(status)
+    end
+
+    context "when the service status is 0" do
+      let(:status) { 0 }
+
+      it "reports 'error'" do
+
+        expect(subject).to receive(:puts).with("error")
+
+        subject.status
+      end
+    end
+
+    context "when the service status is 1" do
+      let(:status) { 1 }
+
+      it "reports 'probing'" do
+
+        expect(subject).to receive(:puts).with("probing")
+
+        subject.status
+      end
+    end
+
+    context "when the service status is 2" do
+      let(:status) { 2 }
+
+      it "reports 'probed'" do
+
+        expect(subject).to receive(:puts).with("probed")
+
+        subject.status
+      end
+    end
+
+    context "when the service status is 3" do
+      let(:status) { 3 }
+
+      it "reports 'installing'" do
+
+        expect(subject).to receive(:puts).with("installing")
+
+        subject.status
+      end
+    end
+
+    context "when the service status is 4" do
+      let(:status) { 4 }
+
+      it "reports 'installed'" do
+
+        expect(subject).to receive(:puts).with("installed")
+
+        subject.status
+      end
+    end
+
+    context "when the service status is 5" do
+      let(:status) { 5 }
+
+      it "reports 'unknown'" do
+
+        expect(subject).to receive(:puts).with("unknown")
+
+        subject.status
+      end
+    end
+  end
+end

--- a/cli/test/dinstaller_cli/commands/root_user_test.rb
+++ b/cli/test/dinstaller_cli/commands/root_user_test.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "dinstaller_cli/commands/root_user"
+require "dinstaller_cli/clients/users"
+
+describe DInstallerCli::Commands::RootUser do
+  subject { described_class.new }
+
+  before do
+    allow(subject).to receive(:puts)
+    allow(DInstallerCli::Clients::Users).to receive(:new).and_return(client)
+  end
+
+  let(:client) { instance_double(DInstallerCli::Clients::Users) }
+
+  describe "#ssh_key" do
+    before do
+      allow(client).to receive(:root_ssh_key).and_return("xyz-123")
+    end
+
+    context "when no SSH key is given" do
+      it "shows the current SSH key" do
+        expect(subject).to receive(:puts).with("xyz-123")
+
+        subject.ssh_key
+      end
+    end
+
+    context "when a SSH key is given" do
+      it "selects the given SSH key" do
+        expect(client).to receive(:root_ssh_key=).with("abc-789")
+
+        subject.ssh_key("abc-789")
+      end
+    end
+  end
+
+  describe "#password" do
+    before do
+      allow(client).to receive(:root_password?).and_return(password_set)
+    end
+
+    context "when no password is given" do
+      context "and the password is not set yet" do
+        let(:password_set) { false }
+
+        it "shows nothing" do
+          expect(subject).to_not receive(:puts)
+
+          subject.password
+        end
+      end
+
+      context "and the password is set" do
+        let(:password_set) { true }
+
+        it "shows <secret>" do
+          expect(subject).to receive(:puts).with("<secret>")
+
+          subject.password
+        end
+      end
+    end
+
+    context "when a password is given" do
+      let(:password_set) { true }
+
+      it "sets the given password" do
+        expect(client).to receive(:root_password=).with("n0ts3cr3t")
+
+        subject.password("n0ts3cr3t")
+      end
+    end
+  end
+
+  describe "#clear" do
+    it "removes root configuration" do
+      expect(client).to receive(:remove_root_info)
+
+      subject.clear
+    end
+  end
+end

--- a/cli/test/dinstaller_cli/commands/software_test.rb
+++ b/cli/test/dinstaller_cli/commands/software_test.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "dinstaller_cli/commands/software"
+require "dinstaller_cli/clients/software"
+
+describe DInstallerCli::Commands::Software do
+  subject { described_class.new }
+
+  before do
+    allow(subject).to receive(:puts)
+    allow(DInstallerCli::Clients::Software).to receive(:new).and_return(client)
+  end
+
+  let(:client) { instance_double(DInstallerCli::Clients::Software) }
+
+  describe "#available_products" do
+    before do
+      allow(client).to receive(:available_products).and_return(products)
+    end
+
+    let(:products) { [["Tumbleweed", "openSUSE Tumbleweed"], ["Leap15.4", "openSUSE Leap 15.4"]] }
+
+    it "shows the available products" do
+      expect(subject).to receive(:puts).with([
+                                               "Tumbleweed - openSUSE Tumbleweed",
+                                               "Leap15.4 - openSUSE Leap 15.4"
+                                             ])
+
+      subject.available_products
+    end
+  end
+
+  describe "#selected_product" do
+    before do
+      allow(client).to receive(:selected_product).and_return("Tumbleweed")
+    end
+
+    context "when no product is given" do
+      it "shows the currently selected product" do
+        expect(subject).to receive(:puts).with("Tumbleweed")
+
+        subject.selected_product
+      end
+    end
+
+    context "when a product is given" do
+      it "selects the given product" do
+        expect(client).to receive(:select_product).with("Leap15.4")
+
+        subject.selected_product("Leap15.4")
+      end
+    end
+  end
+end

--- a/cli/test/dinstaller_cli/commands/storage_test.rb
+++ b/cli/test/dinstaller_cli/commands/storage_test.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "dinstaller_cli/commands/storage"
+require "dinstaller_cli/clients/storage"
+
+describe DInstallerCli::Commands::Storage do
+  subject { described_class.new }
+
+  before do
+    allow(subject).to receive(:puts)
+    allow(DInstallerCli::Clients::Storage).to receive(:new).and_return(client)
+  end
+
+  let(:client) { instance_double(DInstallerCli::Clients::Storage) }
+
+  describe "#available_devices" do
+    before do
+      allow(client).to receive(:available_devices).and_return(devices)
+    end
+
+    let(:devices) { ["/dev/sda", "/dev/sdb"] }
+
+    it "shows the available devices" do
+      expect(subject).to receive(:puts).with(["/dev/sda", "/dev/sdb"])
+
+      subject.available_devices
+    end
+  end
+
+  describe "#selected_devices" do
+    before do
+      allow(client).to receive(:candidate_devices).and_return(["/dev/sda"])
+    end
+
+    context "when no device is given" do
+      it "shows the currently selected devices" do
+        expect(subject).to receive(:puts).with(["/dev/sda"])
+
+        subject.selected_devices
+      end
+    end
+
+    context "when a device is given" do
+      it "calculates the proposal with the given device" do
+        expect(client).to receive(:calculate).with(["/dev/sdb"])
+
+        subject.selected_devices("/dev/sdb")
+      end
+    end
+  end
+
+  describe "#actions" do
+    before do
+      allow(client).to receive(:actions).and_return(actions)
+    end
+
+    let(:actions) do
+      [
+        "Create GPT on /dev/vdc",
+        "Create partition /dev/vdc1 (8.00 MiB) as BIOS Boot Partition",
+        "Create partition /dev/vdc2 (27.99 GiB) for / with btrfs",
+        "Create partition /dev/vdc3 (2.00 GiB) for swap"
+      ]
+    end
+
+    it "shows the actions to perform" do
+      expect(subject).to receive(:puts).with(actions)
+
+      subject.actions
+    end
+  end
+end

--- a/cli/test/dinstaller_cli/commands/user_test.rb
+++ b/cli/test/dinstaller_cli/commands/user_test.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "dinstaller_cli/commands/user"
+require "dinstaller_cli/clients/users"
+
+describe DInstallerCli::Commands::User do
+  subject { described_class.new }
+
+  before do
+    allow(subject).to receive(:puts)
+    allow(DInstallerCli::Clients::Users).to receive(:new).and_return(client)
+  end
+
+  let(:client) { instance_double(DInstallerCli::Clients::Users) }
+
+  describe "#set" do
+    it "sets the first user config" do
+      expect(client).to receive(:create_first_user).with("test", anything)
+
+      subject.set("test")
+    end
+  end
+
+  describe "#show" do
+    before do
+      allow(client).to receive(:first_user).and_return(config)
+    end
+
+    context "when no user is configured" do
+      let(:config) { [] }
+
+      it "shows nothing" do
+        expect(subject).to_not receive(:puts)
+      end
+    end
+
+    context "when a user is configured" do
+      let(:config) { ["Test user", "test", true] }
+
+      it "shows the first user config" do
+        expect(subject).to receive(:puts).with(/Full Name: Test user/)
+        expect(subject).to receive(:puts).with(/Name: test/)
+        expect(subject).to receive(:puts).with(/Autologin: yes/)
+
+        subject.show
+      end
+    end
+  end
+
+  describe "#clear" do
+    it "removes the first user config" do
+      expect(client).to receive(:remove_first_user)
+
+      subject.clear
+    end
+  end
+end

--- a/cli/test/test_helper.rb
+++ b/cli/test/test_helper.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "yast/rspec"
+
+SRC_PATH = File.expand_path("../lib", __dir__)
+FIXTURES_PATH = File.expand_path("fixtures", __dir__)
+$LOAD_PATH.unshift(SRC_PATH)
+
+# make sure we run the tests in English locale
+# (some tests check the output which is marked for translation)
+ENV["LC_ALL"] = "en_US.UTF-8"
+
+if ENV["COVERAGE"]
+  require "simplecov"
+  SimpleCov.start do
+    add_filter "/test/"
+  end
+
+  # track all ruby files under src
+  SimpleCov.track_files("#{SRC_PATH}/**/*.rb")
+
+  # additionally use the LCOV format for on-line code coverage reporting at CI
+  if ENV["CI"] || ENV["COVERAGE_LCOV"]
+    require "simplecov-lcov"
+
+    SimpleCov::Formatter::LcovFormatter.config do |c|
+      c.report_with_single_file = true
+      # this is the default Coveralls GitHub Action location
+      # https://github.com/marketplace/actions/coveralls-github-action
+      c.single_report_path = "coverage/lcov.info"
+    end
+
+    formatters = [
+      SimpleCov::Formatter::HTMLFormatter, SimpleCov::Formatter::LcovFormatter
+    ]
+    SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(formatters)
+  end
+end


### PR DESCRIPTION
## Feature

This PR implements the first version of a CLI for the DInstaller service. Note, this CLI is a quick and initial proposal. The idea is to have somenthing to present in the openSUSE Conference 22 in order to show how the web UI reacts to changes performed from the CLI. All the commands will be revisited later. Moreover, we will reevaluate whether to continue using ruby or to reimplement the CLI with a different (compiled) language. 

This CLI provides the following commands:

~~~
dinstallerctl help COMMAND
dinstallerctl status
dinstallerctl install
dinstallerctl language SUBCOMMAND
dinstallerctl software SUBCOMMAND
dinstallerctl storage SUBCOMMAND
dinstallerctl rootuser SUBCOMMAND
dinstallerctl user SUBCOMMAND
~~~

In general, evething that can be done with the web UI can also be done with the CLI, excepts answering questions. This CLI will be extended to support installation from a config file.

Related to:

* https://trello.com/c/qjBEtfg0/2961-8-d-installer-build-a-cli-to-install-the-system-from-an-autoyast-like-profile
* https://github.com/yast/d-installer/issues/163


## Testing

- Added unit tests
- Tested manually

## Screenshots

![d-installer-cli](https://user-images.githubusercontent.com/1112304/170696938-ad10f3a1-6332-4c38-ab8a-1d96f6bc23e9.gif)

