### PR TITLE
Fix issues with D-Bus

### DIFF
--- a/service/lib/dinstaller/config.rb
+++ b/service/lib/dinstaller/config.rb
@@ -75,13 +75,13 @@ module DInstaller
     def data
       return @data if @data
 
-      @data = @pure_data || {}
+      @data = @pure_data.dup || {}
       pick_product(@data["products"].keys.first) if @data["products"]
       @data
     end
 
     def pick_product(product)
-      @data.merge!(@data[product])
+      data.merge!(data[product])
     end
 
     # Whether there are more than one product

--- a/service/lib/dinstaller/dbus/clients/base.rb
+++ b/service/lib/dinstaller/dbus/clients/base.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "dbus"
+require "abstract_method"
+
+module DInstaller
+  module DBus
+    module Clients
+      # Base class for D-Bus clients
+      class Base
+        # @!method service_name
+        #   Name of the D-Bus service
+        #   @return [String]
+        abstract_method :service_name
+
+        # D-Bus service
+        #
+        # @return [::DBus::Service]
+        def service
+          @service ||= bus.service(service_name)
+        end
+
+      private
+
+        # Registers callback to be called when the properties of the given object changes
+        #
+        # @note Signal subscription is done only once. Otherwise, the latest subscription overrides
+        #   the previous one.
+        #
+        # @param dbus_object [::DBus::Object]
+        # @param block [Proc]
+        def on_properties_change(dbus_object, &block)
+          @on_properties_change_callbacks ||= {}
+          @on_properties_change_callbacks[dbus_object.path] ||= []
+          @on_properties_change_callbacks[dbus_object.path] << block
+
+          return if @on_properties_change_callbacks[dbus_object.path].size > 1
+
+          dbus_properties = dbus_object["org.freedesktop.DBus.Properties"]
+          dbus_properties.on_signal("PropertiesChanged") do |interface, changes, invalid|
+            callbacks = @on_properties_change_callbacks[dbus_object.path]
+            callbacks.each { |c| c.call(interface, changes, invalid) }
+          end
+        end
+
+        def bus
+          @bus ||= ::DBus::SystemBus.instance
+        end
+      end
+    end
+  end
+end

--- a/service/lib/dinstaller/dbus/clients/users.rb
+++ b/service/lib/dinstaller/dbus/clients/users.rb
@@ -19,24 +19,26 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "dbus"
+require "dinstaller/dbus/clients/base"
 require "dinstaller/dbus/clients/with_service_status"
 
 module DInstaller
   module DBus
     module Clients
       # D-Bus client for users configuration
-      class Users
+      class Users < Base
         include WithServiceStatus
 
         def initialize
+          super
+
           @dbus_object = service.object("/org/opensuse/DInstaller/Users1")
           @dbus_object.introspect
         end
 
-        # @return [::DBus::Service]
-        def service
-          @service ||= bus.service("org.opensuse.DInstaller.Users")
+        # @return [String]
+        def service_name
+          @service_name ||= "org.opensuse.DInstaller.Users"
         end
 
         # Configuration of the first user to create during the installation
@@ -104,10 +106,6 @@ module DInstaller
 
         # @return [::DBus::Object]
         attr_reader :dbus_object
-
-        def bus
-          @bus ||= ::DBus::SystemBus.instance
-        end
       end
     end
   end

--- a/service/lib/dinstaller/dbus/clients/with_service_status.rb
+++ b/service/lib/dinstaller/dbus/clients/with_service_status.rb
@@ -45,19 +45,13 @@ module DInstaller
         # @note Signal subscription is done only once. Otherwise, the latest subscription overrides
         #   the previous one.
         #
-        # @param callback [Proc]
+        # @param block [Proc]
         # @yieldparam service_status [ServiceStatus::IDLE, ServiceStatus::BUSY]
