### PR TITLE
CLI: add config command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
       run: npm run jsdoc
 
     - name: Publish JSDoc Documentation
+      if: ${{ secrets.SURGE_TOKEN != '' }}
       run: npx surge jsdoc.out/ ${{ secrets.SURGE_DOMAIN }} --token ${{ secrets.SURGE_TOKEN }}
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       run: npm run jsdoc
 
     - name: Publish JSDoc Documentation
-      if: ${{ secrets.SURGE_TOKEN != '' }}
+      if: ${{ github.ref == 'refs/heads/master' }}
       run: npx surge jsdoc.out/ ${{ secrets.SURGE_DOMAIN }} --token ${{ secrets.SURGE_TOKEN }}
 
 

--- a/cli/lib/dinstaller_cli/commands/config.rb
+++ b/cli/lib/dinstaller_cli/commands/config.rb
@@ -39,7 +39,7 @@ module DInstallerCli
         say_error("error: invalid configuration")
       end
 
-      desc "dump", "Dump the current installation config"
+      desc "dump", "Dump the current installation config to stdout"
       def dump
         say(current_config.dump)
       end

--- a/cli/lib/dinstaller_cli/commands/config.rb
+++ b/cli/lib/dinstaller_cli/commands/config.rb
@@ -1,0 +1,150 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "thor"
+require "dinstaller_cli/install_config"
+require "dinstaller_cli/install_config_reader"
+require "dinstaller_cli/clients/language"
+require "dinstaller_cli/clients/software"
+require "dinstaller_cli/clients/storage"
+require "dinstaller_cli/clients/users"
+
+module DInstallerCli
+  module Commands
+    # Subcommand to configure the installation
+    class Config < Thor
+      desc "load <config>", "Load a config file and apply the configuration"
+      def load(config_source)
+        config = InstallConfigReader.new(config_source).read
+        configure_installation(config)
+      rescue DInstallerCli::InstallConfigReader::Error
+        say_error("error: invalid configuration")
+      end
+
+      desc "dump", "Dump the current installation config"
+      def dump
+        say(current_config.dump)
+      end
+
+    private
+
+      # Configures the installation according to the given config
+      #
+      # Performs D-Bus calls to configure the proper services.
+      #
+      # @param config [InstallConfig]
+      def configure_installation(config)
+        software_client.select_product(config.product) if config.product
+        language_client.select_languages(config.languages) if config.languages.any?
+        storage_client.calculate(config.disks) if config.disks.any?
+
+        configure_user(config.user) if config.user
+        configure_root(config.root) if config.root
+      end
+
+      # Configures the user
+      #
+      # Performs D-Bus calls to configure the users service.
+      #
+      # @param user_config [InstallConfig::User]
+      def configure_user(user_config)
+        user_name = user_config.name || ""
+
+        return if user_name.empty?
+
+        users_client.create_first_user(user_config.name,
+          fullname:  user_config.fullname,
+          password:  user_config.password,
+          autologin: user_config.autologin)
+      end
+
+      # Configures the root user
+      #
+      # Performs D-Bus calls to configure the users service.
+      #
+      # @param root_config [InstallConfig::Root]
+      def configure_root(root_config)
+        users_client.root_password = root_config.password if root_config.password
+        users_client.root_ssh_key = root_config.ssh_key if root_config.ssh_key
+      end
+
+      # Generates an installation config with the current configured values
+      #
+      # @return [InstallConfig]
+      def current_config
+        InstallConfig.new.tap do |config|
+          product = software_client.selected_product
+
+          config.product = product unless product.empty?
+          config.languages = language_client.selected_languages
+          config.disks = storage_client.candidate_devices
+
+          config.user = current_user_config
+          config.root = current_root_config
+        end
+      end
+
+      # Generates a user config with the current configured values
+      #
+      # @note The password is not recovered
+      #
+      # @return [InstallConfig::User]
+      def current_user_config
+        fullname, name, autologin = users_client.first_user
+
+        InstallConfig::User.new.tap do |user|
+          user.name = name unless name.empty?
+          user.fullname = fullname unless fullname.empty?
+          user.autologin = autologin
+        end
+      end
+
+      # Generates a root config with the current configured values
+      #
+      # @note The password is not recovered
+      #
+      # @return [InstallConfig::Root]
+      def current_root_config
+        ssh_key = users_client.root_ssh_key
+
+        InstallConfig::Root.new.tap do |root|
+          root.ssh_key = ssh_key unless ssh_key.empty?
+        end
+      end
+
+      def language_client
+        @language_client ||= Clients::Language.new
+      end
+
+      def software_client
+        @software_client ||= Clients::Software.new
+      end
+
+      def storage_client
+        @storage_client ||= Clients::Storage.new
+      end
+
+      def users_client
+        @users_client ||= Clients::Users.new
+      end
+    end
+  end
+end

