### PR TITLE
[web] Display only one primary action when editing a connection

### DIFF
--- a/web/src/AddressesDataList.jsx
+++ b/web/src/AddressesDataList.jsx
@@ -126,7 +126,7 @@ export default function AddressesDataList({
             <FormLabel isRequired={!allowEmpty}>Addresses</FormLabel>
           </SplitItem>
           <SplitItem>
-            <Button isSmall variant="primary" className="btn-sm" onClick={() => addAddress()}>
+            <Button isSmall variant="secondary" className="btn-sm" onClick={() => addAddress()}>
               {newAddressButtonText}
             </Button>
           </SplitItem>

--- a/web/src/DnsDataList.jsx
+++ b/web/src/DnsDataList.jsx
@@ -103,7 +103,7 @@ export default function DnsDataList({ servers: originalServers, updateDnsServers
             <FormLabel>DNS</FormLabel>
           </SplitItem>
           <SplitItem>
-            <Button isSmall variant="primary" className="btn-sm" onClick={() => addServer()}>
+            <Button isSmall variant="secondary" className="btn-sm" onClick={() => addServer()}>
               {newDnsButtonText}
             </Button>
           </SplitItem>

--- a/web/src/patternfly.scss
+++ b/web/src/patternfly.scss
@@ -129,3 +129,8 @@
   --pf-c-form__label--hover--Cursor: default;
   --pf-c-form__label--m-disabled--hover--Cursor: default;
 }
+
+// Do not use thick border-top for data lists
+.pf-c-data-list {
+  --pf-c-data-list--BorderTopWidth: 2px;
+}


### PR DESCRIPTION
## Problem

The popup shown when editing a connection ends up displaying three buttons that looks like _primary_ actions, which might be a bit confusing.

## Solution

Try to use only one primary action per dialog, as we did in https://github.com/yast/d-installer/pull/292.

## Screenshots

| After | Before |
|-|-|
| ![Dialog with more than one primary action](https://user-images.githubusercontent.com/1691872/201789917-36030afe-717e-45f8-92c1-75e8cdff365d.png) | ![Dialog with only one primary action](https://user-images.githubusercontent.com/1691872/201789967-15a4b64f-1735-4a17-a257-b0b6ec2e57f3.png) |


