### PR TITLE
Move D-Bus configuration to /usr/share

### DIFF
--- a/service/package/gem2rpm.yml
+++ b/service/package/gem2rpm.yml
@@ -14,13 +14,13 @@
   Requires:       yast2-users
 # ## used by gem2rpm
 :post_install: |-
-  install -D -m 0644 %{buildroot}%{gem_base}/gems/%{mod_full_name}/share/dbus.conf %{buildroot}%{_sysconfdir}/dbus-1/system.d/org.opensuse.DInstaller.conf
+  install -D -m 0644 %{buildroot}%{gem_base}/gems/%{mod_full_name}/share/dbus.conf %{buildroot}%{_datadir}/dbus-1/system.d/org.opensuse.DInstaller.conf
   install -D -m 0644 %{buildroot}%{gem_base}/gems/%{mod_full_name}/share/dbus.service %{buildroot}%{_datadir}/dbus-1/system-services/org.opensuse.DInstaller.service
   install -D -m 0644 %{buildroot}%{gem_base}/gems/%{mod_full_name}/share/systemd.service %{buildroot}%{_unitdir}/d-installer.service
   install -D -m 0644 %{buildroot}%{gem_base}/gems/%{mod_full_name}/etc/d-installer.yaml %{buildroot}%{_sysconfdir}/d-installer.yaml
 # ## used by gem_packages
 :main:
-  :filelist: "%{_sysconfdir}/dbus-1/system.d/org.opensuse.DInstaller.conf\n
+  :filelist: "%{_datadir}/dbus-1/system.d/org.opensuse.DInstaller.conf\n
     %{_datadir}/dbus-1/system-services/org.opensuse.DInstaller.service\n
     %{_unitdir}/d-installer.service\n
     %{_sysconfdir}/d-installer.yaml\n"


### PR DESCRIPTION
Move the D-Bus configuration file to `/usr/share/dbus-1/system.d` instead of `/etc/...`. Check [comment #9 on bsc#1202059](https://bugzilla.opensuse.org/show_bug.cgi?id=1202059#c9) for further details.