-        def on_service_status_change(&callback)
-          @on_service_status_change_callbacks ||= []
-          @on_service_status_change_callbacks << callback
-
-          return if @on_service_status_change_callbacks.size > 1
-
-          dbus_properties = dbus_object["org.freedesktop.DBus.Properties"]
-          dbus_properties.on_signal("PropertiesChanged") do |interface, changes, _|
+        def on_service_status_change(&block)
+          on_properties_change(dbus_object) do |interface, changes, _|
             if interface == Interfaces::ServiceStatus::SERVICE_STATUS_INTERFACE
               service_status = to_service_status(changes["Current"])
-              @on_service_status_change_callbacks.each { |c| c.call(service_status) }
+              block.call(service_status)
             end
           end
         end

--- a/service/lib/dinstaller/dbus/manager.rb
+++ b/service/lib/dinstaller/dbus/manager.rb
@@ -135,6 +135,12 @@ module DInstaller
         backend.on_services_status_change do
           dbus_properties_changed(MANAGER_INTERFACE, { "BusyServices" => busy_services }, [])
         end
+
+        backend.software.on_product_selected do |product|
+          safe_run do
+            busy_while { backend.select_product(product) }
+          end
+        end
       end
     end
   end

--- a/service/lib/dinstaller/manager.rb
+++ b/service/lib/dinstaller/manager.rb
@@ -73,11 +73,6 @@ module DInstaller
       start_progress(1)
       progress.step("Probing Languages") { language.probe }
 
-      software.on_product_selected do |selected|
-        config.pick_product(selected)
-        config_phase
-      end
-
       probe_single_product unless config.multi_product?
 
       logger.info("Startup phase done")
@@ -196,6 +191,14 @@ module DInstaller
     # @return [Security]
     def security
       @security ||= Security.new(logger, config)
+    end
+
+    # Actions to perform when a product is selected
+    #
+    # @note The config phase is executed.
+    def select_product(product)
+      config.pick_product(product)
+      config_phase
     end
 
     # Name of busy services

--- a/service/test/dinstaller/dbus/manager_service_test.rb
+++ b/service/test/dinstaller/dbus/manager_service_test.rb
@@ -34,12 +34,16 @@ describe DInstaller::DBus::ManagerService do
     instance_double(::DBus::Service, export: nil)
   end
   let(:cockpit) { instance_double(DInstaller::CockpitManager, setup: nil) }
+  let(:software_client) do
+    instance_double(DInstaller::DBus::Clients::Software, on_product_selected: nil)
+  end
 
   before do
     allow(::DBus::SystemBus).to receive(:instance).and_return(bus)
     allow(bus).to receive(:request_service).and_return(bus_service)
     allow(DInstaller::Manager).to receive(:new).with(config, logger).and_return(manager)
     allow(DInstaller::CockpitManager).to receive(:new).and_return(cockpit)
+    allow(manager).to receive(:software).and_return(software_client)
   end
 
   describe "#start" do

--- a/service/test/dinstaller/dbus/manager_test.rb
+++ b/service/test/dinstaller/dbus/manager_test.rb
@@ -33,10 +33,14 @@ describe DInstaller::DBus::Manager do
   let(:backend) do
     instance_double(DInstaller::Manager,
       installation_phase:        installation_phase,
+      software:                  software_client,
       on_services_status_change: nil)
   end
 
   let(:installation_phase) { DInstaller::InstallationPhase.new }
+  let(:software_client) do
+    instance_double(DInstaller::DBus::Clients::Software, on_product_selected: nil)
+  end
   let(:service_status_recorder) { DInstaller::ServiceStatusRecorder.new }
 
   let(:idle) { DInstaller::DBus::ServiceStatus::IDLE }
@@ -71,6 +75,11 @@ describe DInstaller::DBus::Manager do
 
     it "configures callbacks for changes in the status of other services" do
       expect(backend).to receive(:on_services_status_change)
+      subject
+    end
+
+    it "configures callbacks to be called when a product is selected" do
+      expect(software_client).to receive(:on_product_selected)
       subject
     end
 

