### PR TITLE
JSDoc: make FooClient classes visible to it

### DIFF
--- a/web/src/client/language.js
+++ b/web/src/client/language.js
@@ -23,7 +23,10 @@ import { applyMixin, withDBus } from "./mixins";
 
 const LANGUAGE_IFACE = "org.opensuse.DInstaller.Language1";
 
-export default class LanguageClient {
+/**
+ * Language client
+ */
+class LanguageClient {
   constructor(dbusClient) {
     this._client = dbusClient;
   }
@@ -64,3 +67,4 @@ export default class LanguageClient {
 }
 
 applyMixin(LanguageClient, withDBus);
+export default LanguageClient;

--- a/web/src/client/manager.js
+++ b/web/src/client/manager.js
@@ -25,7 +25,10 @@ import cockpit from "../lib/cockpit";
 const MANAGER_IFACE = "org.opensuse.DInstaller.Manager1";
 const MANAGER_PATH = "/org/opensuse/DInstaller/Manager1";
 
-export default class ManagerClient {
+/**
+ * Manager client
+ */
+class ManagerClient {
   constructor(dbusClient) {
     this._client = dbusClient;
   }
@@ -101,3 +104,4 @@ export default class ManagerClient {
 }
 
 applyMixin(ManagerClient, withDBus);
+export default ManagerClient;

--- a/web/src/client/monitor.js
+++ b/web/src/client/monitor.js
@@ -25,7 +25,10 @@ import cockpit from "../lib/cockpit";
 const DBUS_SERVICE = "org.freedesktop.DBus";
 const MATCHER = { interface: DBUS_SERVICE, member: "NameOwnerChanged" };
 
-export default class Monitor {
+/**
+ * Monitor a D-Bus service
+ */
+class Monitor {
   /**
    * @param {object} dbusClient - from cockpit.dbus
    * @param {string} serviceName - service to monitor
@@ -54,3 +57,4 @@ export default class Monitor {
 }
 
 applyMixin(Monitor, withDBus);
+export default Monitor;

--- a/web/src/client/questions.js
+++ b/web/src/client/questions.js
@@ -101,7 +101,10 @@ function buildQuestion(dbusQuestion) {
   return question;
 }
 
-export default class QuestionsClient {
+/**
+ * Questions client
+ */
+class QuestionsClient {
   constructor(dbusClient) {
     this._client = dbusClient;
   }
@@ -190,3 +193,5 @@ export default class QuestionsClient {
     });
   }
 }
+
+export default QuestionsClient;

--- a/web/src/client/software.js
+++ b/web/src/client/software.js
@@ -23,7 +23,10 @@ import { applyMixin, withDBus } from "./mixins";
 
 const SOFTWARE_IFACE = "org.opensuse.DInstaller.Software1";
 
-export default class SoftwareClient {
+/**
+ * Software client
+ */
+class SoftwareClient {
   constructor(dbusClient) {
     this._client = dbusClient;
   }
@@ -53,3 +56,4 @@ export default class SoftwareClient {
 }
 
 applyMixin(SoftwareClient, withDBus);
+export default SoftwareClient;

--- a/web/src/client/storage.js
+++ b/web/src/client/storage.js
@@ -26,7 +26,10 @@ const STORAGE_PROPOSAL_IFACE = "org.opensuse.DInstaller.Storage.Proposal1";
 const STORAGE_ACTIONS_IFACE = "org.opensuse.DInstaller.Storage.Actions1";
 const ACTIONS_PATH = "/org/opensuse/DInstaller/Storage/Actions1";
 
-export default class StorageClient {
+/**
+ * Storage client
+ */
+class StorageClient {
   constructor(dbusClient) {
     this._client = dbusClient;
   }
@@ -84,3 +87,4 @@ export default class StorageClient {
 }
 
 applyMixin(StorageClient, withDBus);
+export default StorageClient;

--- a/web/src/client/users.js
+++ b/web/src/client/users.js
@@ -23,7 +23,10 @@ import { applyMixin, withDBus } from "./mixins";
 
 const USERS_IFACE = "org.opensuse.DInstaller.Users1";
 
-export default class UsersClient {
+/**
+ * Users client
+ */
+class UsersClient {
   constructor(dbusClient) {
     this._client = dbusClient;
   }
@@ -125,3 +128,4 @@ export default class UsersClient {
 }
 
 applyMixin(UsersClient, withDBus);
+export default UsersClient;


### PR DESCRIPTION
## Problem

```js
export default class Foo { ... }
```
works for JS but sadly not for JSDoc.

The rendered docs has just 1 entry instead of all the classes:
> ### Classes
> exports


## Solution

Use

```js
class Foo {
  ...
}
export default Foo;
```

> ### Classes
> 
> LanguageClient
> ManagerClient
> Monitor
> NetworkClient
> QuestionsClient
> SoftwareClient
> StorageClient
> UsersClient

The same is probably true for `function`


## Testing

- *Tested manually*: `npm run jsdoc` before and after


