### PR TITLE
Support nil value for resolvables list

### DIFF
--- a/service/lib/dinstaller/dbus/y2dir/manager/modules/PackagesProposal.rb
+++ b/service/lib/dinstaller/dbus/y2dir/manager/modules/PackagesProposal.rb
@@ -31,13 +31,13 @@ module Yast
 
     # @see https://github.com/yast/yast-yast2/blob/b8cd178b7f341f6e3438782cb703f4a3ab0529ed/library/general/src/modules/PackagesProposal.rb#L118
     def AddResolvables(unique_id, type, resolvables, optional: false)
-      client.add_resolvables(unique_id, type, resolvables, optional: optional)
+      client.add_resolvables(unique_id, type, resolvables || [], optional: optional)
       true
     end
 
     # @see https://github.com/yast/yast-yast2/blob/b8cd178b7f341f6e3438782cb703f4a3ab0529ed/library/general/src/modules/PackagesProposal.rb#L145
     def SetResolvables(unique_id, type, resolvables, optional: false)
-      client.set_resolvables(unique_id, type, resolvables, optional: optional)
+      client.set_resolvables(unique_id, type, resolvables || [], optional: optional)
       true
     end
 
@@ -48,7 +48,7 @@ module Yast
 
     # @see https://github.com/yast/yast-yast2/blob/b8cd178b7f341f6e3438782cb703f4a3ab0529ed/library/general/src/modules/PackagesProposal.rb#L177
     def RemoveResolvables(unique_id, type, resolvables, optional: false)
-      client.remove_resolvables(unique_id, type, resolvables, optional: optional)
+      client.remove_resolvables(unique_id, type, resolvables || [], optional: optional)
       true
     end
 

--- a/service/package/rubygem-d-installer.changes
+++ b/service/package/rubygem-d-installer.changes
@@ -4,6 +4,8 @@ Tue Jul 26 09:56:53 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 - Update to version 0.4.1:
   * Respond to D-Bus messages during software installation
     (gh#yast/d-installer#223).
+  * Prevent the redefined PackagesProposal module from sending a
+    nil value over D-Bus.
 
 -------------------------------------------------------------------
 Fri Jul 15 07:24:16 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>


### PR DESCRIPTION
In the original `PackagesProposal` module, it is possible to [use `nil` as the `resolvables` parameter](https://github.com/yast/yast-yast2/blob/master/library/general/src/modules/PackagesProposal.rb#L122). So we should keep this behavior in the new module.