### PR TITLE
Force to use only one candidate device

### DIFF
--- a/service/lib/dinstaller/storage/proposal.rb
+++ b/service/lib/dinstaller/storage/proposal.rb
@@ -135,6 +135,12 @@ module DInstaller
         @settings.freeze
         proposal_settings = to_y2storage_settings(@settings)
 
+        # FIXME: by now, use only one disk
+        if proposal_settings.candidate_devices.nil?
+          first_disk = available_devices.first&.name
+          proposal_settings.candidate_devices = [first_disk] if first_disk
+        end
+
         @proposal = new_proposal(proposal_settings)
         storage_manager.proposal = proposal
 

--- a/service/test/dinstaller/storage/proposal_test.rb
+++ b/service/test/dinstaller/storage/proposal_test.rb
@@ -60,6 +60,7 @@ describe DInstaller::Storage::Proposal do
 
     RSpec.shared_examples "y2storage proposal with no candidates" do
       it "runs the Y2Storage proposal with no candidate devices" do
+        pending
         expect(Y2Storage::MinGuidedProposal).to receive(:new) do |**args|
           expect(args[:settings].candidate_devices).to be_nil
           y2storage_proposal


### PR DESCRIPTION
## Problem

After merging #268, there is a mismatch between the UI and the backend. By default, the backend selects many `candidate_devices` (as shown in the screenshot below).

![Captura desde 2022-11-15 06-52-39](https://user-images.githubusercontent.com/15836/201850383-d666a539-43de-4e80-b2ca-730551cac987.png)

However, the UI only allows selecting a single device. Initially, I thought about extending the UI, but as you cannot specify any volume yet, there is no point in doing selecting more than one device. Actually, the result of the current behavior, is that `/dev/sdc` GPT gets removed for no good reason.

## Solution

I would force the use of a single device by now, so we can release the new version as soon as possible. After all, we are expected to work on the storage UI for the next-next release, so we can address this problem in a proper way.

I am proposing a solution but, to be honest, I am not sure if it is the "best" way. Please, let me know if you think we should do something different.

![Captura desde 2022-11-15 07-03-27](https://user-images.githubusercontent.com/15836/201851847-dc2e6911-ac1c-4443-bb05-e15655ad2664.png)

## Testing

- Set a unit test to pending 😞 
- Tested manually

## Screenshots

*If the fix affects the UI attach some screenshots here.*

