### PR TITLE
Calculate service status

### DIFF
--- a/service/lib/dinstaller/dbus/clients/software.rb
+++ b/service/lib/dinstaller/dbus/clients/software.rb
@@ -20,6 +20,7 @@
 # find current contact information at www.suse.com.
 
 require "dbus"
+require "dinstaller/status_manager"
 
 module DInstaller
   module DBus
@@ -35,6 +36,13 @@ module DInstaller
 
           @dbus_proposal = service.object("/org/opensuse/DInstaller/Software/Proposal1")
           @dbus_proposal.introspect
+        end
+
+        # Current status of the service
+        #
+        # @return [Status]
+        def status
+          Status.create(dbus_object["org.opensuse.DInstaller.Software1"]["Status"])
         end
 
         # Available products for the installation
@@ -62,7 +70,7 @@ module DInstaller
 
         # Starts the probing process
         #
-        # If a block is given, the method returns inmmediatelly and the probing is performed in an
+        # If a block is given, the method returns immediately and the probing is performed in an
         # asynchronous way.
         #
         # @param done [Proc] Block to execute once the probing is done

--- a/service/lib/dinstaller/dbus/clients/users.rb
+++ b/service/lib/dinstaller/dbus/clients/users.rb
@@ -20,6 +20,7 @@
 # find current contact information at www.suse.com.
 
 require "dbus"
+require "dinstaller/status_manager"
 
 module DInstaller
   module DBus
@@ -29,6 +30,13 @@ module DInstaller
         def initialize
           @dbus_object = service.object("/org/opensuse/DInstaller/Users1")
           @dbus_object.introspect
+        end
+
+        # Current status of the service
+        #
+        # @return [Status]
+        def status
+          Status.create(dbus_object["org.opensuse.DInstaller.Users1"]["Status"])
         end
 
         # Configuration of the first user to create during the installation

--- a/service/lib/dinstaller/status_manager.rb
+++ b/service/lib/dinstaller/status_manager.rb
@@ -72,7 +72,23 @@ module DInstaller
     attr_reader :on_change_callbacks
   end
 
+  # Status of the service
   module Status
+    def self.create(id)
+      case id
+      when 0
+        Error.new
+      when 1
+        Probing.new
+      when 2
+        Probed.new
+      when 3
+        Installing.new
+      when 4
+        Installed.new
+      end
+    end
+
     # Status base class
     class Base
       # Status id
@@ -85,6 +101,14 @@ module DInstaller
       # @param id [Integer] status id
       def initialize(id)
         @id = id
+      end
+
+      # Two status are equal if they have the same id
+      #
+      # @param other [Status::Base]
+      # @return [Boolean]
+      def ==(other)
+        id == other.id
       end
     end
 

--- a/service/test/dinstaller/dbus/clients/software_test.rb
+++ b/service/test/dinstaller/dbus/clients/software_test.rb
@@ -45,6 +45,16 @@ describe DInstaller::DBus::Clients::Software do
 
   subject { described_class.new }
 
