### PR TITLE
Usability improvements in the LUKS decrypt dialog

### DIFF
--- a/service/lib/dinstaller/luks_activation_question.rb
+++ b/service/lib/dinstaller/luks_activation_question.rb
@@ -75,7 +75,7 @@ module DInstaller
     #
     # @return [String]
     def generate_text
-      "The device #{device_info} is encrypted. Do you want to decrypt it?"
+      "The device #{device_info} is encrypted."
     end
 
     # Device information to include in the question

--- a/web/src/LuksActivationQuestion.jsx
+++ b/web/src/LuksActivationQuestion.jsx
@@ -20,7 +20,7 @@
  */
 
 import React, { useState } from "react";
-import { Alert, Form, FormGroup, Stack, StackItem, Text, TextInput } from "@patternfly/react-core";
+import { ActionGroup, Alert, Form, FormGroup, Stack, StackItem, Text, TextInput } from "@patternfly/react-core";
 import Popup from "./Popup";
 import QuestionActions from "./QuestionActions";
 
@@ -53,15 +53,15 @@ export default function LuksActivationQuestion({ question, answerCallback }) {
       aria-label="Question"
       titleIconVariant={() => <Icon size="24" />}
     >
-      <Stack hasGutter>
-        { renderAlert(question.attempt) }
-        <StackItem>
-          <Text>
-            { question.text }
-          </Text>
-        </StackItem>
-        <StackItem>
-          <Form>
+      <Form>
+        <Stack hasGutter>
+          { renderAlert(question.attempt) }
+          <StackItem>
+            <Text>
+              { question.text }
+            </Text>
+          </StackItem>
+          <StackItem>
             <FormGroup label="Encryption Password" fieldId="luks-password">
               <TextInput
                 autoFocus
@@ -71,18 +71,20 @@ export default function LuksActivationQuestion({ question, answerCallback }) {
                 onChange={setPassword}
               />
             </FormGroup>
-          </Form>
-        </StackItem>
-      </Stack>
+          </StackItem>
+        </Stack>
 
-      <Popup.Actions>
-        <QuestionActions
-          actions={question.options}
-          defaultAction={question.defaultOption}
-          actionCallback={actionCallback}
-          conditions={conditions}
-        />
-      </Popup.Actions>
+        <ActionGroup>
+          <Popup.Actions>
+            <QuestionActions
+              actions={question.options}
+              defaultAction="decrypt"
+              actionCallback={actionCallback}
+              conditions={conditions}
+            />
+          </Popup.Actions>
+        </ActionGroup>
+      </Form>
     </Popup>
   );
 }

--- a/web/src/Popup.jsx
+++ b/web/src/Popup.jsx
@@ -70,7 +70,7 @@ const Action = ({ children, ...props }) => (
  * @param {object} [props] - {@link Action} props
  */
 const PrimaryAction = ({ children, ...props }) => (
-  <Action { ...props } variant="primary">{ children }</Action>
+  <Action { ...props } variant="primary" type="submit">{ children }</Action>
 );
 
 /**


### PR DESCRIPTION
## Problem

The problem is already described at #165, the dialog for decrypting a LUKS device has several usability problems including:

- The wording is a bit weird (kind of inconsistent with the labels of the buttons).
- Clicking "enter" does not submit the password, instead it causes a page reload.
- The default option is to skip decryption which:
  - Hurts usability with keyboard (and you are already using the keyboard if you entered the password, isn't it?)
  - Makes too easy to skip decryption even after you have already entered a password

## Solution

- Simpler wording, based on the YaST one (see YaST screenshot at #165)
- "Decrypt" is enforced to be the default option.
- Ensure pressing "enter" works as expected, that is:
  - Doing nothing if there is no password in the corresponding input (since the "Decrypt" button is disabled).
  - Submitting the entered password if there is any written.

## Still pending

The buttons don't look like in the other dialogs. They are aligned to the left.

## Potentially controversial code changes

- type=submit
- hardcoded string

## Testing

Tested manually

## Screenshots

![decrypt](https://user-images.githubusercontent.com/3638289/190193029-af1b3964-13ce-4ffc-aed7-cc6ce3c70c2e.png)

