### PR TITLE
Activate the manager service without systemd

### DIFF
--- a/service/share/org.opensuse.DInstaller.service
+++ b/service/share/org.opensuse.DInstaller.service
@@ -2,4 +2,3 @@
 Name=org.opensuse.DInstaller
 Exec=/usr/bin/d-installer manager
 User=root
-SystemdService=d-installer.service


### PR DESCRIPTION
Followup to #295 

## Problem

We are starting one of the handful of services in a different way, via systemd instead of via dbus-daemon.

There is no reason other than I wanted to try if it works. It just adds complexity.

## Solution

Remove the unnecessary difference from the other services. dbus-daemon starts it just fine.


## Testing


- [x] manual test: take a clean VM; checkout the repo; `./setup.sh`; open browser to see no error; verify with `d-installer -s`

## Screenshots

Not affected
