### PR TITLE
Remove Restart Button

### DIFF
--- a/web/src/InstallationFinished.jsx
+++ b/web/src/InstallationFinished.jsx
@@ -39,11 +39,8 @@ import {
   EOS_CHECK_CIRCLE as SectionIcon
 } from "eos-icons-react";
 
-const Actions = ({ onRestart, onReboot }) => (
+const Actions = ({ onReboot }) => (
   <>
-    <Button isLarge variant="secondary" onClick={onRestart}>
-      Restart Installation
-    </Button>
     <Button isLarge variant="primary" onClick={onReboot}>
       Reboot
     </Button>
@@ -52,14 +49,13 @@ const Actions = ({ onRestart, onReboot }) => (
 
 function InstallationFinished() {
   const client = useInstallerClient();
-  const onRestartAction = () => client.manager.startProbing();
   const onRebootAction = () => client.manager.rebootSystem();
 
   return (
     <Layout
       sectionTitle="Installation Finished"
       SectionIcon={SectionIcon}
-      FooterActions={() => <Actions onRestart={onRestartAction} onReboot={onRebootAction} />}
+      FooterActions={() => <Actions onReboot={onRebootAction} />}
     >
       <Center>
         <EmptyState>
@@ -71,8 +67,7 @@ function InstallationFinished() {
             <div>
               <Text>The installation on your machine is complete.</Text>
               <Text>
-                At this point you can 'Restart installation' to continue playing with D-Installer or
-                'Reboot' the machine to log in to the new system.
+                At this point you can 'Reboot' the machine to log in to the new system.
               </Text>
               <Text>Have a lot of fun! Your openSUSE Development Team.</Text>
             </div>

--- a/web/src/InstallationFinished.test.jsx
+++ b/web/src/InstallationFinished.test.jsx
@@ -37,7 +37,6 @@ describe("InstallationFinished", () => {
     createClient.mockImplementation(() => {
       return {
         manager: {
-          startProbing: startProbingFn,
           rebootSystem: rebootSystemFn
         }
       };
@@ -50,24 +49,10 @@ describe("InstallationFinished", () => {
     await screen.findByText("Congratulations!");
   });
 
-  it("shows a 'Restart Installation' button", async () => {
-    installerRender(<InstallationFinished />);
-
-    await screen.findByRole("button", { name: /Restart Installation/i });
-  });
-
   it("shows a 'Reboot' button", async () => {
     installerRender(<InstallationFinished />);
 
     await screen.findByRole("button", { name: /Reboot/i });
-  });
-
-  it("starts the probing process if user clicks on 'Restart Installation' button", async () => {
-    const { user } = installerRender(<InstallationFinished />);
-
-    const button = await screen.findByRole("button", { name: /Restart Installation/i });
-    await user.click(button);
-    expect(startProbingFn).toHaveBeenCalled();
   });
 
   it("reboots the system if the user clicks on 'Reboot' button", async () => {


### PR DESCRIPTION
## Problem

Users are confused by restart installer button at the end of installation. Also it is not needed for developement, as we can restart service by hand.

trello: https://trello.com/c/8zfxnWQs/2968-1-d-installer-drop-the-restart-installation-button


## Solution

Remove the button.


## Testing

- *Tested manually*