--- a/cli/lib/dinstaller_cli/commands/main.rb
+++ b/cli/lib/dinstaller_cli/commands/main.rb
@@ -66,6 +66,9 @@ module DInstallerCli
         say(status)
       end
 
+      desc "config SUBCOMMAND", "Manage configuration of the installation"
+      subcommand "config", Config
+
       desc "language SUBCOMMAND", "Manage language configuration"
       subcommand "language", Language
 

--- a/cli/lib/dinstaller_cli/commands/main.rb
+++ b/cli/lib/dinstaller_cli/commands/main.rb
@@ -20,13 +20,13 @@
 # find current contact information at www.suse.com.
 
 require "thor"
-require "dinstaller_cli/install_config_reader"
+require "dinstaller_cli/commands/config"
 require "dinstaller_cli/commands/language"
 require "dinstaller_cli/commands/software"
 require "dinstaller_cli/commands/storage"
 require "dinstaller_cli/commands/root_user"
 require "dinstaller_cli/commands/user"
-require "dinstaller_cli/clients"
+require "dinstaller_cli/clients/manager"
 
 module DInstallerCli
   module Commands
@@ -36,15 +36,10 @@ module DInstallerCli
         true
       end
 
-      desc "install [<config>]", "Perform the installation"
-      def install(config_source = nil)
+      desc "install", "Perform the installation"
+      def install
         answer = ask("Do you want to start the installation?", limited_to: ["y", "n"])
         return unless answer == "y"
-
-        if config_source
-          config = InstallConfigReader.new(config_source).read
-          configure_installation(config)
-        end
 
         manager_client.commit
       rescue InstallConfigReader::Error
@@ -88,64 +83,8 @@ module DInstallerCli
 
     private
 
-      # Configures the installation according to the given config
-      #
-      # Performs D-Bus calls to configure the proper services.
-      #
-      # @param config [InstallConfig]
-      def configure_installation(config)
-        software_client.select_product(config.product) if config.product
-        language_client.select_languages(config.languages) if config.languages.any?
-        storage_client.calculate(config.disks) if config.disks.any?
-
-        configure_user(config.user) if config.user
-        configure_root(config.root) if config.root
-      end
-
-      # Configures the user
-      #
-      # Performs D-Bus calls to configure the users service.
-      #
-      # @param user_config [InstallConfig::User]
-      def configure_user(user_config)
-        user_name = user_config.name || ""
-
-        return if user_name.empty?
-
-        users_client.create_first_user(user_config.name,
-          fullname:  user_config.fullname,
-          password:  user_config.password,
-          autologin: user_config.autologin)
-      end
-
-      # Configures the root user
-      #
-      # Performs D-Bus calls to configure the users service.
-      #
-      # @param root_config [InstallConfig::Root]
-      def configure_root(root_config)
-        users_client.root_password = root_config.password if root_config.password
-        users_client.root_ssh_key = root_config.ssh_key if root_config.ssh_key
-      end
-
       def manager_client
         @manager_client ||= Clients::Manager.new
-      end
-
-      def language_client
-        @language_client ||= Clients::Language.new
-      end
-
-      def software_client
-        @software_client ||= Clients::Software.new
-      end
-
-      def storage_client
-        @storage_client ||= Clients::Storage.new
-      end
-
-      def users_client
-        @users_client ||= Clients::Users.new
       end
     end
   end

--- a/cli/lib/dinstaller_cli/install_config.rb
+++ b/cli/lib/dinstaller_cli/install_config.rb
@@ -57,25 +57,23 @@ module DInstallerCli
       @root = nil
     end
 
+    # Dumps the settings in YAML format
+    #
+    # @return [String]
     def dump
       to_h.to_yaml
     end
 
