### PR TITLE
Add: npm run jsdoc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,9 +46,12 @@ jobs:
         flag-name: frontend
         parallel: true
 
-    # TODO: once it works, push it to surge.sh
     - name: Build JSDoc Documentation
       run: npm run jsdoc
+
+    - name: Publish JSDoc Documentation
+      run: npx surge out/ ${{ secrets.SURGE_DOMAIN }} --token ${{ secrets.SURGE_TOKEN }}
+
 
   backend_tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       run: npm run jsdoc
 
     - name: Publish JSDoc Documentation
-      run: npx surge out/ ${{ secrets.SURGE_DOMAIN }} --token ${{ secrets.SURGE_TOKEN }}
+      run: npx surge jsdoc.out/ ${{ secrets.SURGE_DOMAIN }} --token ${{ secrets.SURGE_TOKEN }}
 
 
   backend_tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,10 @@ jobs:
         flag-name: frontend
         parallel: true
 
+    # TODO: once it works, push it to surge.sh
+    - name: Build JSDoc Documentation
+      run: npm run jsdoc
+
   backend_tests:
     runs-on: ubuntu-latest
     env:

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -16,3 +16,5 @@ test/images/
 POTFILES*
 tmp/
 /po/LINGUAS
+# jsdoc
+/out/

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -16,5 +16,4 @@ test/images/
 POTFILES*
 tmp/
 /po/LINGUAS
-# jsdoc
-/out/
+/jsdoc.out/

--- a/web/README.md
+++ b/web/README.md
@@ -27,3 +27,10 @@ everytime you save a change:
 However, there is no live or hot reloading feature, so you need to reload the code in your browser.
 You can visit the module through the following URL:
 http://localhost:9090/cockpit/@localhost/d-installer/index.html.
+
+### JSDoc Documentation
+
+```
+npm run jsdoc
+xdg-open out/index.html
+```

--- a/web/README.md
+++ b/web/README.md
@@ -32,7 +32,7 @@ http://localhost:9090/cockpit/@localhost/d-installer/index.html.
 
 ```
 npm run jsdoc
-xdg-open out/index.html
+xdg-open jsdoc.out/index.html
 ```
 
 GitHub Actions will automatically publish the result to

--- a/web/README.md
+++ b/web/README.md
@@ -34,3 +34,6 @@ http://localhost:9090/cockpit/@localhost/d-installer/index.html.
 npm run jsdoc
 xdg-open out/index.html
 ```
+
+GitHub Actions will automatically publish the result to
+<https://d-installer-frontend.surge.sh/>

--- a/web/jsdoc.conf.json
+++ b/web/jsdoc.conf.json
@@ -2,7 +2,7 @@
     // comments are allowed.
     // https://jsdoc.app/about-configuring-jsdoc.html
     "opts": {
-        "destination": "./out/", // just make the default explicit
+        "destination": "./jsdoc.out/",
         "private": true,
         "recurse": true
     },

--- a/web/jsdoc.conf.json
+++ b/web/jsdoc.conf.json
@@ -1,0 +1,25 @@
+{
+    // comments are allowed.
+    // https://jsdoc.app/about-configuring-jsdoc.html
+    "opts": {
+        "destination": "./out/", // just make the default explicit
+        "private": true,
+        "recurse": true
+    },
+    "plugins": [],
+    "recurseDepth": 10,
+    "source": {
+        "include": [ "src/" ],
+        "includePattern": ".+\\.js(doc|x)?$",
+        "excludePattern": "(^|\\/|\\\\)_"
+    },
+    "sourceType": "module",
+    "tags": {
+        "allowUnknownTags": true,
+        "dictionaries": ["jsdoc","closure"]
+    },
+    "templates": {
+        "cleverLinks": false,
+        "monospaceLinks": false
+    }
+}

--- a/web/package.json
+++ b/web/package.json
@@ -44,6 +44,7 @@
     "jed": "^1.1.1",
     "jest": "^27.5.1",
     "jest-transform-stub": "^2.0.0",
+    "jsdoc": "^3.6.10",
     "mini-css-extract-plugin": "^2.5.3",
     "po2json": "^1.0.0-alpha",
     "qunit": "^2.9.3",

--- a/web/package.json
+++ b/web/package.json
@@ -9,6 +9,7 @@
     "build": "webpack",
     "eslint": "eslint --ext .js --ext .jsx src/",
     "eslint:fix": "eslint --fix --ext .js --ext .jsx src/",
+    "jsdoc": "npx jsdoc -c jsdoc.conf.json; echo Tip:; echo xdg-open out/index.html",
     "test": "jest"
   },
   "devDependencies": {

--- a/web/package.json
+++ b/web/package.json
@@ -53,6 +53,7 @@
     "sizzle": "^2.3.3",
     "stdio": "^2.1.0",
     "string-replace-loader": "^3.0.0",
+    "surge": "^0.23.1",
     "terser-webpack-plugin": "^5.1.4",
     "webpack": "^5.54.0",
     "webpack-cli": "^4.9.1"

--- a/web/package.json
+++ b/web/package.json
@@ -9,7 +9,7 @@
     "build": "webpack",
     "eslint": "eslint --ext .js --ext .jsx src/",
     "eslint:fix": "eslint --fix --ext .js --ext .jsx src/",
-    "jsdoc": "npx jsdoc -c jsdoc.conf.json; echo Tip:; echo xdg-open out/index.html",
+    "jsdoc": "npx jsdoc -c jsdoc.conf.json && echo Tip: && echo xdg-open jsdoc.out/index.html",
     "test": "jest"
   },
   "devDependencies": {


### PR DESCRIPTION
## Problem

https://github.com/yast/d-installer/issues/155

> Although we document the JavaScript code with [JSDoc](https://jsdoc.app/), we are not building that documentation. If we want to build the docs, we need to run jsdoc manually. And what is even worse, the format of our documentation might be wrong.

> Ideally, we should define a new [script](https://github.com/joseivanlopez/d-installer/blob/d42c1d19de54a9059a6a89e9135767f3da906334/web/package.json#L7-L13) in the package.json to generate the documentation.

## Solution

- add a "jsdoc" script to `package.json`.
- instead of CLI options, prefer a configuration file
- in web/README.md, say  how to use it: `npm run jsdoc`

TODOs

- [x] automatic deployment to surge.sh looks easy https://github.com/yavisht/deploy-via-surge.sh-github-action-template but probably can wait to another PR
- [x] probably need to declare `jsdoc` in `package.json`


## Testing

- This is developer tooling. Simple enough not to need tests: either it works or it doesn't

## Screenshots

![d-installer-jsdoc](https://user-images.githubusercontent.com/102056/172876862-4436cca9-e775-4c44-8f3f-4657a0a344af.jpg)

