### PR TITLE
adds security manager with default apparmor for now

### DIFF
--- a/service/lib/dinstaller/manager.rb
+++ b/service/lib/dinstaller/manager.rb
@@ -22,16 +22,17 @@
 require "yast"
 require "bootloader/proposal_client"
 require "bootloader/finish_client"
-require "dinstaller/config"
 require "dinstaller/cockpit_manager"
+require "dinstaller/config"
 require "dinstaller/language"
 require "dinstaller/network"
 require "dinstaller/progress"
+require "dinstaller/questions_manager"
+require "dinstaller/security"
 require "dinstaller/software"
 require "dinstaller/status_manager"
 require "dinstaller/storage"
 require "dinstaller/users"
-require "dinstaller/questions_manager"
 
 Yast.import "Stage"
 
@@ -108,6 +109,7 @@ module DInstaller
         network.install(progress)
 
         progress.next_step("Installing Bootloader")
+        security.write(progress)
         ::Bootloader::FinishClient.new.write
 
         progress.next_step("Saving Language Settings")
@@ -167,6 +169,14 @@ module DInstaller
       @storage ||= Storage::Manager.new(logger)
     end
 
+    # Security manager
+    #
+    # @return [Security]
+    def security
+      @security ||= Security.new(logger)
+    end
+
+
   private
 
     # Initializes YaST
@@ -196,6 +206,7 @@ module DInstaller
       storage.probe(progress, questions_manager)
 
       progress.next_step("Probing Software")
+      security.probe(progress)
       software.probe(progress)
 
       progress.next_step("Probing Network")

--- a/service/lib/dinstaller/manager.rb
+++ b/service/lib/dinstaller/manager.rb
@@ -176,7 +176,6 @@ module DInstaller
       @security ||= Security.new(logger)
     end
 
-
   private
 
     # Initializes YaST
@@ -196,6 +195,7 @@ module DInstaller
     # Performs probe steps
     #
     # Status and progress are properly updated during the process.
+    # rubocop:disable Metrics/AbcSize
     def probe_steps
       status_manager.change(Status::Probing.new)
 
@@ -216,6 +216,7 @@ module DInstaller
 
       status_manager.change(Status::Probed.new)
     end
+    # rubocop:enable Metrics/AbcSize
 
     # Performs required steps after installing the system
     #

--- a/service/lib/dinstaller/security.rb
+++ b/service/lib/dinstaller/security.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "y2security/lsm"
+require "yast2/execute"
+
+module DInstaller
+  # Backend class between dbus service and yast code
+  class Users
+    def initialize(logger)
+      @logger = logger
+    end
+
+    def write(_progress)
+      config.save
+    end
+
+    def probe(_progress)
+      # TODO: hardcoded apparmor here instead of calling `.propose_default`
+      # as we soon change it to value from config.yml
+      config.select(:apparmor)
+    end
+
+  private
+
+    def config
+      Y2Security::LSM::Config.instance
+    end
+  end
+end

--- a/service/lib/dinstaller/security.rb
+++ b/service/lib/dinstaller/security.rb
@@ -25,7 +25,7 @@ require "yast2/execute"
 
 module DInstaller
   # Backend class between dbus service and yast code
-  class Users
+  class Security
     def initialize(logger)
       @logger = logger
     end

--- a/service/test/dinstaller/manager_test.rb
+++ b/service/test/dinstaller/manager_test.rb
@@ -35,6 +35,7 @@ describe DInstaller::Manager do
   let(:users) { instance_double(DInstaller::Users, write: nil) }
   let(:network) { instance_double(DInstaller::Network, probe: nil, install: nil) }
   let(:storage) { instance_double(DInstaller::Storage::Manager, probe: nil, install: nil) }
+  let(:security) { instance_double(DInstaller::Security, probe: nil, write: nil) }
   let(:status_manager) do
     instance_double(DInstaller::StatusManager, change: nil)
   end
@@ -43,6 +44,7 @@ describe DInstaller::Manager do
   before do
     allow(DInstaller::Language).to receive(:new).and_return(language)
     allow(DInstaller::Network).to receive(:new).and_return(network)
+    allow(DInstaller::Security).to receive(:new).and_return(security)
     allow(DInstaller::Software).to receive(:new).and_return(software)
     allow(DInstaller::StatusManager).to receive(:new).and_return(status_manager)
     allow(DInstaller::Storage::Manager).to receive(:new).and_return(storage)