+    # Converts the settings to hash
+    #
+    # @return [Hash]
     def to_h
       {
         "product"   => product,
         "languages" => languages,
         "disks"     => disks,
-        "user"      => {
-          "name"      => user&.name,
-          "fullname"  => user&.fullname,
-          "autologin" => user&.autologin,
-          "password"  => user&.password
-        },
-        "root"      => {
-          "ssh_key"  => root&.ssh_key,
-          "password" => root&.password
-        }
+        "user"      => user&.to_h || {},
+        "root"      => root&.to_h || {}
       }
     end
 
@@ -105,6 +103,18 @@ module DInstallerCli
         @password = password
         @autologin = autologin
       end
+
+      # Converts the settings to hash
+      #
+      # @return [Hash]
+      def to_h
+        {
+          "name"      => name,
+          "fullname"  => fullname,
+          "autologin" => autologin,
+          "password"  => password
+        }
+      end
     end
 
     # Class to represent the root user config
@@ -122,6 +132,16 @@ module DInstallerCli
       def initialize(password: nil, ssh_key: nil)
         @password = password
         @ssh_key = ssh_key
+      end
+
+      # Converts the settings to hash
+      #
+      # @return [Hash]
+      def to_h
+        {
+          "ssh_key"  => ssh_key,
+          "password" => password
+        }
       end
     end
   end

--- a/cli/lib/dinstaller_cli/install_config.rb
+++ b/cli/lib/dinstaller_cli/install_config.rb
@@ -19,6 +19,8 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
+require "yaml"
+
 module DInstallerCli
   # Class to represent the installation config
   class InstallConfig
@@ -53,6 +55,28 @@ module DInstallerCli
       @disks = []
       @user = nil
       @root = nil
+    end
+
+    def dump
+      to_h.to_yaml
+    end
+
+    def to_h
+      {
+        "product"   => product,
+        "languages" => languages,
+        "disks"     => disks,
+        "user"      => {
+          "name"      => user&.name,
+          "fullname"  => user&.fullname,
+          "autologin" => user&.autologin,
+          "password"  => user&.password
+        },
+        "root"      => {
+          "ssh_key"  => root&.ssh_key,
+          "password" => root&.password
+        }
+      }
     end
 
     # Class to represent the user config

--- a/cli/lib/dinstaller_cli/install_config_reader.rb
+++ b/cli/lib/dinstaller_cli/install_config_reader.rb
@@ -27,11 +27,11 @@ module DInstallerCli
   #
   # The YAML file has the following structure:
   #
+  # product: <product-id>
+  #
   # languages:
   #   - <language-id>
   #   - <language-id>
-  #
-  # product: <product-id>
   #
   # disks:
   #   - <device-name>
@@ -87,14 +87,14 @@ module DInstallerCli
     # @return [InstallConfig]
     def config_from(content)
       InstallConfig.new.tap do |config|
-        languages = content["languages"]
         product = content["product"]
+        languages = content["languages"]
         disks = content["disks"]
         user = content["user"]
         root = content["root"]
 
-        config.languages = languages if languages
         config.product = product if product
+        config.languages = languages if languages
         config.disks = disks if disks
         config.user = user_config_from(user) if user
         config.root = root_config_from(root) if root

