### PR TITLE
Fix D-Bus software client reference in Autologin replacement

### DIFF
--- a/service/lib/dinstaller/dbus/y2dir/modules/Autologin.rb
+++ b/service/lib/dinstaller/dbus/y2dir/modules/Autologin.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 # ------------------------------------------------------------------------------
 # Copyright (c) 2006-2012 Novell, Inc. All Rights Reserved.
 #
@@ -27,9 +25,7 @@
 #
 # $Id$
 require "yast"
-
 require "dinstaller/dbus/clients/software"
-
 
 module Yast
   class AutologinClass < Module
@@ -65,8 +61,8 @@ module Yast
       # Pkg stuff initialized?
       @pkg_initialized = false
 
-      # D-Bus software client
-      @dbus_client = DInstaller::Clients::Software.new
+      # Software service client
+      @dbus_client = nil
     end
 
     def available
@@ -94,17 +90,16 @@ module Yast
         )
       ) == "yes"
 
-      @user = "" if @user == nil || @user == ""
+      @user = "" if @user.nil? || @user == ""
 
       @used = @user != ""
       @used
     end
 
-
     # Write autologin settings
     # @param [Boolean] write_only when true, suseconfig script will not be run
     # @return written anything?
-    def Write(write_only)
+    def Write(_write_only)
       return false if !available || !@modified
 
       Builtins.y2milestone(
@@ -181,7 +176,7 @@ module Yast
     #
     # @return Boolean
     def supported?
-      supported = @dbus_client.provisions_selected?(DISPLAY_MANAGERS).any?
+      supported = dbus_client.provisions_selected?(DISPLAY_MANAGERS).any?
 
       if supported
         log.info("Autologin is supported")
@@ -192,17 +187,26 @@ module Yast
       supported
     end
 
-    publish :variable => :user, :type => "string"
-    publish :variable => :pw_less, :type => "boolean"
-    publish :variable => :used, :type => "boolean"
-    publish :variable => :modified, :type => "boolean"
-    publish :function => :Read, :type => "boolean ()"
-    publish :function => :Write, :type => "boolean (boolean)"
-    publish :function => :Disable, :type => "void ()"
-    publish :function => :Use, :type => "void (boolean)"
-    publish :function => :supported?, :type => "boolean ()"
-    publish :function => :DisableAndWrite, :type => "boolean (boolean)"
-    publish :function => :AskForDisabling, :type => "boolean (string)"
+    publish variable: :user, type: "string"
+    publish variable: :pw_less, type: "boolean"
+    publish variable: :used, type: "boolean"
+    publish variable: :modified, type: "boolean"
+    publish function: :Read, type: "boolean ()"
+    publish function: :Write, type: "boolean (boolean)"
+    publish function: :Disable, type: "void ()"
+    publish function: :Use, type: "void (boolean)"
+    publish function: :supported?, type: "boolean ()"
+    publish function: :DisableAndWrite, type: "boolean (boolean)"
+    publish function: :AskForDisabling, type: "boolean (string)"
+
+  private
+
+    # Software service client
+    #
+    # @return [DInstaller::DBus::Clients::Software] Software service client
+    def dbus_client
+      @dbus_client ||= DInstaller::DBus::Clients::Software.new
+    end
   end
 
   Autologin = AutologinClass.new

--- a/service/test/dinstaller/dbus/y2dir/modules/Autologin_test.rb
+++ b/service/test/dinstaller/dbus/y2dir/modules/Autologin_test.rb
@@ -1,0 +1,59 @@
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../../../test_helper"
+require_relative File.join(
+  SRC_PATH, "dinstaller", "dbus", "y2dir", "modules", "Autologin.rb"
+)
+
+describe Yast::Autologin do
+  subject { Yast::Autologin }
+
+  before do
+    subject.main
+    allow(DInstaller::DBus::Clients::Software).to receive(:new).and_return(client)
+  end
+
+  let(:client) do
+    instance_double(DInstaller::DBus::Clients::Software)
+  end
+
+  describe "#supported?" do
+    before do
+      allow(client).to receive(:provisions_selected?).with(Array)
+        .and_return(provisions_selected?)
+    end
+
+    context "when some display manager is selected" do
+      let(:provisions_selected?) { [true, false] }
+
+      it "returns true" do
+        expect(subject.supported?).to eq(true)
+      end
+    end
+
+    context "when no display managers are selected" do
+      let(:provisions_selected?) { [false, false] }
+
+      it "returns false" do
+        expect(subject.supported?).to eq(false)
+      end
+    end
+  end
+end

--- a/service/test/dinstaller/dbus/y2dir/modules/autologin_test.rb
+++ b/service/test/dinstaller/dbus/y2dir/modules/autologin_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) [2022] SUSE LLC
 #
 # All Rights Reserved.

--- a/service/test/dinstaller/software_test.rb
+++ b/service/test/dinstaller/software_test.rb
@@ -109,6 +109,33 @@ describe DInstaller::Software do
     end
   end
 
+  describe "#install" do
+    let(:commit_result) { [250, [], [], [], []] }
+
+    before do
+      allow(Yast::PackageInstallation).to receive(:Commit).and_return(commit_result)
+    end
+
+    it "installs the packages" do
+      expect(Yast::PackageInstallation).to receive(:Commit).with({})
+        .and_return(commit_result)
+      subject.install
+    end
+
+    it "sets up the package callbacks" do
+      expect(DInstaller::PackageCallbacks).to receive(:setup)
+      subject.install
+    end
+
+    context "when packages installation fails" do
+      let(:commit_result) { nil }
+
+      it "raises an exception" do
+        expect { subject.install }.to raise_error(RuntimeError)
+      end
+    end
+  end
+
   describe "#finish" do
     let(:rootdir) { Dir.mktmpdir }
     let(:repos_dir) { File.join(rootdir, "etc", "zypp", "repos.d") }


### PR DESCRIPTION
Fix a wrong reference to the D-Bus software client in the Autologin replacement.