### PR TITLE
Better error reporting for the storage proposal

### DIFF
--- a/web/src/Storage.jsx
+++ b/web/src/Storage.jsx
@@ -130,9 +130,17 @@ export default function Storage() {
     });
   }, [client.manager]);
 
-  const errorMessage = `Cannot make a proposal for ${target}`;
+  const errorMessage = () => {
+    if (targets.length === 0) {
+      return "Cannot find a suitable storage device for installation";
+    } else if (target) {
+      return `Cannot make a proposal for ${target}`;
+    } else {
+      return "Something went wrong when trying to come up with an storage proposal";
+    }
+  };
 
-  if (state.status === BUSY || target === undefined) {
+  if (state.status === BUSY) {
     return (
       <InstallerSkeleton lines={3} />
     );
@@ -140,12 +148,13 @@ export default function Storage() {
 
   return (
     <>
-      <TargetSelector
-        target={target || "Select device to install into"}
-        targets={targets}
-        onAccept={onAccept}
-      />
-      {error && <Alert variant="danger" isPlain isInline title={errorMessage} />}
+      {targets.length > 0 &&
+        <TargetSelector
+          target={target || "Select device to install into"}
+          targets={targets}
+          onAccept={onAccept}
+        />}
+      {error && <Alert variant="danger" isPlain isInline title={errorMessage()} />}
       <Proposal data={actions} />
     </>
   );

--- a/web/src/Storage.test.jsx
+++ b/web/src/Storage.test.jsx
@@ -29,15 +29,7 @@ import { IDLE } from "./client/status";
 jest.mock("./client");
 jest.mock("./InstallerSkeleton", () => () => "Loading storage");
 
-const proposalSettings = {
-  availableDevices: [
-    { id: "/dev/sda", label: "/dev/sda, 500 GiB" },
-    { id: "/dev/sdb", label: "/dev/sdb, 650 GiB" }
-  ],
-  candidateDevices: ["/dev/sda"],
-  lvm: false
-};
-
+let proposalSettings;
 let storageActions;
 
 let onActionsChangeFn = jest.fn();
@@ -52,6 +44,14 @@ const storageMock = {
 
 beforeEach(() => {
   storageActions = [{ text: "Mount /dev/sda1 as root", subvol: false, delete: false }];
+  proposalSettings = {
+    availableDevices: [
+      { id: "/dev/sda", label: "/dev/sda, 500 GiB" },
+      { id: "/dev/sdb", label: "/dev/sdb, 650 GiB" }
+    ],
+    candidateDevices: ["/dev/sda"],
+    lvm: false
+  };
   createClient.mockImplementation(() => {
     return {
       storage: {
@@ -153,5 +153,21 @@ describe("when the storage actions changes", () => {
     const [cb] = callbacks;
     act(() => cb([]));
     await screen.findByText("Cannot make a proposal for /dev/sda");
+  });
+});
+
+describe("when there are not devices for installation", () => {
+  beforeEach(() => {
+    storageActions = [];
+    proposalSettings = {
+      availableDevices: [],
+      candidateDevices: [],
+      lvm: false
+    };
+  });
+
+  it("reports an error", async() => {
+    installerRender(<Storage />);
+    await screen.findByText("Cannot find a suitable storage device for installation");
   });
 });

--- a/web/src/Storage.test.jsx
+++ b/web/src/Storage.test.jsx
@@ -93,14 +93,14 @@ describe("when the user selects another disk", () => {
     calculateStorageProposalFn = jest.fn().mockResolvedValue(0);
 
     const { user } = installerRender(<Storage />);
-    const button = await screen.findByRole("button", { name: "/dev/sda" });
+    const button = await screen.findByRole("button", { name: "/dev/sda, 500 GiB" });
     await user.click(button);
 
     const targetSelector = await screen.findByLabelText("Device to install into");
     await user.selectOptions(targetSelector, ["/dev/sdb"]);
     await user.click(screen.getByRole("button", { name: "Confirm" }));
 
-    await screen.findByRole("button", { name: "/dev/sdb" });
+    await screen.findByRole("button", { name: "/dev/sdb, 650 GiB" });
     expect(calculateStorageProposalFn).toHaveBeenCalledWith({
       candidateDevices: ["/dev/sdb"]
     });
@@ -117,13 +117,13 @@ describe("when the storage proposal changes", () => {
 
   it("updates the proposal", async () => {
     installerRender(<Storage />);
-    await screen.findByRole("button", { name: "/dev/sda" });
+    await screen.findByRole("button", { name: "/dev/sda, 500 GiB" });
 
     const [cb] = callbacks;
     act(() => {
       cb("/dev/sdb");
     });
-    await screen.findByRole("button", { name: "/dev/sdb" });
+    await screen.findByRole("button", { name: "/dev/sdb, 650 GiB" });
   });
 });
 

--- a/web/src/TargetSelector.jsx
+++ b/web/src/TargetSelector.jsx
@@ -61,10 +61,12 @@ export default function TargetSelector({ target, targets, onAccept }) {
     );
   };
 
+  const targetDevice = targets.find(i => i.id === target);
+
   return (
     <>
       <Button variant="link" onClick={open}>
-        {target}
+        {targetDevice && targetDevice.label}
       </Button>
 
       <Popup isOpen={isFormOpen} onSubmit={accept} aria-label="Target Selector">


### PR DESCRIPTION
## Problem

When D-Installer does not find any suitable storage device for installation, the user does not get any feedback.

## Solution

Display a better error when not suitable storage devices were found or when something else happened.

Bonus: display more information about the selected storage devices.

## Screenshots

![Captura desde 2022-08-24 13-44-57](https://user-images.githubusercontent.com/15836/186421714-0ec558bc-7ec7-49cc-8ed8-f65e1a712c33.png)