--- a/cli/test/dinstaller_cli/commands/config_test.rb
+++ b/cli/test/dinstaller_cli/commands/config_test.rb
@@ -1,0 +1,226 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "dinstaller_cli/commands/config"
+require "dinstaller_cli/install_config"
+require "dinstaller_cli/install_config_reader"
+require "dinstaller_cli/clients/language"
+require "dinstaller_cli/clients/software"
+require "dinstaller_cli/clients/storage"
+require "dinstaller_cli/clients/users"
+
+describe DInstallerCli::Commands::Config do
+  before do
+    allow(DInstallerCli::Clients::Software).to receive(:new).and_return(software_client)
+    allow(DInstallerCli::Clients::Language).to receive(:new).and_return(language_client)
+    allow(DInstallerCli::Clients::Storage).to receive(:new).and_return(storage_client)
+    allow(DInstallerCli::Clients::Users).to receive(:new).and_return(users_client)
+  end
+
+  let(:software_client) { instance_double(DInstallerCli::Clients::Software) }
+  let(:language_client) { instance_double(DInstallerCli::Clients::Language) }
+  let(:storage_client) { instance_double(DInstallerCli::Clients::Storage) }
+  let(:users_client) { instance_double(DInstallerCli::Clients::Users) }
+
+  subject { described_class.new }
+
+  describe "#load" do
+    before do
+      allow(DInstallerCli::InstallConfigReader).to receive(:new).with(config_source)
+        .and_return(reader)
+    end
+
+    let(:config_source) { "config.yaml" }
+
+    let(:reader) { instance_double(DInstallerCli::InstallConfigReader) }
+
+    context "when the config cannot be loaded" do
+      before do
+        allow(reader).to receive(:read).and_raise(DInstallerCli::InstallConfigReader::Error)
+      end
+
+      it "informs about wrong config" do
+        expect(subject).to receive(:say_error).with(/invalid configuration/)
+
+        subject.load(config_source)
+      end
+    end
+
+    context "when the config can be loaded" do
+      before do
+        allow(reader).to receive(:read).and_return(config)
+      end
+
+      let(:config) { DInstallerCli::InstallConfig.new }
+
+      context "and the config specifies a product" do
+        before do
+          config.product = "Tumbleweed"
+        end
+
+        it "configures the product" do
+          expect(software_client).to receive(:select_product).with("Tumbleweed")
+
+          subject.load(config_source)
+        end
+      end
+
+      context "and the config does not specify a product" do
+        it "does not configure a product" do
+          expect(software_client).to_not receive(:select_product)
+
+          subject.load(config_source)
+        end
+      end
+
+      context "and the config specifies a language" do
+        before do
+          config.languages = ["es_ES"]
+        end
+
+        it "configures the language" do
+          expect(language_client).to receive(:select_languages).with(["es_ES"])
+
+          subject.load(config_source)
+        end
+      end
+
+      context "and the config does not specify a language" do
+        it "does not configure a language" do
+          expect(language_client).to_not receive(:select_languages)
+
+          subject.load(config_source)
+        end
+      end
+
+      context "and the config specifies disks" do
+        before do
+          config.disks = ["/dev/vda", "/dev/vdb"]
+        end
+
+        it "calculates the proposal with the target disks" do
+          expect(storage_client).to receive(:calculate).with(["/dev/vda", "/dev/vdb"])
+
+          subject.load(config_source)
+        end
+      end
+
+      context "and the config does not specify disks" do
+        it "does not calculate the proposal" do
+          expect(storage_client).to_not receive(:calculate)
+
+          subject.load(config_source)
+        end
+      end
+
+      context "and the config specifies user config" do
+        before do
+          config.user = DInstallerCli::InstallConfig::User.new(name: name)
+        end
+
+        context "and the user config has no name" do
+          let(:name) { "" }
+
+          it "does not configure the user" do
+            expect(users_client).to_not receive(:create_first_user)
+
+            subject.load(config_source)
+          end
+        end
+
+        context "and the user config has a name" do
+          let(:name) { "test" }
+
+          it "configures the user" do
+            expect(users_client).to receive(:create_first_user).with("test", anything)
+
+            subject.load(config_source)
+          end
+        end
+      end
+
+      context "and the config does not specify user config" do
+        it "does not configure the user" do
+          expect(users_client).to_not receive(:create_first_user)
+
+          subject.load(config_source)
+        end
+      end
+
+      context "and the config specifies root config" do
+        before do
+          config.root = DInstallerCli::InstallConfig::Root.new(
+            password: "n0ts3cr3t",
+            ssh_key:  "1234abcd"
+          )
+        end
+
+        it "configures the root user" do
+          expect(users_client).to receive(:root_password=).with("n0ts3cr3t")
+          expect(users_client).to receive(:root_ssh_key=).with("1234abcd")
+
+          subject.load(config_source)
+        end
+      end
+
+      context "and the config does not specify root config" do
+        it "does not configure the root user" do
+          expect(users_client).to_not receive(:root_password=)
+          expect(users_client).to_not receive(:root_ssh_key=)
+
+          subject.load(config_source)
+        end
+      end
+    end
+  end
+
+  describe "#dump" do
+    before do
+      allow(software_client).to receive(:selected_product).and_return("Tumbleweed")
+      allow(language_client).to receive(:selected_languages).and_return(["es_ES"])
+      allow(storage_client).to receive(:candidate_devices).and_return(["/dev/vda"])
+      allow(users_client).to receive(:first_user).and_return(["Test User", "user", true])
+      allow(users_client).to receive(:root_ssh_key).and_return("1234abcd")
+    end
+
+    it "dumps the current config" do
+      expect(subject).to receive(:say).with(
+        "---\n" \
+        "product: Tumbleweed\n" \
+        "languages:\n" \
+        "- es_ES\n" \
+        "disks:\n" \
+        "- \"\/dev\/vda\"\n" \
+        "user:\n" \
+        "  name: user\n" \
+        "  fullname: Test User\n" \
+        "  autologin: true\n" \
+        "  password:\n" \
+        "root:\n" \
+        "  ssh_key: 1234abcd\n" \
+        "  password:\n"
+      )
+
+      subject.dump
+    end
+  end
+end

