### PR TITLE
Explicitly tell user to start the service

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ $ cd d-installer
 $ ./setup.h
 ~~~
 
+Start the d-installer service
+~~~
+cd service; sudo bundle exec bin/d-installer
+~~~
+
 Then point your browser to http://localhost:9090/cockpit/@localhost/d-installer/index.html and that's all.
 
 Note that the [setup.sh](./setup.sh) script installs the required dependencies to build and run the project and it also configures the D-Installer services and cockpit. Alternatively, just go through the following instructions if you want to configure it manually:


### PR DESCRIPTION
## Problem


This explicit mention of starting the service will save one step to the first-timer:

The readme says ./setup.sh will do all the work, and then simply point to http://localhost:9090/cockpit/@localhost/d-installer/index.html#/products. But then you login to cockpit and get "unable to connect to dbus".

Setup.sh tells user to run the service

```
ln -s `pwd`/dist ~/.local/share/cockpit/d-installer
/home/lkocman/Downloads/d-installer

Start the d-installer service:
  cd service; sudo bundle exec bin/d-installer

Visit http://localhost:9090/cockpit/@localhost/d-installer/index.html
```

But since it printed also "visit ... sentence" right after, I expected that perhaps that was also covered by setup.sh and it's simply just printed by some subcommand.


## Solution

Add explicit task to start the service to README.md


## Testing

n/a just a nitpicking on docs.

## Screenshots
![dbus](https://user-images.githubusercontent.com/510119/198269669-a734206b-c052-4240-84ef-1b3a79a4402e.png)