@@ -60,6 +62,7 @@ describe DInstaller::Manager do
 
     it "calls #probe method of each module passing a progress object" do
       expect(software).to receive(:probe).with(subject.progress)
+      expect(security).to receive(:probe).with(subject.progress)
       expect(language).to receive(:probe).with(subject.progress)
       expect(network).to receive(:probe).with(subject.progress)
       expect(storage).to receive(:probe).with(subject.progress, subject.questions_manager)
@@ -83,6 +86,7 @@ describe DInstaller::Manager do
       expect(language).to receive(:install).with(subject.progress)
       expect(network).to receive(:install).with(subject.progress)
       expect(software).to receive(:install).with(subject.progress)
+      expect(security).to receive(:write).with(subject.progress)
       expect(storage).to receive(:install).with(subject.progress)
       expect(users).to receive(:write).with(subject.progress)
       subject.install

--- a/setup.sh
+++ b/setup.sh
@@ -4,7 +4,7 @@
 # package. This script is supposed to run within a repository clone.
 
 sudo zypper --non-interactive install gcc gcc-c++ make openssl-devel ruby-devel \
-  npm git augeas-devel cockpit || exit 1
+  npm git augeas-devel cockpit jemalloc-devel || exit 1
 
 sudo systemctl start cockpit
 

--- a/setup.sh
+++ b/setup.sh
@@ -14,6 +14,7 @@ cd service; bundle config set --local path 'vendor/bundle'; bundle install; cd -
 
 # set up the web UI
 cd web; make devel-install; cd -
+sudo ln -s `pwd`/web/dist /usr/share/cockpit/d-installer
 
 # Start the installer
 echo -e "\nStart the d-installer service:\n  cd service; sudo bundle exec bin/d-installer\n"

--- a/web/Makefile
+++ b/web/Makefile
@@ -85,16 +85,15 @@ install: $(WEBPACK_TEST) po/LINGUAS
 		--template $(APPSTREAMFILE) \
 		-o $(DESTDIR)/usr/share/metainfo/$(APPSTREAMFILE)
 
-# this requires a built source tree and avoids having to install anything system-wide
+# this requires a built source tree and register that build sources to cockpit
+# running on systemd
 devel-install: $(WEBPACK_TEST)
-	mkdir -p ~/.local/share/cockpit
-	rm -f ~/.local/share/cockpit/$(PACKAGE_NAME)
-	ln -s `pwd`/dist ~/.local/share/cockpit/$(PACKAGE_NAME)
+	ln -s `pwd`/dist /usr/share/cockpit/$(PACKAGE_NAME)
 
 # assumes that there was symlink set up using the above devel-install target,
 # and removes it
 devel-uninstall:
-	rm -f ~/.local/share/cockpit/$(PACKAGE_NAME)
+	rm -f /usr/share/cockpit/$(PACKAGE_NAME)
 
 print-version:
 	@echo "$(VERSION)"

--- a/web/Makefile
+++ b/web/Makefile
@@ -85,15 +85,16 @@ install: $(WEBPACK_TEST) po/LINGUAS
 		--template $(APPSTREAMFILE) \
 		-o $(DESTDIR)/usr/share/metainfo/$(APPSTREAMFILE)
 
-# this requires a built source tree and register that build sources to cockpit
-# running on systemd
+# this requires a built source tree and avoids having to install anything system-wide
 devel-install: $(WEBPACK_TEST)
-	ln -s `pwd`/dist /usr/share/cockpit/$(PACKAGE_NAME)
+	mkdir -p ~/.local/share/cockpit
+	rm -f ~/.local/share/cockpit/$(PACKAGE_NAME)
+	ln -s `pwd`/dist ~/.local/share/cockpit/$(PACKAGE_NAME)
 
 # assumes that there was symlink set up using the above devel-install target,
 # and removes it
 devel-uninstall:
-	rm -f /usr/share/cockpit/$(PACKAGE_NAME)
+	rm -f ~/.local/share/cockpit/$(PACKAGE_NAME)
 
 print-version:
 	@echo "$(VERSION)"


### PR DESCRIPTION
## Problem

- https://trello.com/c/iUf1tmUy

Configuration of security manager is missing. This is different from TW where apparmor is used by default and also needed for experimental microos installer as it needs selinux there.


## Solution

Start with trivial security manager using yast backend.


## Testing

- *Tested manually*

