### PR TITLE
Move `<Questions>` component to `<App>`

### DIFF
--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -31,6 +31,7 @@ import ProbingProgress from "./ProbingProgress";
 import InstallationProgress from "./InstallationProgress";
 import InstallationFinished from "./InstallationFinished";
 import LoadingEnvironment from "./LoadingEnvironment";
+import Questions from "./Questions";
 
 import { PROBING, PROBED, INSTALLING, INSTALLED } from "./client/status";
 
@@ -94,6 +95,7 @@ function App() {
   return (
     <Layout>
       <Title>D-Installer</Title>
+      <Questions />
       <Content />
       <AdditionalInfo>
         <About />

--- a/web/src/App.test.jsx
+++ b/web/src/App.test.jsx
@@ -39,13 +39,14 @@ jest.mock("./InstallationProgress", () => () => "InstallationProgress Mock");
 jest.mock("./InstallationFinished", () => () => "InstallationFinished Mock");
 jest.mock("./Overview", () => () => "Overview Mock");
 jest.mock("./TargetIpsPopup", () => () => "Target IPs Mock");
+jest.mock("./Questions", () => () => <div>Questions Mock</div>);
 jest.mock('react-router-dom', () => ({
   Outlet: () => <div>Content</div>
 }));
 
 const callbacks = {};
 const initialStatusMock = null;
-let getStatusFn = jest.fn();
+let getStatusFn = () => Promise.resolve(initialStatusMock);
 const product = { id: "Tumbleweed", name: "openSUSE Tumbleweed" };
 const products = [product];
 
@@ -75,6 +76,12 @@ beforeEach(() => {
 });
 
 const changeStatusTo = status => act(() => callbacks.onChange({ Status: status }));
+
+test("renders the Questions component", async () => {
+  installerRender(<App />);
+
+  await screen.findByText("Questions Mock");
+});
 
 describe("App", () => {
   describe("when there are problems connecting with D-Bus service", () => {

--- a/web/src/Main.jsx
+++ b/web/src/Main.jsx
@@ -22,7 +22,6 @@
 import React from "react";
 import { Outlet, Navigate } from "react-router-dom";
 import LoadingEnvironment from "./LoadingEnvironment";
-import Questions from "./Questions";
 import { useSoftware } from "./context/software";
 
 function Main() {
@@ -36,12 +35,7 @@ function Main() {
     return <LoadingEnvironment />;
   }
 
-  return (
-    <>
-      <Questions />
-      <Outlet />
-    </>
-  );
+  return <Outlet />;
 }
 
 export default Main;

--- a/web/src/Main.test.jsx
+++ b/web/src/Main.test.jsx
@@ -27,7 +27,6 @@ import { installerRender } from "./test-utils";
 import Main from "./Main";
 
 jest.mock("./client");
-jest.mock("./Questions", () => () => "Questions Mock");
 jest.mock("./Layout", () => ({ children }) => <>{children}</>);
 jest.mock('react-router-dom', () => ({
   Outlet: () => <div>Content</div>,
@@ -48,10 +47,9 @@ const products = [{ id: "Tumbleweed", name: "openSUSE Tumbleweed" }];
 let mockProduct = products[0];
 
 describe("when a product is selected", () => {
-  it("renders the Questions component and the content", async () => {
+  it("renders the application content", async () => {
     installerRender(<Main />);
 
-    await screen.findByText("Questions Mock");
     await screen.findByText("Content");
   });
 });


### PR DESCRIPTION
Since a question could arrive at any moment (except when the connection with D-Bus is lost), there is no reason for having the `Questions` component not mounted when the user is selecting a product or accepting a license, for example.

Thus, moving it from `Main` to `App` ensures it is almost always there, apart from avoiding some React complains because of trying to update an unmounted component since it is not removing the subscriptions when it will be unmounting. Maybe a bug, let's discuss it.