### PR TITLE
LUKS activation over D-Bus

### DIFF
--- a/service/lib/dinstaller/dbus/clients/question.rb
+++ b/service/lib/dinstaller/dbus/clients/question.rb
@@ -46,6 +46,11 @@ module DInstaller
 
         # TODO: what other methods are useful?
 
+        # @return [String] Question text
+        def text
+          @dbus_iface["Text"].to_s
+        end
+
         # @return [Symbol] no answer yet = :""
         def answer
           @dbus_iface["Answer"].to_sym

--- a/service/lib/dinstaller/dbus/clients/question.rb
+++ b/service/lib/dinstaller/dbus/clients/question.rb
@@ -37,6 +37,8 @@ module DInstaller
 
           @dbus_object = service[object_path]
           @dbus_iface = @dbus_object["org.opensuse.DInstaller.Question1"]
+          # one D-Bus client for all kinds of questions
+          @luks_iface = @dbus_object["org.opensuse.DInstaller.Question.LuksActivation1"]
         end
 
         # @return [String]
@@ -54,6 +56,11 @@ module DInstaller
         # @return [Symbol] no answer yet = :""
         def answer
           @dbus_iface["Answer"].to_sym
+        end
+
+        # @return [String]
+        def password
+          @luks_iface["Password"]
         end
 
         # Whether the question is already answered

--- a/service/lib/dinstaller/dbus/clients/questions_manager.rb
+++ b/service/lib/dinstaller/dbus/clients/questions_manager.rb
@@ -46,12 +46,16 @@ module DInstaller
         # @param question [DInstaller::Question]
         # @return [DBus::Clients::Question]
         def add(question)
-          q_path = @dbus_object.New(
-            question.text,
-            question.options.map(&:to_s),
-            Array(question.default_option&.to_s)
-          )
+          q_path = add_dbus_question(question)
           DBus::Clients::Question.new(q_path)
+        end
+
+        def add_dbus_question(question)
+          if question.is_a?(DInstaller::LuksActivationQuestion)
+            add_luks_activation_question(question)
+          else
+            add_generic_question(question)
+          end
         end
 
         # Deletes the given question
@@ -85,6 +89,20 @@ module DInstaller
 
         # @return [::DBus::Object]
         attr_reader :dbus_object
+
+        def add_generic_question(question)
+          @dbus_object.New(
+            question.text,
+            question.options.map(&:to_s),
+            Array(question.default_option&.to_s)
+          )
+        end
+
+        def add_luks_activation_question(question)
+          @dbus_object.NewLuksActivation(
+            question.device, question.label, question.size
+          )
+        end
       end
     end
   end

--- a/service/lib/dinstaller/dbus/manager_service.rb
+++ b/service/lib/dinstaller/dbus/manager_service.rb
@@ -23,7 +23,6 @@ require "dbus"
 require "dinstaller/manager"
 require "dinstaller/cockpit_manager"
 require "dinstaller/dbus/manager"
-require "dinstaller/dbus/language"
 require "dinstaller/dbus/storage/proposal"
 
 module DInstaller
@@ -102,17 +101,12 @@ module DInstaller
       # @return [Array<::DBus::Object>]
       def dbus_objects
         @dbus_objects ||= [
-          manager_dbus,
-          language_dbus
+          manager_dbus
         ]
       end
 
       def manager_dbus
         @manager_dbus ||= DInstaller::DBus::Manager.new(manager, logger)
-      end
-
-      def language_dbus
-        @language_dbus ||= DInstaller::DBus::Language.new(manager.language, logger)
       end
     end
   end

--- a/service/lib/dinstaller/dbus/questions.rb
+++ b/service/lib/dinstaller/dbus/questions.rb
@@ -90,6 +90,14 @@ module DInstaller
           path_for(backend_q)
         end
 
+        dbus_method :NewLuksActivation, "in device:s, in label:s, in size:s, out q:o" do
+          |device, label, size|
+
+          backend_q = DInstaller::LuksActivationQuestion.new(device, label: label, size: size)
+          backend.add(backend_q)
+          path_for(backend_q)
+        end
+
         dbus_method :Delete, "in question:o" do |question_path|
           dbus_q = @service.get_node(question_path)&.object
           raise ArgumentError, "Object path #{question_path} not found" unless dbus_q

