### PR TITLE
refresh the UI when detected DBUS object changes

### DIFF
--- a/service/Gemfile.lock
+++ b/service/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    d-installer (0.1)
+    d-installer (0.2)
       cfa (~> 1.0.2)
       cfa_grub2 (~> 2.0.0)
       cheetah (~> 1.0.0)
@@ -26,11 +26,11 @@ GEM
     docile (1.4.0)
     eventmachine (1.2.7)
     fast_gettext (2.2.0)
-    mini_portile2 (2.7.1)
-    nokogiri (1.13.1)
-      mini_portile2 (~> 2.7.0)
+    mini_portile2 (2.8.0)
+    nokogiri (1.13.6)
+      mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
-    nokogiri (1.13.1-x86_64-linux)
+    nokogiri (1.13.6-x86_64-linux)
       racc (~> 1.4)
     packaging_rake_tasks (1.5.1)
       rake
@@ -51,7 +51,7 @@ GEM
       rspec-support (~> 3.11.0)
     rspec-support (3.11.0)
     ruby-augeas (0.5.0)
-    ruby-dbus (0.18.0.beta5)
+    ruby-dbus (0.18.0.beta6)
       rexml
     simplecov (0.21.2)
       docile (~> 1.1)

--- a/service/lib/dinstaller/dbus/users.rb
+++ b/service/lib/dinstaller/dbus/users.rb
@@ -89,7 +89,7 @@ module DInstaller
           logger.info "Removing the first user"
           backend.remove_first_user
 
-          PropertiesChanged(USERS_INTERFACE, { "FirstUser" => {} }, [])
+          PropertiesChanged(USERS_INTERFACE, { "FirstUser" => first_user }, [])
           0
         end
       end

--- a/web/src/FirstUser.jsx
+++ b/web/src/FirstUser.jsx
@@ -53,6 +53,14 @@ export default function Users() {
     });
   }, [client.users]);
 
