### PR TITLE
Install LSM patterns

### DIFF
--- a/service/lib/dinstaller/dbus/y2dir/manager/modules/Package.rb
+++ b/service/lib/dinstaller/dbus/y2dir/manager/modules/Package.rb
@@ -36,6 +36,14 @@ module Yast
     def Available(_package_name)
       true
     end
+
+    # Determines whether the package is available
+    #
+    # @see https://github.com/yast/yast-yast2/blob/b8cd178b7f341f6e3438782cb703f4a3ab0529ed/library/packages/src/modules/Package.rb#L121
+    # @todo Perform a real D-Bus call.
+    def Installed(_package_name, target: nil)
+      false
+    end
   end
 
   Package = PackageClass.new

--- a/service/lib/dinstaller/security.rb
+++ b/service/lib/dinstaller/security.rb
@@ -69,7 +69,7 @@ module DInstaller
     end
 
     def write
-      config.save
+      lsm_config.save
     end
 
     def probe

--- a/service/lib/dinstaller/security.rb
+++ b/service/lib/dinstaller/security.rb
@@ -60,6 +60,9 @@ end
 module DInstaller
   # Backend class between dbus service and yast code
   class Security
+    # @return [Logger]
+    attr_reader :logger
+
     def initialize(logger, config)
       @config = config
       @logger = logger
@@ -70,12 +73,23 @@ module DInstaller
     end
 
     def probe
-      config.select(@config.data["security"]["lsm"])
+      selected_lsm = config.data["security"]["lsm"]
+      lsm_config.select(selected_lsm)
+
+      patterns = if selected_lsm.nil?
+        []
+      else
+        lsm_data = config.data["security"]["available_lsms"][selected_lsm]
+        lsm_data["patterns"]
+      end
+      Yast::PackagesProposal.SetResolvables("LSM", :pattern, patterns)
     end
 
   private
 
-    def config
+    attr_reader :config
+
+    def lsm_config
       Y2Security::LSM::Config.instance
     end
   end

--- a/service/test/dinstaller/security_test.rb
+++ b/service/test/dinstaller/security_test.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+require "dinstaller/security"
+
+describe DInstaller::Security do
+  subject { described_class.new(logger, config) }
+
+  let(:logger) { Logger.new($stdout) }
+
+  let(:config_path) do
+    File.join(FIXTURES_PATH, "root_dir", "etc", "d-installer.yaml")
+  end
+
+  let(:config) do
+    DInstaller::Config.new(YAML.safe_load(File.read(config_path)))
+  end
+
+  let(:y2security) do
+    instance_double(Y2Security::LSM::Config, select: nil)
+  end
+
+  before do
+    allow(Y2Security::LSM::Config).to receive(:instance).and_return(y2security)
+  end
+
+  describe "#probe" do
+    it "selects the default LSM" do
+      expect(y2security).to receive(:select).with("apparmor")
+      subject.probe
+    end
+  end
+end

--- a/service/test/dinstaller/security_test.rb
+++ b/service/test/dinstaller/security_test.rb
@@ -71,4 +71,11 @@ describe DInstaller::Security do
       end
     end
   end
+
+  describe "#write" do
+    it "saves the LSM configuration" do
+      expect(lsm_config).to receive(:save)
+      security.write
+    end
+  end
 end


### PR DESCRIPTION
## Problem

Required patterns for the default LSM are not selected, hence the system might not be usable (for instance, Leap Micro will not boot).

## Solution

Add the needed patterns required for the "selected" LSM patterns.

## Testing

- Added a new unit test
- Tested manually
