### PR TITLE
[service] Remove unneeded dbus_name

### DIFF
--- a/service/lib/dinstaller/dbus/interfaces/validation.rb
+++ b/service/lib/dinstaller/dbus/interfaces/validation.rb
@@ -81,7 +81,7 @@ module DInstaller
         def self.included(base)
           base.class_eval do
             dbus_interface VALIDATION_INTERFACE do
-              dbus_reader :errors, "as", dbus_name: "Errors"
+              dbus_reader :errors, "as"
               dbus_reader :valid?, "b", dbus_name: "Valid"
             end
           end


### PR DESCRIPTION
Remove unneeded parameter `dbus_name`