--- a/service/lib/dinstaller/luks_activation_question.rb
+++ b/service/lib/dinstaller/luks_activation_question.rb
@@ -36,6 +36,15 @@ module DInstaller
   #
   #   question.answer = :decrypt # in case you want to decrypt with the given password
   class LuksActivationQuestion < Question
+    # @return [String]
+    attr_reader :device
+
+    # @return [String, nil]
+    attr_reader :label
+
+    # @return [String, nil]
+    attr_reader :size
+
     # Current attempt to decrypt the device
     #
     # @return [Integer]
@@ -61,15 +70,6 @@ module DInstaller
     attr_accessor :password
 
   private
-
-    # @return [String]
-    attr_reader :device
-
-    # @return [String, nil]
-    attr_reader :label
-
-    # @return [String, nil]
-    attr_reader :size
 
     # Generate the text for the question
     #

--- a/service/test/dinstaller/dbus/clients/question_test.rb
+++ b/service/test/dinstaller/dbus/clients/question_test.rb
@@ -31,12 +31,15 @@ describe DInstaller::DBus::Clients::Question do
       .and_return(dbus_object)
     allow(dbus_object).to receive(:[]).with("org.opensuse.DInstaller.Question1")
       .and_return(question_iface)
+    allow(dbus_object).to receive(:[]).with("org.opensuse.DInstaller.Question.LuksActivation1")
+      .and_return(luks_iface)
   end
 
   let(:bus) { instance_double(::DBus::SystemBus) }
   let(:service) { instance_double(::DBus::Service) }
   let(:dbus_object) { instance_double(::DBus::ProxyObject) }
   let(:question_iface) { instance_double(::DBus::ProxyObjectInterface) }
+  let(:luks_iface) { instance_double(::DBus::ProxyObjectInterface) }
 
   subject { described_class.new("/org/opensuse/DInstaller/Questions1/23") }
 
@@ -44,6 +47,20 @@ describe DInstaller::DBus::Clients::Question do
     it "returns false if there is no answer" do
       expect(question_iface).to receive(:[]).with("Answer").and_return("")
       expect(subject.answered?).to eq false
+    end
+  end
+
+  describe "#text" do
+    it "returns the appropriate property" do
+      expect(question_iface).to receive(:[]).with("Text").and_return("the text")
+      expect(subject.text).to eq "the text"
+    end
+  end
+
+  describe "#password" do
+    it "returns the appropriate property of the luks interface" do
+      expect(luks_iface).to receive(:[]).with("Password").and_return("the password")
+      expect(subject.password).to eq "the password"
     end
   end
 end

--- a/service/test/dinstaller/dbus/manager_service_test.rb
+++ b/service/test/dinstaller/dbus/manager_service_test.rb
@@ -37,9 +37,6 @@ describe DInstaller::DBus::ManagerService do
   let(:software_client) do
     instance_double(DInstaller::DBus::Clients::Software, on_product_selected: nil)
   end
-  let(:language_client) do
-    instance_double(DInstaller::DBus::Clients::Language, on_language_selected: nil)
-  end
 
   before do
     allow(::DBus::SystemBus).to receive(:instance).and_return(bus)
@@ -47,7 +44,6 @@ describe DInstaller::DBus::ManagerService do
     allow(DInstaller::Manager).to receive(:new).with(config, logger).and_return(manager)
     allow(DInstaller::CockpitManager).to receive(:new).and_return(cockpit)
     allow(manager).to receive(:software).and_return(software_client)
-    allow(manager).to receive(:language).and_return(language_client)
   end
 
   describe "#start" do
@@ -58,12 +54,12 @@ describe DInstaller::DBus::ManagerService do
   end
 
   describe "#export" do
-    it "exports the language manager object" do
-      language_obj = instance_double(DInstaller::DBus::Language, path: nil)
-      allow(DInstaller::DBus::Language).to receive(:new)
-        .with(manager.language, logger).and_return(language_obj)
+    it "exports the manager object" do
+      manager_obj = instance_double(DInstaller::DBus::Manager, path: nil)
+      allow(DInstaller::DBus::Manager).to receive(:new)
+        .with(manager, logger).and_return(manager_obj)
 
