### PR TITLE
Usability improvements in the LUKS decrypt dialog

### DIFF
--- a/service/lib/dinstaller/luks_activation_question.rb
+++ b/service/lib/dinstaller/luks_activation_question.rb
@@ -75,7 +75,7 @@ module DInstaller
     #
     # @return [String]
     def generate_text
-      "The device #{device_info} is encrypted. Do you want to decrypt it?"
+      "The device #{device_info} is encrypted."
     end
 
     # Device information to include in the question

--- a/web/src/LuksActivationQuestion.jsx
+++ b/web/src/LuksActivationQuestion.jsx
@@ -39,11 +39,19 @@ const renderAlert = (attempt) => {
 export default function LuksActivationQuestion({ question, answerCallback }) {
   const [password, setPassword] = useState(question.password || "");
   const conditions = { disable: { decrypt: password === "" } };
+  const defaultAction = "decrypt";
 
   const actionCallback = (option) => {
     question.password = password;
     question.answer = option;
     answerCallback(question);
+  };
+
+  const triggerDefaultAction = async (e) => {
+    e.preventDefault();
+    if (!conditions.disable?.[defaultAction]) {
+      actionCallback(defaultAction);
+    }
   };
 
   return (
@@ -61,7 +69,7 @@ export default function LuksActivationQuestion({ question, answerCallback }) {
           </Text>
         </StackItem>
         <StackItem>
-          <Form>
+          <Form onSubmit={triggerDefaultAction}>
             <FormGroup label="Encryption Password" fieldId="luks-password">
               <TextInput
                 autoFocus
@@ -78,7 +86,7 @@ export default function LuksActivationQuestion({ question, answerCallback }) {
       <Popup.Actions>
         <QuestionActions
           actions={question.options}
-          defaultAction={question.defaultOption}
+          defaultAction={defaultAction}
           actionCallback={actionCallback}
           conditions={conditions}
         />

--- a/web/src/LuksActivationQuestion.jsx
+++ b/web/src/LuksActivationQuestion.jsx
@@ -47,7 +47,7 @@ export default function LuksActivationQuestion({ question, answerCallback }) {
     answerCallback(question);
   };
 
-  const triggerDefaultAction = async (e) => {
+  const triggerDefaultAction = (e) => {
     e.preventDefault();
     if (!conditions.disable?.[defaultAction]) {
       actionCallback(defaultAction);

--- a/web/src/LuksActivationQuestion.test.jsx
+++ b/web/src/LuksActivationQuestion.test.jsx
@@ -80,7 +80,7 @@ describe("LuksActivationQuestion", () => {
     });
   });
 
-  describe("when the user clicks on 'Skip'", () => {
+  describe("when the user selects one of the options", () => {
     beforeEach(() => {
       question = {
         id: 1,
@@ -90,39 +90,44 @@ describe("LuksActivationQuestion", () => {
       };
     });
 
-    it("calls the callback after setting both, answer and password", async() => {
-      const { user } = renderQuestion();
+    describe("by clicking on 'Skip'", () => {
+      it("calls the callback after setting both, answer and password", async() => {
+        const { user } = renderQuestion();
 
-      const passwordInput = await screen.findByLabelText("Encryption Password");
-      await user.type(passwordInput, "notSecret");
-      const skipButton = await screen.findByRole("button", { name: /Skip/ });
-      await user.click(skipButton);
+        const passwordInput = await screen.findByLabelText("Encryption Password");
+        await user.type(passwordInput, "notSecret");
+        const skipButton = await screen.findByRole("button", { name: /Skip/ });
+        await user.click(skipButton);
 
-      expect(question).toEqual(expect.objectContaining({ password: "notSecret", answer: "skip" }));
-      expect(answerFn).toHaveBeenCalledWith(question);
-    });
-  });
-
-  describe("when the user clicks on 'Decrypt'", () => {
-    beforeEach(() => {
-      question = {
-        id: 1,
-        text: "A Luks device found. Do you want to open it?",
-        attempt: 1,
-        options: ["decrypt", "skip"],
-      };
+        expect(question).toEqual(expect.objectContaining({ password: "notSecret", answer: "skip" }));
+        expect(answerFn).toHaveBeenCalledWith(question);
+      });
     });
 
-    it("calls the callback after setting both, answer and password", async() => {
-      const { user } = renderQuestion();
+    describe("by clicking on 'Decrypt'", () => {
+      it("calls the callback after setting both, answer and password", async() => {
+        const { user } = renderQuestion();
 
-      const passwordInput = await screen.findByLabelText("Encryption Password");
-      await user.type(passwordInput, "notSecret");
-      const skipButton = await screen.findByRole("button", { name: /Decrypt/ });
-      await user.click(skipButton);
+        const passwordInput = await screen.findByLabelText("Encryption Password");
+        await user.type(passwordInput, "notSecret");
+        const decryptButton = await screen.findByRole("button", { name: /Decrypt/ });
+        await user.click(decryptButton);
 
-      expect(question).toEqual(expect.objectContaining({ password: "notSecret", answer: "decrypt" }));
-      expect(answerFn).toHaveBeenCalledWith(question);
+        expect(question).toEqual(expect.objectContaining({ password: "notSecret", answer: "decrypt" }));
+        expect(answerFn).toHaveBeenCalledWith(question);
+      });
+    });
+
+    describe("submiting the form by pressing 'enter'", () => {
+      it("calls the callback after setting both, answer and password", async() => {
+        const { user } = renderQuestion();
+
+        const passwordInput = await screen.findByLabelText("Encryption Password");
+        await user.type(passwordInput, "notSecret{enter}");
+
+        expect(question).toEqual(expect.objectContaining({ password: "notSecret", answer: "decrypt" }));
+        expect(answerFn).toHaveBeenCalledWith(question);
+      });
     });
   });
 });


### PR DESCRIPTION
## Problem

The problem is already described at #165, the dialog for decrypting a LUKS device has several usability problems including:

- The wording is a bit weird (kind of inconsistent with the labels of the buttons).
- Clicking "enter" does not submit the password, instead it causes a page reload.
- The default option is to skip decryption which:
  - Hurts usability with keyboard (and you are already using the keyboard if you entered the password, isn't it?)
  - Makes too easy to skip decryption even after you have already entered a password

## Solution

- Simpler wording, based on the YaST one (see YaST screenshot at #165)
- "Decrypt" is enforced to be the default option.
- Ensure pressing "enter" works as expected, that is:
  - Doing nothing if there is no password in the corresponding input (since the "Decrypt" button is disabled).
  - Submitting the entered password if there is any written.

## Other pull requests

This replaces #252. In my opinion, this is less intrusive.

## Testing

Tested manually
