### PR TITLE
Validate IPs

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -13,6 +13,7 @@
         "core-js": "^3.21.1",
         "eos-ds": "^5.0.0",
         "eos-icons-react": "^2.3.0",
+        "ipaddr.js": "^2.0.1",
         "react": "17.0.2",
         "react-dom": "17.0.2",
         "react-router-dom": "^6.3.0",
@@ -7467,6 +7468,14 @@
       "dev": true,
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.0.1.tgz",
+      "integrity": "sha512-1qTgH9NG+IIJ4yfKs2e6Pp1bZg8wbDbKHT21HrLIeYBTRLgMYKnMTPAuI3Lcs61nfx5h1xlXnbJtH1kX5/d/ng==",
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/is-arrayish": {
@@ -19186,6 +19195,11 @@
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
       "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
       "dev": true
+    },
+    "ipaddr.js": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.0.1.tgz",
+      "integrity": "sha512-1qTgH9NG+IIJ4yfKs2e6Pp1bZg8wbDbKHT21HrLIeYBTRLgMYKnMTPAuI3Lcs61nfx5h1xlXnbJtH1kX5/d/ng=="
     },
     "is-arrayish": {
       "version": "0.2.1",

--- a/web/package.json
+++ b/web/package.json
@@ -71,6 +71,7 @@
     "core-js": "^3.21.1",
     "eos-ds": "^5.0.0",
     "eos-icons-react": "^2.3.0",
+    "ipaddr.js": "^2.0.1",
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-router-dom": "^6.3.0",

--- a/web/src/AddressesDataList.jsx
+++ b/web/src/AddressesDataList.jsx
@@ -34,7 +34,6 @@ import {
   DataListItemCells,
   DataListCell,
   DataListAction,
-  TextInput,
   Stack,
   StackItem,
   Split,
@@ -44,6 +43,8 @@ import {
 import PlusIcon from "@patternfly/react-icons/dist/js/icons/plus-icon";
 import MinusIcon from "@patternfly/react-icons/dist/js/icons/minus-icon";
 import FormLabel from "./FormLabel";
+import IpAddressInput from "./IpAddressInput";
+import IpPrefixInput from "./IpPrefixInput";
 
 let index = 0;
 
@@ -90,15 +91,15 @@ export default function AddressesDataList({
 
     const cells = [
       <DataListCell key={`address-${id}-local`}>
-        <TextInput
+        <IpAddressInput
           defaultValue={address}
           onChange={value => updateAddress(id, "address", value)}
-          placeholder="Ip Address"
-          aria-label="Ip Address"
+          placeholder="IP Address"
+          aria-label="IP Address"
         />
       </DataListCell>,
       <DataListCell key={`address-${id}-label`}>
-        <TextInput
+        <IpPrefixInput
           defaultValue={prefix}
           onChange={value => updateAddress(id, "prefix", value)}
           placeholder="Prefix length or netmask"

--- a/web/src/IpAddressInput.jsx
+++ b/web/src/IpAddressInput.jsx
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) [2022] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React, { useState } from 'react';
+import { isValidIp } from './utils';
+import { TextInput, ValidatedOptions } from '@patternfly/react-core';
+
+const IpAddressInput = ({ placeholder, onError = () => null, ...props }) => {
+  const [validated, setValidated] = useState("default");
+
+  return (
+    <TextInput
+      placeholder={ placeholder || "IP Address"}
+      validated={ValidatedOptions[validated]}
+      onFocus={() => setValidated("default")}
+      onBlur={e => {
+        const value = e.target.value;
+
+        if (value === "" || isValidIp(value)) {
+          return;
+        }
+
+        setValidated("error");
+        onError(value);
+      }}
+      {...props}
+    />
+  );
+};
+
+export default IpAddressInput;

--- a/web/src/IpPrefixInput.jsx
+++ b/web/src/IpPrefixInput.jsx
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) [2022] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React, { useState } from 'react';
+import { isValidIpPrefix } from './utils';
+import { TextInput, ValidatedOptions } from '@patternfly/react-core';
+
+const IpPrefixInput = ({ placeholder, onError = () => null, ...props }) => {
+  const [validated, setValidated] = useState("default");
+
+  return (
+    <TextInput
+      placeholder={ placeholder || "IP prefix or netmask"}
+      validated={ValidatedOptions[validated]}
+      onFocus={() => setValidated("default")}
+      onBlur={e => {
+        const value = e.target.value;
+
+        if (value === "" || isValidIpPrefix(value)) {
+          return;
+        }
+
+        setValidated("error");
+        onError(value);
+      }}
+      {...props}
+    />
+  );
+};
+
+export default IpPrefixInput;

--- a/web/src/utils.js
+++ b/web/src/utils.js
@@ -20,6 +20,7 @@
  */
 
 import { useEffect, useRef, useCallback } from "react";
+import ipaddr from "ipaddr.js";
 
 /**
  * Returns a new array with a given collection split into two groups, the first holding elements
@@ -120,7 +121,35 @@ function useCancellablePromise() {
   return { cancellablePromise };
 }
 
+/**
+ * Check if an IP is valid
+ *
+ * By now, only IPv4 is supported.
+ *
+ * @param {string} value - An IP Address
+ * @return {boolean} true if given IP is valid; false otherwise.
+ */
+const isValidIp = (value) => ipaddr.IPv4.isValidFourPartDecimal(value);
+
+/**
+ * Check if a value is a valid netmask or network prefix
+ *
+ * By now, only IPv4 is supported.
+ *
+ * @param {string} value - An IP Address
+ * @return {boolean} true if given IP is valid; false otherwise.
+ */
+const isValidIpPrefix = (value) => {
+  if (value.match(/^\d+$/)) {
+    return parseInt(value) <= 32;
+  } else {
+    return ipaddr.IPv4.isValidFourPartDecimal(value);
+  }
+};
+
 export {
   partition,
-  useCancellablePromise
+  useCancellablePromise,
+  isValidIp,
+  isValidIpPrefix
 };

--- a/web/src/utils.test.js
+++ b/web/src/utils.test.js
@@ -19,14 +19,33 @@
  * find current contact information at www.suse.com.
  */
 
-import { partition } from "./utils";
+import { partition, isValidIp, isValidIpPrefix } from "./utils";
 
 describe("partition", () => {
-  it("returns two groups of elements that do and do not satisfy provided filter", async () => {
+  it("returns two groups of elements that do and do not satisfy provided filter", () => {
     const numbers = [1, 2, 3, 4, 5, 6];
     const [odd, even] = partition(numbers, number => number % 2);
 
     expect(odd).toEqual([1, 3, 5]);
     expect(even).toEqual([2, 4, 6]);
+  });
+});
+
+describe("isValidIp", () => {
+  it("returns true when it is a valid IPv4 address", () => {
+    expect(isValidIp("192.168.122.1")).toEqual(true);
+    expect(isValidIp("192.168.122")).toEqual(false);
+    expect(isValidIp("my-ip")).toEqual(false);
+  });
+});
+
+describe("isValidIpPrefix", () => {
+  it("returns true when it is a valid prefix", () => {
+    expect(isValidIpPrefix("24")).toEqual(true);
+    expect(isValidIpPrefix("64.168.122")).toEqual(false);
+  });
+
+  it("returns true when it is a valid netmask", () => {
+    expect(isValidIpPrefix("255.255.255.0")).toEqual(true);
   });
 });


### PR DESCRIPTION
Add IP and netmask/prefix validation to #260. The confirmation button is not disabled yet.
Under the hood, we use https://github.com/whitequark/ipaddr.js/ as it is rather small and we already used it in cockpit-wicked.

<details>
<summary>Validating the IP address</summary>

![Invalid IP](https://user-images.githubusercontent.com/15836/196686058-d632aecf-80e7-408f-9f83-a8782eaa4065.png)
</details>
