### PR TITLE
Force network manager as we do not support other backends

### DIFF
--- a/service/lib/dinstaller/network.rb
+++ b/service/lib/dinstaller/network.rb
@@ -36,8 +36,9 @@ module DInstaller
       logger.info "Probing network"
       Yast::Lan.read_config
       settings = Y2Network::ProposalSettings.instance
-      settings.refresh_packages
       settings.apply_defaults
+      # force NetworkManager as we are not supporting other backends
+      settings.enable_network_manager!
     end
 
     # Writes the network configuration to the installed system

--- a/service/test/dinstaller/network_test.rb
+++ b/service/test/dinstaller/network_test.rb
@@ -28,7 +28,8 @@ describe DInstaller::Network do
 
   let(:logger) { Logger.new($stdout, level: :warn) }
   let(:proposal) do
-    instance_double(Y2Network::ProposalSettings, apply_defaults: nil, refresh_packages: nil)
+    instance_double(Y2Network::ProposalSettings,
+      apply_defaults: nil, refresh_packages: nil, enable_network_manager!: true)
   end
 
   describe "#probe" do
@@ -42,9 +43,13 @@ describe DInstaller::Network do
       network.probe
     end
 
-    it "refresh packages and apply defaults" do
-      expect(proposal).to receive(:refresh_packages)
+    it "apply the defaults" do
       expect(proposal).to receive(:apply_defaults)
+      network.probe
+    end
+
+    it "forces a selection of NetworkManager as the backend to be used" do
+      expect(proposal).to receive(:enable_network_manager!)
       network.probe
     end
   end


### PR DESCRIPTION
## Problem

When we started with the installer we [added support for basic network setup](https://trello.com/c/xPThihCG/85-2-d-installer-basic-network-set-up) using the defaults from the control file which in case of ALP is not present anymore.

## Solution

As currently we will not support other backends apart of NetworkManager we will enforce the selected backend as NetworkManager and will continue relying in the y2network save_network client  in order to copy the config and enable the service at the end of the installation

