### PR TITLE
[RFC] D-Bus service is responsive during probing and installation

### DIFF
--- a/service/lib/dinstaller/dbus/service.rb
+++ b/service/lib/dinstaller/dbus/service.rb
@@ -20,6 +20,7 @@
 # find current contact information at www.suse.com.
 
 require "dbus"
+require "dinstaller/dbus/task_runner"
 require "dinstaller/dbus/manager"
 require "dinstaller/dbus/language"
 require "dinstaller/dbus/software"
@@ -51,12 +52,15 @@ module DInstaller
       # @return [DInstaller::Manager]
       attr_reader :manager
 
+      attr_reader :task_runner
+
       # @param manager [Manager] Installation manager
       # @param logger [Logger]
       def initialize(manager, logger = nil)
         @manager = manager
         @logger = logger || Logger.new($stdout)
         @bus = ::DBus::SystemBus.instance
+        @task_runner = TaskRunner.new
       end
 
       # Exports the installer object through the D-Bus service
@@ -69,6 +73,7 @@ module DInstaller
 
       # Call this from some main loop to dispatch the D-Bus messages
       def dispatch
+        task_runner.cleanup
         bus.dispatch_message_queue
       end
 

--- a/service/lib/dinstaller/dbus/task_runner.rb
+++ b/service/lib/dinstaller/dbus/task_runner.rb
@@ -1,0 +1,72 @@
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+module DInstaller
+  module DBus
+    # This class prevents many conflicting blocks to run at the same time
+    #
+    # Running a time consuming task (like software probing) on a separate thread allows the D-Bus
+    # service to keep responsive meanwhile. However, as YaST is not thread safe, some incoming
+    # request might conflict with the running process.
+    #
+    # Wrapping the potentially conflicting code with #run_thread or #run will protect
+    # the conflicts by raising a DBus::Error.
+    #
+    # @example Run a long running task
+    #   runner = TaskRunner.new
+    #   runner.run_thread { long_running_task }
+    #
+    # @example Raise an error when a long running task is still alive
+    #   runner = TaskRunner.new
+    #   runner.run_thread { long_running_task }
+    #   runner.run_thread { another_task } #=> <DBus::Error>
+    #
+    # @example Run a short task
+    #   runner = TaskRunner.new
+    #   runner.run { short_task }
+    class TaskRunner
+      def initialize
+        @thread = nil
+      end
+
+      def run(&block)
+        raise error if @thread&.alive?
+
+        block.call
+      end
+
+      def run_thread(&block)
+        raise error if @thread&.alive?
+
+        @thread = Thread.new(&block)
+      end
+
+      def cleanup
+        return if @thread.nil? || @thread.alive?
+
+        @thread.join
+        @thread = nil
+      end
+
+      def error
+        DBus.error("org.opensuse.DInstaller.Error.Busy")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Problem

When a time-consuming task is running (like *probing*  or *installation*), the D-Bus service does not dispatch any other call. Hence you cannot ask for the current status, progress or any other value. The UI gets the status/progress information from signals.

We could mitigate this problem by running time-consuming tasks in a separate thread. However, as YaST is not thread-safe, we might face some problems in the future if conflicting tasks run simultaneously.

## Solution

We have introduced a new class (`TaskRunner`) that takes care of running one, and only one, of those potentially conflicting tasks at a time. In case you try to run more than one of those tasks simultaneously, the second one is rejected with a DBus error.

## To do

- [ ] Identify potentially conflicting tasks.
- [ ] Adapt the UI not to wait for signals to get the status.
- [ ] Testing

## Related work

This PR adds some responsiveness to the D-Bus service. Additionally, we are working on a multi-process approach to get some parallelism.