### PR TITLE
Restrict D-Bus access and disable autostart

### DIFF
--- a/service/package/gem2rpm.yml
+++ b/service/package/gem2rpm.yml
@@ -15,12 +15,10 @@
 # ## used by gem2rpm
 :post_install: |-
   install -D -m 0644 %{buildroot}%{gem_base}/gems/%{mod_full_name}/share/dbus.conf %{buildroot}%{_datadir}/dbus-1/system.d/org.opensuse.DInstaller.conf
-  install -D -m 0644 %{buildroot}%{gem_base}/gems/%{mod_full_name}/share/dbus.service %{buildroot}%{_datadir}/dbus-1/system-services/org.opensuse.DInstaller.service
   install -D -m 0644 %{buildroot}%{gem_base}/gems/%{mod_full_name}/share/systemd.service %{buildroot}%{_unitdir}/d-installer.service
   install -D -m 0644 %{buildroot}%{gem_base}/gems/%{mod_full_name}/etc/d-installer.yaml %{buildroot}%{_sysconfdir}/d-installer.yaml
 # ## used by gem_packages
 :main:
   :filelist: "%{_datadir}/dbus-1/system.d/org.opensuse.DInstaller.conf\n
-    %{_datadir}/dbus-1/system-services/org.opensuse.DInstaller.service\n
     %{_unitdir}/d-installer.service\n
     %{_sysconfdir}/d-installer.yaml\n"

--- a/service/share/dbus.conf
+++ b/service/share/dbus.conf
@@ -12,7 +12,7 @@
     <allow own="org.opensuse.DInstaller.Users" />
   </policy>
 
-  <policy context="default">
+  <policy user="root">
     <allow send_destination="org.opensuse.DInstaller" />
     <allow send_destination="org.opensuse.DInstaller"
            send_interface="org.freedesktop.DBus.Introspectable"/>

--- a/service/share/dbus.service
+++ b/service/share/dbus.service
@@ -1,5 +1,0 @@
-[D-BUS Service]
-Name=org.opensuse.DInstaller
-Exec=/usr/bin/d-installer
-User=root
-SystemdService=d-installer


### PR DESCRIPTION
As part of the [security audit](https://bugzilla.opensuse.org/show_bug.cgi?id=1202059#c13), we have been asked to limit the access to the D-Bus service to a specific user (we are starting with `root`) and to disable the autostart, as it does not make sense in case of the installer.