+  describe "#status" do
+    before do
+      allow(software_iface).to receive(:[]).with("Status").and_return(2)
+    end
+
+    it "returns the status of the service" do
+      expect(subject.status).to eq(DInstaller::Status::Probed.new)
+    end
+  end
+
   describe "#available_products" do
     before do
       allow(software_iface).to receive(:[]).with("AvailableBaseProducts").and_return(

--- a/service/test/dinstaller/dbus/clients/users_test.rb
+++ b/service/test/dinstaller/dbus/clients/users_test.rb
@@ -41,6 +41,16 @@ describe DInstaller::DBus::Clients::Users do
 
   subject { described_class.new }
 
+  describe "#status" do
+    before do
+      allow(users_iface).to receive(:[]).with("Status").and_return(2)
+    end
+
+    it "returns the status of the service" do
+      expect(subject.status).to eq(DInstaller::Status::Probed.new)
+    end
+  end
+
   describe "#first_user" do
     before do
       allow(users_iface).to receive(:[]).with("FirstUser").and_return(

--- a/service/test/dinstaller/dbus/software/manager_test.rb
+++ b/service/test/dinstaller/dbus/software/manager_test.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../../test_helper"
+require "dinstaller/dbus/software/manager"
+require "dinstaller/software"
+require "dinstaller/status_manager"
+require "dinstaller/progress"
+
+describe DInstaller::DBus::Software::Manager do
+  subject { described_class.new(backend, logger) }
+
+  let(:backend) do
+    instance_double(DInstaller::Software, status_manager: status_manager, progress: progress)
+  end
+
+  let(:logger) { Logger.new($stdout) }
+
+  let(:status_manager) { DInstaller::StatusManager.new(status) }
+
+  let(:status) { DInstaller::Status::Installing.new }
+
+  let(:progress) { DInstaller::Progress.new }
+
+  it "configures callbacks for changes in the status" do
+    new_status = DInstaller::Status::Installed.new
+
+    expect(subject).to receive(:PropertiesChanged) do |iface, properties, _|
+      expect(iface).to match(/Software1/)
+      expect(properties["Status"]).to eq(new_status.id)
+    end
+
+    status_manager.change(new_status)
+  end
+
+  describe "#status" do
+    it "returns the id of its current status" do
+      expect(subject.status).to eq(status.id)
+    end
+  end
+end

--- a/service/test/dinstaller/dbus/users_test.rb
+++ b/service/test/dinstaller/dbus/users_test.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "dinstaller/dbus/users"
+require "dinstaller/users"
+require "dinstaller/status_manager"
+
+describe DInstaller::DBus::Users do
+  subject { described_class.new(backend, logger) }
+
+  let(:backend) { instance_double(DInstaller::Users, status_manager: status_manager) }
+
+  let(:logger) { Logger.new($stdout) }
+
+  let(:status_manager) { DInstaller::StatusManager.new(status) }
+
+  let(:status) { DInstaller::Status::Installing.new }
+
+  it "configures callbacks for changes in the status" do
+    new_status = DInstaller::Status::Installed.new
+
+    expect(subject).to receive(:PropertiesChanged) do |iface, properties, _|
+      expect(iface).to match(/Users1/)
+      expect(properties["Status"]).to eq(new_status.id)
+    end
+
+    status_manager.change(new_status)
+  end
+
+  describe "#status" do
+    it "returns the id of its current status" do
+      expect(subject.status).to eq(status.id)
+    end
+  end
+end

--- a/service/test/dinstaller/software_test.rb
+++ b/service/test/dinstaller/software_test.rb
@@ -27,7 +27,7 @@ require "dinstaller/progress"
 describe DInstaller::Software do
   subject { described_class.new(config, logger) }
 
-  let(:logger) { Logger.new($stdout) }
+  let(:logger) { Logger.new($stdout, level: :warn) }
   let(:config) { DInstaller::Config.new }
   let(:progress) { DInstaller::Progress.new }
   let(:products) { [tw_prod] }
@@ -53,6 +53,12 @@ describe DInstaller::Software do
   end
 
   describe "#probe" do
+    it "sets the status to probing and probed" do
+      expect(subject.status_manager).to receive(:change).with(DInstaller::Status::Probing)
+      expect(subject.status_manager).to receive(:change).with(DInstaller::Status::Probed)
+      subject.probe
+    end
+
     it "initializes the package system" do
       expect(Yast::Pkg).to receive(:TargetInitialize).with("/")
       subject.probe

--- a/service/test/dinstaller/status_manager_test.rb
+++ b/service/test/dinstaller/status_manager_test.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+require "dinstaller/status_manager"
+
+describe DInstaller::StatusManager do
+  subject { described_class.new(initial_status) }
+
+  let(:initial_status) { DInstaller::Status::Error.new }
+
+  describe "#error?" do
+    context "if the current status is error" do
+      it "returns true" do
+        expect(subject.error?).to eq(true)
+      end
+    end
+
+    context "if the current status is not error" do
+      let(:initial_status) { DInstaller::Status::Probed.new }
+
+      it "returns false" do
+        expect(subject.error?).to eq(false)
+      end
+    end
+  end
+
+  describe "#change" do
+    before do
+      subject.on_change { logger.info("change status") }
+    end
+
+    let(:logger) { Logger.new($stdout, level: :warn) }
+
+    let(:new_status) { DInstaller::Status::Installed.new }
+
+    it "sets the given status" do
+      subject.change(new_status)
+
+      expect(subject.status).to eq(new_status)
+    end
+
+    it "runs the callbacks" do
+      expect(logger).to receive(:info).with(/change status/)
+
+      subject.change(new_status)
+    end
+  end
+end
+
+describe DInstaller::Status do
+  describe ".create" do
+    it "creates a status according to the given id" do
+      expect(DInstaller::Status.create(0)).to eq(DInstaller::Status::Error.new)
+      expect(DInstaller::Status.create(1)).to eq(DInstaller::Status::Probing.new)
+      expect(DInstaller::Status.create(2)).to eq(DInstaller::Status::Probed.new)
+      expect(DInstaller::Status.create(3)).to eq(DInstaller::Status::Installing.new)
+      expect(DInstaller::Status.create(4)).to eq(DInstaller::Status::Installed.new)
+    end
+  end
+end

--- a/service/test/dinstaller/users_test.rb
+++ b/service/test/dinstaller/users_test.rb
@@ -36,6 +36,13 @@ describe DInstaller::Users do
       .and_return(users_config)
   end
 
+  describe "#new" do
+    it "initializes the service as probed" do
+      users = described_class.new(logger)
+      expect(users.status_manager.status).to eq(DInstaller::Status::Probed.new)
+    end
+  end
+
   describe "#assign_root_password" do
     let(:root_user) { instance_double(Y2Users::User) }
 
@@ -132,6 +139,12 @@ describe DInstaller::Users do
         .with(force_read: true).and_return(system_config)
       allow(Y2Users::Linux::Writer).to receive(:new).and_return(writer)
       allow(Yast::Execute).to receive(:locally!)
+    end
+
+    it "sets the status to installing and installed" do
+      expect(subject.status_manager).to receive(:change).with(DInstaller::Status::Installing)
+      expect(subject.status_manager).to receive(:change).with(DInstaller::Status::Installed)
+      subject.write(progress)
     end
 
     it "writes system and installer defined users" do


### PR DESCRIPTION
## Problem

Now there are several services, but only the central service (i.e., *manager*) reports an status. Each service should have its own status.

* See https://github.com/yast/d-installer/pull/202

## Solution

Add status to each service. And the *manager* service calculates the general status according to the status of the rest of services.

NOTE: there is too much common code between services. This will be improved in a following-up PR, in which a common D-Bus API will be provided for the status and progress of the services. 

## Testing

- Added new unit tests
- Tested manually