--- a/cli/test/dinstaller_cli/commands/main_test.rb
+++ b/cli/test/dinstaller_cli/commands/main_test.rb
@@ -23,7 +23,7 @@ require_relative "../../test_helper"
 require "dinstaller_cli/commands/main"
 require "dinstaller_cli/install_config"
 require "dinstaller_cli/install_config_reader"
-require "dinstaller_cli/clients"
+require "dinstaller_cli/clients/manager"
 
 describe DInstallerCli::Commands::Main do
   it "includes a 'language' command" do
@@ -48,25 +48,15 @@ describe DInstallerCli::Commands::Main do
 
   before do
     allow(DInstallerCli::Clients::Manager).to receive(:new).and_return(manager_client)
-    allow(DInstallerCli::Clients::Software).to receive(:new).and_return(software_client)
-    allow(DInstallerCli::Clients::Language).to receive(:new).and_return(language_client)
-    allow(DInstallerCli::Clients::Storage).to receive(:new).and_return(storage_client)
-    allow(DInstallerCli::Clients::Users).to receive(:new).and_return(users_client)
   end
 
   let(:manager_client) { instance_double(DInstallerCli::Clients::Manager) }
-  let(:software_client) { instance_double(DInstallerCli::Clients::Software) }
-  let(:language_client) { instance_double(DInstallerCli::Clients::Language) }
-  let(:storage_client) { instance_double(DInstallerCli::Clients::Storage) }
-  let(:users_client) { instance_double(DInstallerCli::Clients::Users) }
 
   subject { described_class.new }
 
   describe "#install" do
     before do
       allow(subject).to receive(:ask).and_return(answer)
-      allow(subject).to receive(:say)
-      allow(subject).to receive(:say_error)
       allow(manager_client).to receive(:commit)
     end
 
@@ -91,163 +81,10 @@ describe DInstallerCli::Commands::Main do
     context "if the user confirms" do
       let(:answer) { "y" }
 
-      context "and a config file was given" do
-        let(:config_source) { "config.yaml" }
+      it "performs the installation" do
+        expect(manager_client).to receive(:commit)
 
