### PR TITLE
Use `cockpit.proxies` and reduce the number of async methods

### DIFF
--- a/web/src/Network.jsx
+++ b/web/src/Network.jsx
@@ -22,7 +22,6 @@
 import React, { useEffect, useState } from "react";
 import { Button, Stack, StackItem } from "@patternfly/react-core";
 import { useInstallerClient } from "./context/installer";
-import { useCancellablePromise } from "./utils";
 import { ConnectionTypes } from "./client/network";
 import NetworkWiredStatus from "./NetworkWiredStatus";
 import NetworkWifiStatus from "./NetworkWifiStatus";
@@ -31,14 +30,13 @@ import WirelessSelector from "./WirelessSelector";
 export default function Network() {
   const client = useInstallerClient();
   const [initialized, setInitialized] = useState(false);
-  const { cancellablePromise } = useCancellablePromise();
   const [connections, setConnections] = useState([]);
   const [accessPoints, setAccessPoints] = useState([]);
   const [openWirelessSelector, setOpenWirelessSelector] = useState(false);
 
   useEffect(() => {
-    cancellablePromise(client.network.activeConnections()).then(setConnections);
-  }, [client.network, cancellablePromise]);
+    setConnections(client.network.activeConnections());
+  }, [client.network]);
 
   useEffect(() => {
     const onConnectionAdded = addedConnection => {

--- a/web/src/client/network.test.js
+++ b/web/src/client/network.test.js
@@ -33,8 +33,8 @@ const conn = {
 
 const adapter = {
   setUp: jest.fn(),
-  activeConnections: jest.fn().mockResolvedValue([conn]),
-  hostname: jest.fn().mockResolvedValue("localhost"),
+  activeConnections: jest.fn().mockReturnValue([conn]),
+  hostname: jest.fn().mockReturnValue("localhost.localdomain"),
   subscribe: jest.fn(),
   getConnection: jest.fn(),
   addConnection: jest.fn(),
@@ -43,16 +43,25 @@ const adapter = {
 };
 
 describe("NetworkClient", () => {
-  describe("#config", () => {
-    it("returns an object containing the hostname, known IPv4 addresses, and active connections", async () => {
+  describe("#activeConnections", () => {
+    it("retuns the list of active connections from the adapter", () => {
       const client = new NetworkClient(adapter);
-      const config = await client.config();
+      const connections = client.activeConnections();
+      expect(connections).toEqual([conn]);
+    });
+  });
 
-      expect(config.hostname).toEqual("localhost");
-      expect(config.addresses).toEqual([
-        { address: "192.168.122.1", prefix: 24 }
-      ]);
-      expect(config.connections).toEqual([conn]);
+  describe("#addresses", () => {
+    it("returns the list of addresses", () => {
+      const client = new NetworkClient(adapter);
+      expect(client.addresses()).toEqual([{ address: "192.168.122.1", prefix: 24 }]);
+    });
+  });
+
+  describe("#hostname", () => {
+    it("returns the hostname from the adapter", () => {
+      const client = new NetworkClient(adapter);
+      expect(client.hostname()).toEqual("localhost.localdomain");
     });
   });
 });

--- a/web/src/client/network/index.js
+++ b/web/src/client/network/index.js
@@ -106,10 +106,10 @@ o  *   NetworkManagerAdapter.
    * @return {() => void} Function to remove the handler
    */
   onNetworkEvent(handler) {
-    const position = this.handlers.length;
     this.handlers.push(handler);
     return () => {
-      this.handlers.splice(position, 1);
+      const position = this.handlers.indexOf(handler);
+      if (position > -1) this.handlers.splice(position, 1);
     };
   }
 

--- a/web/src/client/network/index.js
+++ b/web/src/client/network/index.js
@@ -37,16 +37,6 @@ const NetworkEventTypes = Object.freeze({
   ACTIVE_CONNECTION_REMOVED: "active_connection_removed"
 });
 
-/** @typedef {(conns: ActiveConnection[]) => void} ConnectionFn */
-/** @typedef {(conns: string[]) => void} ConnectionPathsFn */
-
-/**
- * @typedef {object} Handlers
- * @property {ConnectionFn[]} connectionAdded
- * @property {ConnectionFn[]} connectionRemoved
- * @property {ConnectionFn[]} connectionUpdated
- */
-
 /**
  * @typedef {object} NetworkAdapter
  * @property {() => ActiveConnection[]} activeConnections

--- a/web/src/client/network/index.js
+++ b/web/src/client/network/index.js
@@ -49,7 +49,7 @@ const NetworkEventTypes = Object.freeze({
 
 /**
  * @typedef {object} NetworkAdapter
- * @property {() => Promise<ActiveConnection[]>} activeConnections
+ * @property {() => ActiveConnection[]} activeConnections
  * @property {() => AccessPoint[]} accessPoints
  * @property {(handler: (event: NetworkEvent) => void) => void} subscribe
  * @property {(id: string) => Promise<Connection>} getConnection
@@ -102,7 +102,7 @@ o  *   NetworkManagerAdapter.
    */
   async config() {
     return {
-      connections: await this.adapter.activeConnections(),
+      connections: this.adapter.activeConnections(),
       addresses: await this.addresses(),
       hostname: await this.adapter.hostname()
     };
@@ -170,9 +170,9 @@ o  *   NetworkManagerAdapter.
   /**
    * Returns the active connections
    *
-   * @returns {Promise<ActiveConnection[]>}
+   * @returns {ActiveConnection[]}
    */
-  async activeConnections() {
+  activeConnections() {
     return this.adapter.activeConnections();
   }
 

--- a/web/src/client/network/index.js
+++ b/web/src/client/network/index.js
@@ -55,7 +55,7 @@ const NetworkEventTypes = Object.freeze({
  * @property {(id: string) => Promise<Connection>} getConnection
  * @property {(connection: Connection) => Promise<any>} addConnection
  * @property {(connection: Connection) => Promise<any>} updateConnection
- * @property {() => Promise<string>} hostname
+ * @property {() => string} hostname
  * @property {() => void} setUp
  */
 
@@ -96,18 +96,6 @@ o  *   NetworkManagerAdapter.
     this.setUpDone = false;
     /** @type {NetworkEventFn[]} */
     this.handlers = [];
-  }
-
-  /**
-   * Returns IP config overview - addresses, connections and hostname
-   * @return {Promise<{addresses: IPAddress[], hostname: string, connections: ActiveConnection[]}>}
-   */
-  async config() {
-    return {
-      connections: this.adapter.activeConnections(),
-      addresses: await this.addresses(),
-      hostname: await this.adapter.hostname()
-    };
   }
 
   /**
@@ -189,9 +177,18 @@ o  *   NetworkManagerAdapter.
    * @private
    * @return {Promise<IPAddress[]>}
    */
-  async addresses() {
-    const conns = await this.adapter.activeConnections();
+  addresses() {
+    const conns = this.adapter.activeConnections();
     return conns.flatMap(c => c.addresses);
+  }
+
+  /**
+   * Returns the computer's hostname
+   *
+   * @return {string}
+   */
+  hostname() {
+    return this.adapter.hostname();
   }
 }
 

--- a/web/src/client/network/network_manager.js
+++ b/web/src/client/network/network_manager.js
@@ -43,8 +43,8 @@ const ACTIVE_CONNECTION_IFACE = "org.freedesktop.NetworkManager.Connection.Activ
 const ACTIVE_CONNECTION_NAMESPACE = "/org/freedesktop/NetworkManager/ActiveConnection";
 const IP4CONFIG_IFACE = "org.freedesktop.NetworkManager.IP4Config";
 const IP4CONFIG_NAMESPACE = "/org/freedesktop/NetworkManager/IP4Config";
-const AP_IFACE = "org.freedesktop.NetworkManager.AccessPoint";
-const AP_NAMESPACE = "/org/freedesktop/NetworkManager/AccessPoint";
+const ACCESS_POINT_IFACE = "org.freedesktop.NetworkManager.AccessPoint";
+const ACCESS_POINT_NAMESPACE = "/org/freedesktop/NetworkManager/AccessPoint";
 
 const ApFlags = Object.freeze({
   NONE: 0x00000000,
@@ -187,7 +187,7 @@ class NetworkManagerAdapter {
   async setUp(handler) {
     this.eventsHandler = handler;
     this.proxies = {
-      accessPoints: await this.client.proxies(AP_IFACE, AP_NAMESPACE),
+      accessPoints: await this.client.proxies(ACCESS_POINT_IFACE, ACCESS_POINT_NAMESPACE),
       activeConnections: await this.client.proxies(
         ACTIVE_CONNECTION_IFACE, ACTIVE_CONNECTION_NAMESPACE
       ),


### PR DESCRIPTION
This PR refactors the network client to:

* use `cockpit.proxies`, making it easier to track the changes (using events on `proxies`) and to read the properties;
* reduce the number of `async` methods in the network client.

We can use the same approach for objects like `/org/freedesktop/NetworkManager`, but let's do it as a separate PR.