### PR TITLE
Simplify the D-Bus policy config 

### DIFF
--- a/service/share/dbus.conf
+++ b/service/share/dbus.conf
@@ -3,6 +3,7 @@
  "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
 
 <busconfig>
+  <!-- only root can own the services -->
   <policy user="root">
     <allow own="org.opensuse.DInstaller" />
     <allow own="org.opensuse.DInstaller.Language" />
@@ -12,41 +13,23 @@
     <allow own="org.opensuse.DInstaller.Users" />
   </policy>
 
+  <!-- only root can send anything to the services -->
   <policy user="root">
     <allow send_destination="org.opensuse.DInstaller" />
-    <allow send_destination="org.opensuse.DInstaller"
-           send_interface="org.freedesktop.DBus.Introspectable"/>
-    <allow send_destination="org.opensuse.DInstaller" />
-    <allow receive_sender="org.opensuse.DInstaller" />
-
     <allow send_destination="org.opensuse.DInstaller.Language" />
-    <allow send_destination="org.opensuse.DInstaller.Language"
-           send_interface="org.freedesktop.DBus.Introspectable"/>
-    <allow send_destination="org.opensuse.DInstaller.Language" />
-    <allow receive_sender="org.opensuse.DInstaller.Language" />
-
     <allow send_destination="org.opensuse.DInstaller.Questions" />
-    <allow send_destination="org.opensuse.DInstaller.Questions"
-           send_interface="org.freedesktop.DBus.Introspectable"/>
-    <allow send_destination="org.opensuse.DInstaller.Questions" />
-    <allow receive_sender="org.opensuse.DInstaller.Questions" />
-
     <allow send_destination="org.opensuse.DInstaller.Software" />
-    <allow send_destination="org.opensuse.DInstaller.Software"
-           send_interface="org.freedesktop.DBus.Introspectable"/>
-    <allow send_destination="org.opensuse.DInstaller.Software" />
-    <allow receive_sender="org.opensuse.DInstaller.Software" />
-
     <allow send_destination="org.opensuse.DInstaller.Storage" />
-    <allow send_destination="org.opensuse.DInstaller.Storage"
-           send_interface="org.freedesktop.DBus.Introspectable"/>
-    <allow send_destination="org.opensuse.DInstaller.Storage" />
-    <allow receive_sender="org.opensuse.DInstaller.Storage" />
+    <allow send_destination="org.opensuse.DInstaller.Users" />
+  </policy>
 
-    <allow send_destination="org.opensuse.DInstaller.Users" />
-    <allow send_destination="org.opensuse.DInstaller.Users"
-           send_interface="org.freedesktop.DBus.Introspectable"/>
-    <allow send_destination="org.opensuse.DInstaller.Users" />
-    <allow receive_sender="org.opensuse.DInstaller.Users" />
+  <!-- anyone can ask about the API -->
+  <policy context="default">
+    <allow send_interface="org.freedesktop.DBus.Introspectable" send_destination="org.opensuse.DInstaller" />
+    <allow send_interface="org.freedesktop.DBus.Introspectable" send_destination="org.opensuse.DInstaller.Language" />
+    <allow send_interface="org.freedesktop.DBus.Introspectable" send_destination="org.opensuse.DInstaller.Questions" />
+    <allow send_interface="org.freedesktop.DBus.Introspectable" send_destination="org.opensuse.DInstaller.Software" />
+    <allow send_interface="org.freedesktop.DBus.Introspectable" send_destination="org.opensuse.DInstaller.Storage" />
+    <allow send_interface="org.freedesktop.DBus.Introspectable" send_destination="org.opensuse.DInstaller.Users" />
   </policy>
 </busconfig>

--- a/service/share/dbus.conf
+++ b/service/share/dbus.conf
@@ -22,14 +22,4 @@
     <allow send_destination="org.opensuse.DInstaller.Storage" />
     <allow send_destination="org.opensuse.DInstaller.Users" />
   </policy>
-
-  <!-- anyone can ask about the API -->
-  <policy context="default">
-    <allow send_interface="org.freedesktop.DBus.Introspectable" send_destination="org.opensuse.DInstaller" />
-    <allow send_interface="org.freedesktop.DBus.Introspectable" send_destination="org.opensuse.DInstaller.Language" />
-    <allow send_interface="org.freedesktop.DBus.Introspectable" send_destination="org.opensuse.DInstaller.Questions" />
-    <allow send_interface="org.freedesktop.DBus.Introspectable" send_destination="org.opensuse.DInstaller.Software" />
-    <allow send_interface="org.freedesktop.DBus.Introspectable" send_destination="org.opensuse.DInstaller.Storage" />
-    <allow send_interface="org.freedesktop.DBus.Introspectable" send_destination="org.opensuse.DInstaller.Users" />
-  </policy>
 </busconfig>


### PR DESCRIPTION
## Problem

In https://bugzilla.suse.com/show_bug.cgi?id=1202059 we are asking for a security review of our D-Bus service.

But the relevant bus policy file is hard to read.

## Solution

Simplify the policy file while keeping it equivalent.


## Testing

- [x] Manually tested that the D-Bus policy simplification is still working:

#### Owning the bus name:

Non-root should fail
- `bundle exec bin/d-installer questions`
  - Expect error /not allowed to own the service "org.opensuse.DInstaller.Questions"/

Root should succeed
- `sudo !!`
  - Expect no error

#### Introspection call:
Non-root should fail
- `busctl introspect org.opensuse.DInstaller.Questions /org/opensuse/DInstaller/Questions1`
  - Expect error /Access denied/

Root should succeed:
- `sudo !!`
  - Expect /PropertiesChanged/

#### Question API call:
Non-root should fail
```
busctl \
  call \
  org.opensuse.DInstaller.Questions \
  /org/opensuse/DInstaller/Questions1 \
  org.opensuse.DInstaller.Questions1 \
  New sasas "should I stay or should I go" 2 yes no 1 yes
```

Root should succeed:
- `sudo !!`
  - Expect /^o "\/org\/opensuse/


## Screenshots

Not affected
