### PR TITLE
Install storage packages

### DIFF
--- a/service/lib/dinstaller/software.rb
+++ b/service/lib/dinstaller/software.rb
@@ -152,9 +152,6 @@ module DInstaller
       optional_patterns = @config.data["software"]["optional_patterns"] || []
       Yast::PackagesProposal.SetResolvables("d-installer", :pattern, optional_patterns,
         optional: true)
-
-      # FIXME: temporary workaround to get btrfsprogs into the installed system
-      Yast::PackagesProposal.AddResolvables("d-installer", :package, ["btrfsprogs"])
     end
 
     # call solver to satisfy dependency or log error

--- a/service/test/dinstaller/storage/proposal_test.rb
+++ b/service/test/dinstaller/storage/proposal_test.rb
@@ -28,9 +28,17 @@ describe DInstaller::Storage::Proposal do
 
   let(:logger) { Logger.new($stdout, level: :warn) }
   let(:config) { DInstaller::Config.new(config_data) }
-  let(:y2storage_proposal) { instance_double(Y2Storage::GuidedProposal, failed?: failed) }
+  let(:y2storage_proposal) do
+    instance_double(Y2Storage::GuidedProposal, failed?: failed, devices: proposed_devicegraph)
+  end
   let(:y2storage_manager) do
     instance_double(Y2Storage::StorageManager, probed: nil, probed_disk_analyzer: nil)
+  end
+  let(:proposed_devicegraph) do
+    instance_double(Y2Storage::Devicegraph, used_features: used_features)
+  end
+  let(:used_features) do
+    instance_double(Y2Storage::StorageFeaturesList, pkg_list: ["btrfsprogs", "snapper"])
   end
   let(:failed) { false }
   let(:config_data) { {} }
@@ -39,6 +47,7 @@ describe DInstaller::Storage::Proposal do
     before do
       allow(Y2Storage::StorageManager).to receive(:instance).and_return y2storage_manager
       allow(Y2Storage::GuidedProposal).to receive(:initial).and_return y2storage_proposal
+      allow(Yast::PackagesProposal).to receive(:SetResolvables)
       allow(y2storage_manager).to receive(:proposal=)
     end
 


### PR DESCRIPTION
## Problem

Only the `btrfsprogs` is installed (it is hardcoded in the software service).


## Solution

Use the `StorageFeaturesList` from `storage-ng` to determine which packages should be installed. 

## Testing

- Added a new unit test
- Tested manually