### PR TITLE
Remove external links

### DIFF
--- a/web/src/About.jsx
+++ b/web/src/About.jsx
@@ -45,8 +45,7 @@ export default function About() {
           to give it a try, we recommend to use a virtual machine to prevent any possible data loss.
         </Text>
         <Text>
-          For more information, check{" "}
-          <a href="https://github.com/yast/d-installer">the project's repository</a>.
+          For more information, please visit the project's repository at https://github.com/yast/d-installer.
         </Text>
         <Popup.Actions>
           <Popup.Confirm onClick={close} autoFocus>Close</Popup.Confirm>

--- a/web/src/InstallationFinished.jsx
+++ b/web/src/InstallationFinished.jsx
@@ -26,8 +26,7 @@ import {
   Text,
   EmptyState,
   EmptyStateIcon,
-  EmptyStateBody,
-  EmptyStateSecondaryActions
+  EmptyStateBody
 } from "@patternfly/react-core";
 
 import { Title as SectionTitle, PageIcon, MainActions } from "./Layout";
@@ -67,11 +66,6 @@ function InstallationFinished() {
               </Text>
               <Text>Have a lot of fun! Your openSUSE Development Team.</Text>
             </div>
-            <EmptyStateSecondaryActions>
-              <Button component="a" href="https://www.opensuse.org" target="_blank" variant="link">
-                www.opensuse.org
-              </Button>
-            </EmptyStateSecondaryActions>
           </EmptyStateBody>
         </EmptyState>
       </Center>


### PR DESCRIPTION
## Problem

As spotted at https://github.com/yast/d-installer/issues/273, external links can be confusing for users when there is no internet connection.

* https://trello.com/c/RLEAZDfH (internal link)

## Solution

Remove the external links by now. Later, when the project is more mature, we can invest more time to find a better solution for displaying external content if there is an active connection.