-        context "and the config cannot be loaded" do
-          before do
-            allow_any_instance_of(DInstallerCli::InstallConfigReader).to receive(:read)
-              .and_raise(DInstallerCli::InstallConfigReader::Error)
-          end
-
-          it "informs about wrong config" do
-            expect(subject).to receive(:say_error).with(/invalid configuration/)
-
-            subject.install(config_source)
-          end
-
-          it "does not perform the installation" do
-            expect(manager_client).to_not receive(:commit)
-
-            subject.install(config_source)
-          end
-        end
-
-        context "and the config can be loaded" do
-          before do
-            allow(DInstallerCli::InstallConfigReader).to receive(:new).with(config_source)
-              .and_return(config_reader)
-          end
-
-          let(:config_reader) { instance_double(DInstallerCli::InstallConfigReader, read: config) }
-
-          let(:config) { DInstallerCli::InstallConfig.new }
-
-          it "performs the installation" do
-            expect(manager_client).to receive(:commit)
-
-            subject.install(config_source)
-          end
-
-          context "and the config specifies a product" do
-            before do
-              config.product = "Tumbleweed"
-            end
-
-            it "configures the product" do
-              expect(software_client).to receive(:select_product).with("Tumbleweed")
-
-              subject.install(config_source)
-            end
-          end
-
-          context "and the config does not specify a product" do
-            it "does not configure a product" do
-              expect(software_client).to_not receive(:select_product)
-
-              subject.install(config_source)
-            end
-          end
-
-          context "and the config specifies a language" do
-            before do
-              config.languages = ["es_ES"]
-            end
-
-            it "configures the language" do
-              expect(language_client).to receive(:select_languages).with(["es_ES"])
-
-              subject.install(config_source)
-            end
-          end
-
-          context "and the config does not specify a language" do
-            it "does not configure a language" do
-              expect(language_client).to_not receive(:select_languages)
-
-              subject.install(config_source)
-            end
-          end
-
-          context "and the config specifies disks" do
-            before do
-              config.disks = ["/dev/vda", "/dev/vdb"]
-            end
-
-            it "calculates the proposal with the target disks" do
-              expect(storage_client).to receive(:calculate).with(["/dev/vda", "/dev/vdb"])
-
-              subject.install(config_source)
-            end
-          end
-
-          context "and the config does not specify disks" do
-            it "does not calculate the proposal" do
-              expect(storage_client).to_not receive(:calculate)
-
-              subject.install(config_source)
-            end
-          end
-
-          context "and the config specifies user config" do
-            before do
-              config.user = DInstallerCli::InstallConfig::User.new(name: name)
-            end
-
-            context "and the user config has no name" do
-              let(:name) { "" }
-
-              it "does not configure the user" do
-                expect(users_client).to_not receive(:create_first_user)
-
-                subject.install(config_source)
-              end
-            end
-
-            context "and the user config has a name" do
-              let(:name) { "test" }
-
-              it "configures the user" do
-                expect(users_client).to receive(:create_first_user).with("test", anything)
-
-                subject.install(config_source)
-              end
-            end
-          end
-
-          context "and the config does not specify user config" do
-            it "does not configure the user" do
-              expect(users_client).to_not receive(:create_first_user)
-
-              subject.install(config_source)
-            end
-          end
-
-          context "and the config specifies root config" do
-            before do
-              config.root = DInstallerCli::InstallConfig::Root.new(
-                password: "n0ts3cr3t",
-                ssh_key:  "1234abcd"
-              )
-            end
-
-            it "configures the root user" do
-              expect(users_client).to receive(:root_password=).with("n0ts3cr3t")
-              expect(users_client).to receive(:root_ssh_key=).with("1234abcd")
-
-              subject.install(config_source)
-            end
-          end
-
-          context "and the config does not specify root config" do
-            it "does not configure the root user" do
-              expect(users_client).to_not receive(:root_password=)
-              expect(users_client).to_not receive(:root_ssh_key=)
-
-              subject.install(config_source)
-            end
-          end
-        end
+        subject.install
       end
     end
   end

--- a/cli/test/dinstaller_cli/commands/main_test.rb
+++ b/cli/test/dinstaller_cli/commands/main_test.rb
@@ -26,6 +26,10 @@ require "dinstaller_cli/install_config_reader"
 require "dinstaller_cli/clients/manager"
 
 describe DInstallerCli::Commands::Main do
+  it "includes a 'config' command" do
+    expect(described_class.subcommands).to include("config")
+  end
+
   it "includes a 'language' command" do
     expect(described_class.subcommands).to include("language")
   end

--- a/cli/test/dinstaller_cli/install_config_reader_test.rb
+++ b/cli/test/dinstaller_cli/install_config_reader_test.rb
@@ -48,8 +48,27 @@ describe DInstallerCli::InstallConfigReader do
         expect(config.user.fullname).to eq("User Test")
         expect(config.user.password).to eq("n0ts3cr3t")
         expect(config.user.autologin).to eq(true)
+        expect(config.root).to_not be_nil
         expect(config.root.password).to eq("n0ts3cr3t")
         expect(config.root.ssh_key).to eq("1234abcd")
+      end
+
+      context "and some settings are missing in the config file" do
+        let(:source) { File.join(FIXTURES_PATH, "incomplete_config.yaml") }
+
+        it "generates an install config without the missing settings" do
+          config = subject.read
+
+          expect(config.languages).to contain_exactly("en_US")
+          expect(config.product).to be_nil
+          expect(config.disks).to contain_exactly("/dev/vda")
+          expect(config.user).to_not be_nil
+          expect(config.user.name).to eq("test")
+          expect(config.user.fullname).to be_nil
+          expect(config.user.password).to be_empty
+          expect(config.user.autologin).to eq(true)
+          expect(config.root).to be_nil
+        end
       end
     end
   end