+  useEffect(() => {
+    return client.users.onUsersChange(changes => {
+      if (changes.firstUser !== undefined) {
+        setUser(changes.firstUser);
+      }
+    });
+  }, [client.users]);
+
   if (user === null) return <Skeleton width="50%" fontSize="sm" />;
 
   const open = () => {

--- a/web/src/InstallationFinished.test.jsx
+++ b/web/src/InstallationFinished.test.jsx
@@ -29,7 +29,6 @@ import InstallationFinished from "./InstallationFinished";
 
 jest.mock("./client");
 
-const startProbingFn = jest.fn();
 const rebootSystemFn = jest.fn();
 
 describe("InstallationFinished", () => {

--- a/web/src/LanguageSelector.jsx
+++ b/web/src/LanguageSelector.jsx
@@ -49,6 +49,10 @@ const reducer = (state, action) => {
       return { ...state, formCurrent: action.payload };
     }
 
+    case "MODIFIED": {
+      return { ...state, current: action.payload };
+    }
+
     case "OPEN": {
       return { ...state, isFormOpen: true, formCurrent: state.current };
     }
@@ -82,6 +86,15 @@ export default function LanguageSelector() {
     };
 
     loadLanguages().catch(console.error);
+  }, [client.language]);
+
+  useEffect(() => {
+    return client.language.onLanguageChange(changes => {
+      dispatch({
+        type: "MODIFIED",
+        payload: changes.current
+      });
+    });
   }, [client.language]);
 
   const open = () => dispatch({ type: "OPEN" });

--- a/web/src/Overview.test.jsx
+++ b/web/src/Overview.test.jsx
@@ -47,15 +47,18 @@ beforeEach(() => {
       storage: {
         getStorageProposal: () => Promise.resolve(proposal),
         getStorageActions: () => Promise.resolve(actions),
-        onActionsChange: jest.fn()
+        onActionsChange: jest.fn(),
+        onStorageProposalChange: jest.fn()
       },
       language: {
         getLanguages: () => Promise.resolve(languages),
-        getSelectedLanguages: () => Promise.resolve(["en_US"])
+        getSelectedLanguages: () => Promise.resolve(["en_US"]),
+        onLanguageChange: jest.fn()
       },
       software: {
         getProducts: () => Promise.resolve(products),
-        getSelectedProduct: () => Promise.resolve("openSUSE")
+        getSelectedProduct: () => Promise.resolve("openSUSE"),
+        onProductChange: jest.fn()
       },
       manager: {
         startInstallation: startInstallationFn
@@ -63,7 +66,8 @@ beforeEach(() => {
       users: {
         getUser: () => Promise.resolve(fakeUser),
         isRootPasswordSet: () => Promise.resolve(true),
-        getRootSSHKey: () => Promise.resolve("ssh-rsa")
+        getRootSSHKey: () => Promise.resolve("ssh-rsa"),
+        onUsersChange: jest.fn()
       }
     };
   });

--- a/web/src/ProductSelector.jsx
+++ b/web/src/ProductSelector.jsx
@@ -84,6 +84,15 @@ export default function ProductSelector() {
     loadProducts().catch(console.error);
   }, [client.software]);
 
+  useEffect(() => {
+    return client.software.onProductChange(changes => {
+      dispatch({
+        type: "CHANGE",
+        payload: changes
+      });
+    });
+  }, [client.software]);
+
   const open = () => dispatch({ type: "OPEN" });
 
   const cancel = () => dispatch({ type: "CANCEL" });

--- a/web/src/ProductSelector.test.jsx
+++ b/web/src/ProductSelector.test.jsx
@@ -20,7 +20,7 @@
  */
 
 import React from "react";
-import { screen, within } from "@testing-library/react";
+import { act, screen, within } from "@testing-library/react";
 import { installerRender } from "./test-utils";
 import ProductSelector from "./ProductSelector";
 import { createClient } from "./client";
@@ -38,6 +38,7 @@ const softwareMock = {
 };
 
 const selectProductFn = jest.fn().mockResolvedValue();
+let onProductChangeFn = jest.fn();
 
 beforeEach(() => {
   // if defined outside, the mock is cleared automatically
@@ -45,7 +46,8 @@ beforeEach(() => {
     return {
       software: {
         ...softwareMock,
-        selectProduct: selectProductFn
+        selectProduct: selectProductFn,
+        onProductChange: onProductChangeFn
       }
     };
   });
@@ -73,5 +75,25 @@ describe("when the user changes the product", () => {
     await screen.findByRole("button", { name: "openSUSE Tumbleweed" });
     expect(selectProductFn).toHaveBeenCalledWith("openSUSE");
     expect(selectProductFn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("when the Product Selection change", () => {
+  let callbacks;
+
+  beforeEach(() => {
+    callbacks = [];
+    onProductChangeFn = cb => callbacks.push(cb);
+  });
+
+  it("updates the proposal", async () => {
+    installerRender(<ProductSelector />);
+    await screen.findByRole("button", { name: "openSUSE MicroOS" });
+
+    const [cb] = callbacks;
+    act(() => {
+      cb("openSUSE");
+    });
+    await screen.findByRole("button", { name: "openSUSE Tumbleweed" });
   });
 });

--- a/web/src/RootPassword.jsx
+++ b/web/src/RootPassword.jsx
@@ -45,6 +45,14 @@ export default function RootPassword() {
       .catch(console.error);
   }, [client.users]);
 
+  useEffect(() => {
+    return client.users.onUsersChange(changes => {
+      if (changes.rootPasswordSet !== undefined) {
+        setIsRootPasswordSet(changes.rootPasswordSet);
+      }
+    });
+  }, [client.users]);
+
   if (isRootPasswordSet === null) return <Skeleton width="60%" fontSize="sm" />;
 
   const open = () => setIsFormOpen(true);

--- a/web/src/RootSSHKey.jsx
+++ b/web/src/RootSSHKey.jsx
@@ -45,6 +45,14 @@ export default function RootSSHKey() {
       .catch(console.error);
   }, [client.users]);
 
+  useEffect(() => {
+    return client.users.onUsersChange(changes => {
+      if (changes.rootSSHKey !== undefined) {
+        setSSHKey(changes.rootSSHKey);
+      }
+    });
+  }, [client.users]);
+
   if (sshKey === null) return <Skeleton width="55%" fontSize="sm" />;
 
   const open = () => {

--- a/web/src/Storage.jsx
+++ b/web/src/Storage.jsx
@@ -67,14 +67,14 @@ export default function Storage() {
   useEffect(() => {
     const loadStorage = async () => {
       const {
-        availableDevices: disks,
-        candidateDevices: [disk]
+        availableDevices,
+        candidateDevices: [candidateDeviceId]
       } = await client.storage.getStorageProposal();
       const actions = await client.storage.getStorageActions();
-      const target = disk || disks[0]?.id;
+      const targetDeviceId = candidateDeviceId || availableDevices[0]?.id;
       dispatch({
         type: "LOAD",
-        payload: { target, targets: disks, actions }
+        payload: { target: targetDeviceId, targets: availableDevices, actions }
       });
     };
 
@@ -89,7 +89,7 @@ export default function Storage() {
   }, [client.storage]);
 
   useEffect(() => {
-    return client.storage.onTargetChange(changes => {
+    return client.storage.onStorageProposalChange(changes => {
       dispatch({ type: "CHANGE_TARGET", payload: { selected: changes } });
     });
   }, [client.storage]);

--- a/web/src/Storage.jsx
+++ b/web/src/Storage.jsx
@@ -71,9 +71,10 @@ export default function Storage() {
         candidateDevices: [disk]
       } = await client.storage.getStorageProposal();
       const actions = await client.storage.getStorageActions();
+      const target = disk || disks[0]?.id;
       dispatch({
         type: "LOAD",
-        payload: { target: disk, targets: disks, actions }
+        payload: { target, targets: disks, actions }
       });
     };
 
@@ -84,6 +85,12 @@ export default function Storage() {
     return client.storage.onActionsChange(changes => {
       const { All: newActions } = changes;
       dispatch({ type: "UPDATE_ACTIONS", payload: newActions });
+    });
+  }, [client.storage]);
+
+  useEffect(() => {
+    return client.storage.onTargetChange(changes => {
+      dispatch({ type: "CHANGE_TARGET", payload: { selected: changes } });
     });
   }, [client.storage]);
 

--- a/web/src/Storage.test.jsx
+++ b/web/src/Storage.test.jsx
@@ -37,6 +37,7 @@ const proposalSettings = {
 };
 
 let onActionsChangeFn = jest.fn();
+let onStorageProposalChangeFn = jest.fn();
 let calculateStorageProposalFn;
 
 const storageMock = {
@@ -51,7 +52,8 @@ beforeEach(() => {
       storage: {
         ...storageMock,
         calculateStorageProposal: calculateStorageProposalFn,
-        onActionsChange: onActionsChangeFn
+        onActionsChange: onActionsChangeFn,
+        onStorageProposalChange: onStorageProposalChangeFn
       }
     };
   });
@@ -96,7 +98,27 @@ describe("when the user selects another disk", () => {
   });
 });
 
-describe("when the proposal changes", () => {
+describe("when the storage proposal changes", () => {
+  let callbacks;
+
+  beforeEach(() => {
+    callbacks = [];
+    onStorageProposalChangeFn = cb => callbacks.push(cb);
+  });
+
+  it("updates the proposal", async () => {
+    installerRender(<Storage />);
+    await screen.findByRole("button", { name: "/dev/sda" });
+
+    const [cb] = callbacks;
+    act(() => {
+      cb("/dev/sdb");
+    });
+    await screen.findByRole("button", { name: "/dev/sdb" });
+  });
+});
+
+describe("when the storage actions changes", () => {
   let callbacks;
 
   beforeEach(() => {

--- a/web/src/client/language.js
+++ b/web/src/client/language.js
@@ -22,6 +22,7 @@
 import { applyMixin, withDBus } from "./mixins";
 
 const LANGUAGE_IFACE = "org.opensuse.DInstaller.Language1";
+const LANGUAGE_PATH = "/org/opensuse/DInstaller/Language1";
 
 export default class LanguageClient {
   constructor(dbusClient) {
@@ -60,6 +61,18 @@ export default class LanguageClient {
   async setLanguages(langIDs) {
     const proxy = await this.proxy(LANGUAGE_IFACE);
     return proxy.ToInstall(langIDs);
+  }
+
+  /**
+   * Register a callback to run when properties in the Language object change
+   *
+   * @param {function} handler - callback function
+   */
+  onLanguageChange(handler) {
+    return this.onObjectChanged(LANGUAGE_PATH, changes => {
+      const selected = changes.MarkedForInstall.v[0];
+      handler({ current: selected.v });
+    });
   }
 }
 

--- a/web/src/client/software.js
+++ b/web/src/client/software.js
@@ -22,6 +22,7 @@
 import { applyMixin, withDBus } from "./mixins";
 
 const SOFTWARE_IFACE = "org.opensuse.DInstaller.Software1";
+const SOFTWARE_PATH = "/org/opensuse/DInstaller/Software1";
 
 export default class SoftwareClient {
   constructor(dbusClient) {
@@ -49,6 +50,18 @@ export default class SoftwareClient {
   async selectProduct(id) {
     const proxy = await this.proxy(SOFTWARE_IFACE);
     return proxy.SelectProduct(id);
+  }
+
+  /**
+   * Register a callback to run when properties in the Software object change
+   *
+   * @param {function} handler - callback function
+   */
+  onProductChange(handler) {
+    return this.onObjectChanged(SOFTWARE_PATH, changes => {
+      const selected = changes.SelectedBaseProduct.v;
+      handler(selected);
+    });
   }
 }
 

--- a/web/src/client/storage.js
+++ b/web/src/client/storage.js
@@ -25,7 +25,7 @@ import { applyMixin, withDBus } from "./mixins";
 const STORAGE_PROPOSAL_IFACE = "org.opensuse.DInstaller.Storage.Proposal1";
 const STORAGE_ACTIONS_IFACE = "org.opensuse.DInstaller.Storage.Actions1";
 const ACTIONS_PATH = "/org/opensuse/DInstaller/Storage/Actions1";
-const TARGET_PATH = "/org/opensuse/DInstaller/Storage/Proposal1";
+const STORAGE_PROPOSAL_PATH = "/org/opensuse/DInstaller/Storage/Proposal1";
 
 export default class StorageClient {
   constructor(dbusClient) {
@@ -84,12 +84,12 @@ export default class StorageClient {
   }
 
   /**
-   * Register a callback to run when properties in the Target object change
+   * Register a callback to run when properties in the Storage Proposal object change
    *
    * @param {function} handler - callback function
    */
-  onTargetChange(handler) {
-    return this.onObjectChanged(TARGET_PATH, changes => {
+  onStorageProposalChange(handler) {
+    return this.onObjectChanged(STORAGE_PROPOSAL_PATH, changes => {
       const [selected] = changes.CandidateDevices.v;
       handler(selected.v);
     });

--- a/web/src/client/storage.js
+++ b/web/src/client/storage.js
@@ -25,6 +25,7 @@ import { applyMixin, withDBus } from "./mixins";
 const STORAGE_PROPOSAL_IFACE = "org.opensuse.DInstaller.Storage.Proposal1";
 const STORAGE_ACTIONS_IFACE = "org.opensuse.DInstaller.Storage.Actions1";
 const ACTIONS_PATH = "/org/opensuse/DInstaller/Storage/Actions1";
+const TARGET_PATH = "/org/opensuse/DInstaller/Storage/Proposal1";
 
 export default class StorageClient {
   constructor(dbusClient) {
@@ -79,6 +80,18 @@ export default class StorageClient {
         return { text: textVar.v, subvol: subvolVar.v, delete: deleteVar.v };
       });
       handler({ All: newActions });
+    });
+  }
+
+  /**
+   * Register a callback to run when properties in the Target object change
+   *
+   * @param {function} handler - callback function
+   */
+  onTargetChange(handler) {
+    return this.onObjectChanged(TARGET_PATH, changes => {
+      const [selected] = changes.CandidateDevices.v;
+      handler(selected.v);
     });
   }
 }

--- a/web/src/client/users.js
+++ b/web/src/client/users.js
@@ -1,4 +1,5 @@
 /*
+const USERS_IFACE = "org.opensuse.DInstaller.Users1";
  * Copyright (c) [2022] SUSE LLC
  *
  * All Rights Reserved.
@@ -22,6 +23,7 @@
 import { applyMixin, withDBus } from "./mixins";
 
 const USERS_IFACE = "org.opensuse.DInstaller.Users1";
+const USERS_PATH = "/org/opensuse/DInstaller/Users1";
 
 export default class UsersClient {
   constructor(dbusClient) {
@@ -121,6 +123,24 @@ export default class UsersClient {
     const proxy = await this.proxy(USERS_IFACE);
     const result = await proxy.SetRootSSHKey(key);
     return result === 0;
+  }
+
+  /**
+   * Register a callback to run when properties in the Users object change
+   *
+   * @param {function} handler - callback function
+   */
+  onUsersChange(handler) {
+    return this.onObjectChanged(USERS_PATH, changes => {
+      if (changes.RootPasswordSet) {
+        return handler({ rootPasswordSet: changes.RootPasswordSet.v });
+      } else if (changes.RootSSHKey) {
+        return handler({ rootSSHKey: changes.RootSSHKey.v });
+      } else if (changes.FirstUser) {
+        const [{ v: fullName }, { v: userName }, { v: autologin }] = changes.FirstUser.v;
+        return handler({ firstUser: { fullName, userName, autologin } });
+      }
+    });
   }
 }
 


### PR DESCRIPTION
## Problem

The UI gets refreshed when the status or the storage actions change, no matter where the change comes from (busctl, the new CLI [#166](https://github.com/yast/d-installer/pull/166), etc.). However, that's not the case for other configuration values. For instance, if you change the language via D-Bus, the web UI does not get updated.

We should implement support to refresh the interface in those situations.

- https://trello.com/c/ygoE9Xdx/2970-2-d-installer-refresh-the-web-ui-when-a-configuration-option-changes

## Solution

All the components are now subscribed to DBus object changes refreshing the UI accordingly. 

## Testing

- *Added a new unit test*
- *Tested manually*

## Screenshots

- See the demo [here](https://youtu.be/jTZ8XwvHBfQ?t=115)
