### PR TITLE
Add missing attempt param to LUKS activation questions

### DIFF
--- a/service/.rubocop.yml
+++ b/service/.rubocop.yml
@@ -9,6 +9,16 @@ AllCops:
     - vendor/**/*
     - lib/dinstaller/dbus/y2dir/**/*
 
+# a D-Bus method definition may take up more line lenght than usual
+Layout/LineLength:
+  IgnoredPatterns:
+    - dbus_method
+
+# a D-Bus interface definition may take up more lines than a regular method
+Metrics/BlockLength:
+  IgnoredMethods:
+    - dbus_interface
+
 # assignment in method calls is used to document some params
 Lint/UselessAssignment:
   Enabled: false

--- a/service/lib/dinstaller/dbus/clients/questions_manager.rb
+++ b/service/lib/dinstaller/dbus/clients/questions_manager.rb
@@ -100,7 +100,7 @@ module DInstaller
 
         def add_luks_activation_question(question)
           @dbus_object.NewLuksActivation(
-            question.device, question.label, question.size
+            question.device, question.label, question.size, question.attempt
           )
         end
       end

--- a/service/lib/dinstaller/dbus/questions.rb
+++ b/service/lib/dinstaller/dbus/questions.rb
@@ -93,7 +93,10 @@ module DInstaller
         dbus_method :NewLuksActivation, "in device:s, in label:s, in size:s, in attempt:y, out q:o" do
           |device, label, size, attempt|
 
-          backend_q = DInstaller::LuksActivationQuestion.new(device, label: label, size: size, attempt: attempt)
+          backend_q = DInstaller::LuksActivationQuestion.new(
+            device, label: label, size: size, attempt: attempt
+          )
+
           backend.add(backend_q)
           path_for(backend_q)
         end

--- a/service/lib/dinstaller/dbus/questions.rb
+++ b/service/lib/dinstaller/dbus/questions.rb
@@ -90,10 +90,10 @@ module DInstaller
           path_for(backend_q)
         end
 
-        dbus_method :NewLuksActivation, "in device:s, in label:s, in size:s, out q:o" do
-          |device, label, size|
+        dbus_method :NewLuksActivation, "in device:s, in label:s, in size:s, in attempt:y, out q:o" do
+          |device, label, size, attempt|
 
-          backend_q = DInstaller::LuksActivationQuestion.new(device, label: label, size: size)
+          backend_q = DInstaller::LuksActivationQuestion.new(device, label: label, size: size, attempt: attempt)
           backend.add(backend_q)
           path_for(backend_q)
         end

--- a/service/lib/dinstaller/dbus/users.rb
+++ b/service/lib/dinstaller/dbus/users.rb
@@ -51,7 +51,6 @@ module DInstaller
       FUSER_SIG = "in FullName:s, in UserName:s, in Password:s, in AutoLogin:b, in data:a{sv}"
       private_constant :FUSER_SIG
 
-      # rubocop:disable Metrics/BlockLength
       dbus_interface USERS_INTERFACE do
         dbus_reader :root_password_set, "b"
 
@@ -109,7 +108,6 @@ module DInstaller
           0
         end
       end
-      # rubocop:enable Metrics/BlockLength
 
       def root_ssh_key
         backend.root_ssh_key

--- a/service/test/dinstaller/dbus/questions_test.rb
+++ b/service/test/dinstaller/dbus/questions_test.rb
@@ -152,7 +152,7 @@ describe DInstaller::DBus::Questions do
 
       it "adds a question and returns its path" do
         expect(backend).to receive(:add)
-        expect(subject.public_send(full_method_name, "/dev/tape1", "New games", "90 minutes"))
+        expect(subject.public_send(full_method_name, "/dev/tape1", "New games", "90 minutes", 1))
           .to start_with "/org/opensuse/DInstaller/Questions1/"
       end
     end


### PR DESCRIPTION
## Problem

LuksActivationQuestion is not displaying any hint about a wrong password entered. See https://github.com/yast/d-installer/issues/165#issuecomment-1245428344

## Solution

Add the missing `attempt` param when registering the question in D-Bus.

## Testing

- Adapted unit tests.