-      expect(bus_service).to receive(:export).with(language_obj)
+      expect(bus_service).to receive(:export).with(manager_obj)
       service.export
     end
   end

--- a/service/test/dinstaller/dbus/questions_test.rb
+++ b/service/test/dinstaller/dbus/questions_test.rb
@@ -132,4 +132,44 @@ describe DInstaller::DBus::Questions do
         .to contain_exactly("Attempt", "Password")
     end
   end
+
+  describe "Questions interface" do
+    let(:interface) { "org.opensuse.DInstaller.Questions1" }
+    let(:full_method_name) { described_class.make_method_name(interface, method_name) }
+
+    describe "#New" do
+      let(:method_name) { "New" }
+
+      it "adds a question and returns its path" do
+        expect(backend).to receive(:add)
+        expect(subject.public_send(full_method_name, "How you doin?", ["fine", "great"], []))
+          .to start_with "/org/opensuse/DInstaller/Questions1/"
+      end
+    end
+
+    describe "#NewLuksActivation" do
+      let(:method_name) { "NewLuksActivation" }
+
+      it "adds a question and returns its path" do
+        expect(backend).to receive(:add)
+        expect(subject.public_send(full_method_name, "/dev/tape1", "New games", "90 minutes"))
+          .to start_with "/org/opensuse/DInstaller/Questions1/"
+      end
+    end
+
+    describe "#Delete" do
+      let(:method_name) { "Delete" }
+
+      it "deletes the question" do
+        q = DInstaller::Question.new("Huh?", options: [])
+        path = "/org/opensuse/DInstaller/Questions1/666"
+        dbus_q = DInstaller::DBus::Question.new(path, q, logger)
+        node = instance_double(DBus::Node, object: dbus_q)
+
+        expect(service).to receive(:get_node).with(path).and_return(node)
+        expect(backend).to receive(:delete).with(q)
+        expect { subject.public_send(full_method_name, path) }.to_not raise_error
+      end
+    end
+  end
 end

--- a/service/test/dinstaller/questions_manager_test.rb
+++ b/service/test/dinstaller/questions_manager_test.rb
@@ -31,7 +31,7 @@ describe DInstaller::QuestionsManager do
   let(:callback) { proc {} }
 
   let(:question1) { DInstaller::Question.new("test1", options: [:yes, :no]) }
-  let(:question2) { DInstaller::Question.new("test2", options: [:yes, :no]) }
+  let(:question2) { DInstaller::LuksActivationQuestion.new("sda1") }
 
   describe "#add" do
     before do
@@ -51,7 +51,7 @@ describe DInstaller::QuestionsManager do
         subject.add(question1)
       end
 
-      it "returns trthy value" do
+      it "returns truthy value" do
         expect(subject.add(question1)).to be_truthy
       end
     end
@@ -137,7 +137,7 @@ describe DInstaller::QuestionsManager do
       proc do
         times += 1
         question1.answer = :yes if times == 2
-        question2.answer = :no if times == 3
+        question2.answer = :skip if times == 3
       end
     end
 


### PR DESCRIPTION
## Problem

#249 says: After moving questions to a separate service (see https://github.com/yast/d-installer/pull/248), it is not possible to unlock LUKS devices anymore. The problem is there is no way to ask a LUKS question over D-Bus, so those questions are always handled like generic ones. 


## Solution

Teach the Questions service about `NewLuksActivation` and add the appropriate client code.

## Testing

Added new unit tests

Tested manually:

1. set up a toy LUKS partition in the testing VM
```sh
IMG=/dev/sda3 # it is the swap partition. make sure to use a scratch one too in your testing!
swapoff $IMG
cryptsetup --force-password luksFormat $IMG  # force accepting a simple password
```

2. now run the installer and click through 

3. Once the installer successfully unlocks the partition, we need to close it manually to be able to rerun the test: `cryptsetup close cr-auto-1`

See also `man cryptsetup`

## Screenshots

![d-installer-luks-question](https://user-images.githubusercontent.com/102056/189367224-279d78f9-ea4c-4776-812d-27bfd5374bb0.jpg)


