### PR TITLE
Configurable storage volumes

### DIFF
--- a/doc/yaml_config.md
+++ b/doc/yaml_config.md
@@ -71,3 +71,13 @@ to `/etc/cockpit/ws-certs.d`.
 
 Location of the certificate key to use for remote connections. The key is retrieved and copied to
 `/etc/cockpit/ws-certs.d`. This option is ignored unless the `ssl_cert` is set.
+
+## storage
+
+Options related to management of storage devices. It is map with the following keys:
+
+### volumes
+
+List of volumes used by the proposal. Each volume contains the very same fields described at the
+[corresponding section](https://github.com/yast/yast-installation/blob/master/doc/control-file.md#the-volumes-subsection)
+of the YaST configuration.

--- a/service/etc/d-installer.yaml
+++ b/service/etc/d-installer.yaml
@@ -12,3 +12,72 @@ web:
   ssl: null
   ssl_cert: null
   ssl_key: null
+
+storage:
+  volumes:
+  - mount_point: "/"
+    fs_type: btrfs
+    desired_size: 10 GiB
+    min_size: 5 GiB
+    max_size: unlimited
+    weight: 30
+
+    # There must always be a root
+    proposed_configurable: false
+
+    snapshots: true
+    snapshots_percentage: 250
+    snapshots_configurable: true
+    # Disable snapshots if there is not enough room
+    disable_order: 3
+
+    btrfs_default_subvolume: "@"
+    subvolumes:
+    - path: home
+    - path: opt
+    - path: root
+    - path: srv
+    - path: usr/local
+    # Unified var subvolume - https://lists.opensuse.org/opensuse-packaging/2017-11/msg00017.html
+    - path: var
+      copy_on_write: false
+
+    # Architecture specific subvolumes
+    - path: boot/grub2/arm64-efi
+      archs: aarch64
+    - path: boot/grub2/arm-efi
+      archs: arm
+    - path: boot/grub2/i386-pc
+      archs: x86_64
+    - path: boot/grub2/powerpc-ieee1275
+      archs: ppc,!board_powernv
+    - path: boot/grub2/s390x-emu
+      archs: s390
+    - path: boot/grub2/x86_64-efi
+      archs: x86_64
+    - path: boot/grub2/riscv64-efi
+      archs: riscv64
+
+  - mount_point: "/home"
+    fs_type: xfs
+    desired_size: 40 GiB
+    min_size: 10 GiB
+    max_size: unlimited
+    weight: 60
+
+    proposed: false
+    proposed_configurable: true
+    disable_order: 1
+
+  - mount_point: "swap"
+    fs_type: swap
+    desired_size: 2 GiB
+    min_size: 1 GiB
+    max_size: 2 GiB
+    weight: 10
+
+    adjust_by_ram: false
+    adjust_by_ram_configurable: true
+
+    proposed_configurable: true
+    disable_order: 2

--- a/service/lib/dinstaller/manager.rb
+++ b/service/lib/dinstaller/manager.rb
@@ -168,7 +168,7 @@ module DInstaller
     #
     # @return [Storage::Manager]
     def storage
-      @storage ||= Storage::Manager.new(logger)
+      @storage ||= Storage::Manager.new(logger, config)
     end
 
     # Security manager

--- a/service/lib/dinstaller/storage/manager.rb
+++ b/service/lib/dinstaller/storage/manager.rb
@@ -29,8 +29,9 @@ module DInstaller
   module Storage
     # Manager to handle storage configuration
     class Manager
-      def initialize(logger)
+      def initialize(logger, config)
         @logger = logger
+        @config = config
       end
 
       # Probes storage devices and performs an initial proposal
@@ -57,7 +58,7 @@ module DInstaller
       #
       # @return [Storage::Proposal]
       def proposal
-        @proposal ||= Proposal.new(logger)
+        @proposal ||= Proposal.new(logger, config)
       end
 
       # Storage actions manager
@@ -71,6 +72,9 @@ module DInstaller
 
       # @return [Logger]
       attr_reader :logger
+
+      # @return [Config]
+      attr_reader :config
 
       # Activates the devices, calling activation callbacks if needed
       #

--- a/service/test/dinstaller/storage/manager_test.rb
+++ b/service/test/dinstaller/storage/manager_test.rb
@@ -23,11 +23,13 @@ require_relative "../../test_helper"
 require "dinstaller/storage/manager"
 require "dinstaller/progress"
 require "dinstaller/questions_manager"
+require "dinstaller/config"
 
 describe DInstaller::Storage::Manager do
-  subject(:storage) { described_class.new(logger) }
+  subject(:storage) { described_class.new(logger, config) }
 
   let(:logger) { Logger.new($stdout, level: :warn) }
+  let(:config) { DInstaller::Config.new }
   let(:progress) { DInstaller::Progress.new }
 
   describe "#probe" do

--- a/service/test/dinstaller/storage/proposal_test.rb
+++ b/service/test/dinstaller/storage/proposal_test.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "dinstaller/storage/proposal"
+require "dinstaller/config"
+
+describe DInstaller::Storage::Proposal do
+  subject(:proposal) { described_class.new(logger, config) }
+
+  let(:logger) { Logger.new($stdout, level: :warn) }
+  let(:config) { DInstaller::Config.new(config_data) }
+  let(:y2storage_proposal) { instance_double(Y2Storage::GuidedProposal, failed?: failed) }
+  let(:y2storage_manager) do
+    instance_double(Y2Storage::StorageManager, probed: nil, probed_disk_analyzer: nil)
+  end
+  let(:failed) { false }
+  let(:config_data) { {} }
+
+  describe "#calculate" do
+    before do
+      allow(Y2Storage::StorageManager).to receive(:instance).and_return y2storage_manager
+      allow(Y2Storage::GuidedProposal).to receive(:initial).and_return y2storage_proposal
+      allow(y2storage_manager).to receive(:proposal=)
+    end
+
+    context "when there is no 'volumes' section in the config" do
+      let(:config_data) { {} }
+
+      it "calculates the Y2Storage proposal with a default set of VolumeSpecification" do
+        expect(Y2Storage::GuidedProposal).to receive(:initial) do |**args|
+          expect(args[:settings]).to be_a(Y2Storage::ProposalSettings)
+          vols = args[:settings].volumes
+          expect(vols).to_not be_empty
+          expect(vols).to all(be_a(Y2Storage::VolumeSpecification))
+
+          y2storage_proposal
+        end
+
+        proposal.calculate
+      end
+    end
+
+    context "when there is a 'volumes' section in the config" do
+      let(:config_data) do
+        { "storage" => { "volumes" => [{ "mount_point" => "/one" }, { "mount_point" => "/two" }] } }
+      end
+
+      it "calculates the Y2Storage with the correct set of VolumeSpecification" do
+        expect(Y2Storage::GuidedProposal).to receive(:initial) do |**args|
+          expect(args[:settings]).to be_a(Y2Storage::ProposalSettings)
+          vols = args[:settings].volumes
+          expect(vols).to all(be_a(Y2Storage::VolumeSpecification))
+          expect(vols.map(&:mount_point)).to contain_exactly("/one", "/two")
+
+          y2storage_proposal
+        end
+
+        proposal.calculate
+      end
+    end
+
+    context "when the Y2Storage proposal successes" do
+      let(:failed) { false }
+
+      it "saves the proposal" do
+        expect(y2storage_manager).to receive(:proposal=).with y2storage_proposal
+        proposal.calculate
+      end
+    end
+
+    context "when the Y2Storage proposal fails" do
+      let(:failed) { true }
+
+      it "does not save the proposal" do
+        allow(y2storage_manager).to receive(:staging=)
+        expect(y2storage_manager).to_not receive(:proposal=)
+        proposal.calculate
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Problem

The `Y2Storage::GuidedSetup` tries to accommodate a set of volumes. That's configurable in YaST (and is usually defined by the product, the installation role and other criteria). But in D-Installer there was no way to specify the set of volumes, so it always created the fallback set of volumes that is hard-coded at YaST.

## Solution

Now `d-installer.yaml` can contain a 'volumes' section that is identical to the [corresponding section](https://github.com/yast/yast-installation/blob/master/doc/control-file.md#the-volumes-subsection) of YaST configuration (just using Yaml instead of XML, of course).

The code still uses the fallback legacy list if the list of volumes is missing in the configuration file, but this pull request also syncs the current `d-installer.yaml` with the Tumbleweed configuration [available at openSUSE's skelcd](https://github.com/yast/skelcd-control-openSUSE/blob/master/control/control.openSUSE.xml#L249) repo.

## Testing

- Tested manually with:
  - The hard-coded fallback
  - The TW-like configuration mentioned above
  - A configuration equivalent to MicroOS
- Included the first unit tests for `DInstaller::Storage::Proposal`
