### PR TITLE
extend config with security and more software settings

### DIFF
--- a/doc/yaml_config.md
+++ b/doc/yaml_config.md
@@ -28,6 +28,40 @@ Software manager related options. It is map with following keys:
 
 Array of url for installation repositories.
 
+#### mandatory\_patterns
+
+Array of patterns that have to be selected.
+
+#### optional\_patterns
+
+Array of patterns that should be selected but can be deselected or skipped if not available.
+
+### security
+
+Options related to security
+
+#### lsm
+
+Default linux security module. Currently supported values are `selinux`, `apparmor` and `none`.
+
+#### available\_lsms
+
+Map for available linux security modules. If only one module is
+available it means that lsm is not configurable.
+
+##### patterns
+
+Required patterns for given lsm to be selected.
+
+##### policy
+
+Default policy. Only applicable for selinux lsm.
+
+
+#### selinux\_policy
+
+Default policy for selinux. It is ignored if lsm is not selinux.
+
 ### distributions
 
 List of supported distros that can be offered in installer.
@@ -62,12 +96,12 @@ Cockpit's web server related settings.
 Whether enable or disable TLS/SSL for remote connections. If it is not set, it does not modify
 Cockpit configuration in that regard.
 
-#### ssl_cert
+#### ssl\_cert
 
 Location of the certificate to use for remote connections. The certificate is retrieved and copied
 to `/etc/cockpit/ws-certs.d`.
 
-#### ssl_key
+#### ssl\_key
 
 Location of the certificate key to use for remote connections. The key is retrieved and copied to
 `/etc/cockpit/ws-certs.d`. This option is ignored unless the `ssl_cert` is set.

--- a/doc/yaml_config.md
+++ b/doc/yaml_config.md
@@ -58,10 +58,6 @@ Required patterns for given lsm to be selected.
 Default policy. Only applicable for selinux lsm.
 
 
-#### selinux\_policy
-
-Default policy for selinux. It is ignored if lsm is not selinux.
-
 ### distributions
 
 List of supported distros that can be offered in installer.

--- a/service/etc/d-installer.yaml
+++ b/service/etc/d-installer.yaml
@@ -3,6 +3,22 @@ software:
     - https://download.opensuse.org/tumbleweed/repo/oss/
     - https://download.opensuse.org/tumbleweed/repo/non-oss/
     - https://download.opensuse.org/update/tumbleweed/
+  mandatory_patterns:
+    - enhanced_base # only pattern that is shared among all roles on TW
+  optional_patterns: null # no optional pattern shared
+
+security:
+  lsm: apparmor
+  available_lsms:
+    apparmor:
+      patterns:
+        - apparmor
+    selinux:
+      patterns:
+        - selinux
+      policy: permissive
+    none:
+      patterns: null
 
 distributions:
   # TODO replace simple id with better description of distributions

--- a/service/lib/dinstaller/manager.rb
+++ b/service/lib/dinstaller/manager.rb
@@ -175,7 +175,7 @@ module DInstaller
     #
     # @return [Security]
     def security
-      @security ||= Security.new(logger)
+      @security ||= Security.new(logger, config)
     end
 
   private

--- a/service/lib/dinstaller/security.rb
+++ b/service/lib/dinstaller/security.rb
@@ -27,6 +27,7 @@ require "dinstaller/config"
 
 # FIXME: monkey patching of security config to not read control.xml and
 # instead use DIinstaller::Config
+# TODO: add ability to set product features in LSM::Base
 module Y2Security
   module LSM
     # modified LSM Base class to use dinstaller config
@@ -34,7 +35,7 @@ module Y2Security
       def product_feature_settings
         return @product_feature_settings unless @product_feature_settings.nil?
 
-        value = DIinstaller::Config.data["security"]["available_lsms"][id.to_s]
+        value = DIinstaller::Config.current.data["security"]["available_lsms"][id.to_s]
         res = if value
           {
             selectable:   true,
@@ -59,7 +60,8 @@ end
 module DInstaller
   # Backend class between dbus service and yast code
   class Security
-    def initialize(logger)
+    def initialize(logger, config)
+      @config = config
       @logger = logger
     end
 
@@ -68,9 +70,7 @@ module DInstaller
     end
 
     def probe(_progress)
-      # TODO: hardcoded apparmor here instead of calling `.propose_default`
-      # as we soon change it to value from config.yml
-      config.select(Config.data["security"]["lsm"])
+      config.select(@config.data["security"]["lsm"])
     end
 
   private

--- a/service/lib/dinstaller/security.rb
+++ b/service/lib/dinstaller/security.rb
@@ -35,7 +35,7 @@ module Y2Security
       def product_feature_settings
         return @product_feature_settings unless @product_feature_settings.nil?
 
-        value = DIinstaller::Config.current.data["security"]["available_lsms"][id.to_s]
+        value = ::DInstaller::Config.current.data["security"]["available_lsms"][id.to_s]
         res = if value
           {
             selectable:   true,

--- a/service/lib/dinstaller/software.rb
+++ b/service/lib/dinstaller/software.rb
@@ -194,14 +194,18 @@ module DInstaller
     def store_original_repos
       # Backup was already created, so just remove all repos
       if File.directory?(REPOS_BACKUP)
+        logger.info "removing #{REPOS_DIR}"
         FileUtils.rm_rf(REPOS_DIR)
       else # move repos to backup
+        logger.info "moving #{REPOS_DIR} to #{REPOS_BACKUP}"
         FileUtils.mv(REPOS_DIR, REPOS_BACKUP)
       end
     end
 
     def restore_original_repos
+      logger.info "removing #{REPOS_DIR}"
       FileUtils.rm_rf(REPOS_DIR)
+      logger.info "moving #{REPOS_BACKUP} to #{REPOS_DIR}"
       FileUtils.mv(REPOS_BACKUP, REPOS_DIR)
     end
   end


### PR DESCRIPTION
## Problem

Extend yaml config with patterns for given product and also with more detailed security settings. It is needed for support of microos from yaml.


## Testing

- *Tested manually*