### PR TITLE
Refactor main Service

### DIFF
--- a/service/lib/dinstaller/dbus/users_service.rb
+++ b/service/lib/dinstaller/dbus/users_service.rb
@@ -41,8 +41,9 @@ module DInstaller
       # @return [::DBus::Connection]
       attr_reader :bus
 
+      # @param config [Config] Configuration object
       # @param logger [Logger]
-      def initialize(logger = nil)
+      def initialize(_config, logger = nil)
         @logger = logger || Logger.new($stdout)
         @bus = ::DBus::SystemBus.instance
       end

--- a/service/lib/dinstaller/manager.rb
+++ b/service/lib/dinstaller/manager.rb
@@ -58,7 +58,8 @@ module DInstaller
     # Constructor
     #
     # @param logger [Logger]
-    def initialize(logger)
+    def initialize(config, logger)
+      @config = config
       @logger = logger
       @status_manager = StatusManager.new(Status::Error.new) # temporary status until probing starts
       @questions_manager = QuestionsManager.new(logger)
@@ -129,13 +130,6 @@ module DInstaller
     end
     # rubocop:enable Metrics/AbcSize
 
-    # Configuration
-    def config
-      Config.load unless Config.current
-
-      Config.current
-    end
-
     # Software manager
     #
     # @return [Software]
@@ -179,6 +173,8 @@ module DInstaller
     end
 
   private
+
+    attr_reader :config
 
     # Initializes YaST
     def initialize_yast

--- a/service/test/dinstaller/dbus/manager_service_test.rb
+++ b/service/test/dinstaller/dbus/manager_service_test.rb
@@ -20,14 +20,15 @@
 # find current contact information at www.suse.com.
 
 require_relative "../../test_helper"
-require "dinstaller/dbus/service"
-require "dinstaller/manager"
+require "dinstaller/dbus/manager_service"
+require "dinstaller/config"
 
-describe DInstaller::DBus::Service do
-  subject(:service) { described_class.new(manager, logger) }
+describe DInstaller::DBus::ManagerService do
+  subject(:service) { described_class.new(config, logger) }
 
+  let(:config) { DInstaller::Config.new }
   let(:logger) { Logger.new($stdout) }
-  let(:manager) { DInstaller::Manager.new(logger) }
+  let(:manager) { DInstaller::Manager.new(config, logger) }
   let(:bus) { instance_double(::DBus::SystemBus) }
   let(:bus_service) do
     instance_double(::DBus::Service, export: nil)
@@ -36,6 +37,7 @@ describe DInstaller::DBus::Service do
   before do
     allow(::DBus::SystemBus).to receive(:instance).and_return(bus)
     allow(bus).to receive(:request_service).and_return(bus_service)
+    allow(DInstaller::Manager).to receive(:new).with(config, logger).and_return(manager)
   end
 
   describe "#export" do

--- a/service/test/dinstaller/manager_test.rb
+++ b/service/test/dinstaller/manager_test.rb
@@ -21,10 +21,12 @@
 
 require_relative "../test_helper"
 require "dinstaller/manager"
+require "dinstaller/config"
 
 describe DInstaller::Manager do
-  subject { described_class.new(logger) }
+  subject { described_class.new(config, logger) }
 
+  let(:config) { DInstaller::Config.new }
   let(:logger) { Logger.new($stdout, level: :warn) }
 
   let(:cockpit) { instance_double(DInstaller::CockpitManager, setup: nil) }


### PR DESCRIPTION
Let's consider this one as preparation work for #168.

* `DBus::Service` is now called `DBus::ManagerService`.
* The `Manager` is instantiated within the service (like `UsersService`).
* Simplify the `ServiceRunner`, as now all services have a similar API.
* The configuration is injected from the `ServiceRunner`.

## To do

* Should we use `#export` or `#start`?