--- a/cli/test/dinstaller_cli/install_config_test.rb
+++ b/cli/test/dinstaller_cli/install_config_test.rb
@@ -82,5 +82,25 @@ describe DInstallerCli::InstallConfig do
         }
       )
     end
+
+    context "when there is no user" do
+      before do
+        subject.user = nil
+      end
+
+      it "returns an empty hash for the user key" do
+        expect(subject.to_h["user"]).to eq({})
+      end
+    end
+
+    context "when there is no root" do
+      before do
+        subject.root = nil
+      end
+
+      it "returns an empty hash for the root key" do
+        expect(subject.to_h["root"]).to eq({})
+      end
+    end
   end
 end

--- a/cli/test/dinstaller_cli/install_config_test.rb
+++ b/cli/test/dinstaller_cli/install_config_test.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+require "dinstaller_cli/install_config"
+
+describe DInstallerCli::InstallConfig do
+  subject { described_class.new }
+
+  before do
+    subject.product = "Tumbleweed"
+    subject.languages = ["en_UK", "es_ES"]
+    subject.disks = ["/dev/vda"]
+    subject.user = DInstallerCli::InstallConfig::User.new.tap do |user|
+      user.name = "test"
+      user.autologin = true
+      user.password = "n0ts3cr3t"
+    end
+    subject.root = DInstallerCli::InstallConfig::Root.new.tap do |root|
+      root.ssh_key = "1234abcd"
+      root.password = ""
+    end
+  end
+
+  describe "#dump" do
+    it "dumps the content in YAML format" do
+      expect(subject.dump).to eq(
+        "---\n" \
+        "product: Tumbleweed\n" \
+        "languages:\n" \
+        "- en_UK\n" \
+        "- es_ES\n" \
+        "disks:\n" \
+        "- \"\/dev\/vda\"\n" \
+        "user:\n" \
+        "  name: test\n" \
+        "  fullname:\n" \
+        "  autologin: true\n" \
+        "  password: n0ts3cr3t\n" \
+        "root:\n" \
+        "  ssh_key: 1234abcd\n" \
+        "  password: ''\n"
+      )
+    end
+  end
+
+  describe "#to_h" do
+    it "converts the config to a hash" do
+      expect(subject.to_h).to eq(
+        {
+          "product"   => "Tumbleweed",
+          "languages" => ["en_UK", "es_ES"],
+          "disks"     => ["/dev/vda"],
+          "user"      => {
+            "name"      => "test",
+            "fullname"  => nil,
+            "autologin" => true,
+            "password"  => "n0ts3cr3t"
+          },
+          "root"      => {
+            "ssh_key"  => "1234abcd",
+            "password" => ""
+          }
+        }
+      )
+    end
+  end
+end

--- a/cli/test/fixtures/config.yaml
+++ b/cli/test/fixtures/config.yaml
@@ -1,9 +1,9 @@
 ---
+product: "Tumbleweed"
+
 languages:
   - "es_ES"
   - "en_US"
-
-product: "Tumbleweed"
 
 disks:
   - /dev/vda

--- a/cli/test/fixtures/incomplete_config.yaml
+++ b/cli/test/fixtures/incomplete_config.yaml
@@ -1,0 +1,13 @@
+---
+product:
+
+languages:
+  - "en_US"
+
+disks:
+  - /dev/vda
+
+user:
+  name: "test"
+  password: ""
+  autologin: true


### PR DESCRIPTION
## Problem

In https://github.com/yast/d-installer/pull/179, the command *dinstallerctl install* was extended to optionally receive a config YAML file with the configuration for the installation (language, product, etc). During the review meeting, it was suggested to allow loading the configuration in a separte command. This would make possible to adapt some settings after loading the configuration. For example, if you have a common *config.yaml* file for several machines but you want to modify the language in a specific machine. 

* https://github.com/yast/d-installer/issues/193

## Solution

Provide a new command *dinstallerctl config* which allows to load and to dump the YAML configuration.

~~~bash
dinstallerctl config load config.yaml
dinstallerctl language selected es_ES
dinstallerctl config dump
dinstallerctl install
~~~

## Testing

- Added new unit tests
- Tested manually