--- a/service/test/dinstaller/dbus/manager_test.rb
+++ b/service/test/dinstaller/dbus/manager_test.rb
@@ -86,22 +86,54 @@ describe DInstaller::DBus::Manager do
   end
 
   describe "#config_phase" do
-    it "runs the config phase, setting the service as busy meanwhile" do
-      expect(subject.service_status).to receive(:busy)
-      expect(backend).to receive(:config_phase)
-      expect(subject.service_status).to receive(:idle)
+    context "when the service is idle" do
+      before do
+        subject.service_status.idle
+      end
 
-      subject.config_phase
+      it "runs the config phase, setting the service as busy meanwhile" do
+        expect(subject.service_status).to receive(:busy)
+        expect(backend).to receive(:config_phase)
+        expect(subject.service_status).to receive(:idle)
+
+        subject.config_phase
+      end
+    end
+
+    context "when the service is busy" do
+      before do
+        subject.service_status.busy
+      end
+
+      it "raises a D-Bus error" do
+        expect { subject.config_phase }.to raise_error(::DBus::Error)
+      end
     end
   end
 
   describe "#install_phase" do
-    it "runs the install phase, setting the service as busy meanwhile" do
-      expect(subject.service_status).to receive(:busy)
-      expect(backend).to receive(:install_phase)
-      expect(subject.service_status).to receive(:idle)
+    context "when the service is idle" do
+      before do
+        subject.service_status.idle
+      end
 
-      subject.install_phase
+      it "runs the install phase, setting the service as busy meanwhile" do
+        expect(subject.service_status).to receive(:busy)
+        expect(backend).to receive(:install_phase)
+        expect(subject.service_status).to receive(:idle)
+
+        subject.install_phase
+      end
+    end
+
+    context "when the service is busy" do
+      before do
+        subject.service_status.busy
+      end
+
+      it "raises a D-Bus error" do
+        expect { subject.install_phase }.to raise_error(::DBus::Error)
+      end
     end
   end
 

--- a/service/test/dinstaller/manager_test.rb
+++ b/service/test/dinstaller/manager_test.rb
@@ -76,11 +76,6 @@ describe DInstaller::Manager do
       subject.startup_phase
     end
 
-    it "configures software callbacks" do
-      expect(software).to receive(:on_product_selected)
-      subject.startup_phase
-    end
-
     context "when only one product is defined" do
       let(:config_path) do
         File.join(FIXTURES_PATH, "d-installer-single.yaml")
@@ -178,6 +173,19 @@ describe DInstaller::Manager do
 
       expect(logger).to receive(:info).with(/change status/)
       service_status_recorder.save("org.opensuse.DInstaller.Test", busy)
+    end
+  end
+
+  describe "#select_product" do
+    it "configures the given product as selected product" do
+      subject.select_product("Leap")
+      expect(config.data["software"]["base_product"]).to eq("Leap")
+      expect(config.pure_data["software"]).to be_nil
+    end
+
+    it "runs the config phase" do
+      expect(subject).to receive(:config_phase)
+      subject.select_product("Leap")
     end
   end
 end


### PR DESCRIPTION
## Problem

There are several problems associated to D-Bus:

* D-Bus clients subscribe to the same signal several times, invalidating previous subscriptions.
* The manager service is not set as busy when running the config phase as effect of selectiong a product.
* The manager service could dispatch an action meanwhile it is busy. For example, a client could make the manager to execute the config phase while it is executing the install phase.  

Related to https://github.com/yast/d-installer/pull/209.

## Solution

The problems above are fixed. Clients use the new `#on_properties_change` method to ensure that signal subscriptions are done only once. The D-Bus Manager object configures the callbacks for the *software* client, setting the service as busy while addressing the signal. And the Manager D-Bus API raises an exception if a D-Bus method is requested when the service is busy.

## Testing

* Added new unit tests
* Tested manually
