### PR TITLE
Fix Questions component

### DIFF
--- a/web/src/Questions.jsx
+++ b/web/src/Questions.jsx
@@ -49,11 +49,15 @@ export default function Questions() {
   }, [client.questions, removeQuestion]);
 
   useEffect(() => {
+    const unsubscribeCallbacks = [];
+
     client.questions.getQuestions()
       .then(setPendingQuestions)
       .catch(e => console.error("Something went wrong retrieving pending questions", e));
-    client.questions.onQuestionAdded(addQuestion);
-    client.questions.onQuestionRemoved(removeQuestion);
+    unsubscribeCallbacks.push(client.questions.onQuestionAdded(addQuestion));
+    unsubscribeCallbacks.push(client.questions.onQuestionRemoved(removeQuestion));
+
+    return () => { unsubscribeCallbacks.forEach(cb => cb()) };
   }, [client.questions, addQuestion, removeQuestion]);
 
   if (pendingQuestions.length === 0) return null;


### PR DESCRIPTION
## Problem

`Questions` component is not canceling its subscriptions to D-Bus signals, which makes React complain because of a potential memory leak.

## Solution

Execute all unsubscription callbacks when the component is unmounted.

## Testing

- *Tested manually*