### PR TITLE
Use calculated settings

### DIFF
--- a/service/lib/dinstaller/dbus/storage/proposal.rb
+++ b/service/lib/dinstaller/dbus/storage/proposal.rb
@@ -94,25 +94,27 @@ module DInstaller
         #
         # @return [Array<String>]
         def candidate_devices
-          backend.candidate_devices
+          return [] unless backend.calculated_settings
+
+          backend.calculated_settings.candidate_devices
         end
 
         # Whether the proposal creates logical volumes
         #
         # @return [Boolean]
         def lvm
-          return false unless backend.settings
+          return false unless backend.calculated_settings
 
-          backend.settings.use_lvm?
+          backend.calculated_settings.lvm
         end
 
-        # Whether the proposal encrypts devices
+        # Password for encrypting devices
         #
-        # @return [Boolean]
+        # @return [String]
         def encryption_password
-          return "" unless backend.settings
+          return "" unless backend.calculated_settings
 
-          backend.settings.encryption_password
+          backend.calculated_settings.encryption_password
         end
 
         # Volumes used as template for creating a new volume
@@ -126,7 +128,9 @@ module DInstaller
         #
         # @return [Hash]
         def volumes
-          backend.calculated_volumes.map { |v| to_dbus_volume(v) }
+          return [] unless backend.calculated_settings
+
+          backend.calculated_settings.volumes.map { |v| to_dbus_volume(v) }
         end
 
         # List of sorted actions in D-Bus format
@@ -167,7 +171,7 @@ module DInstaller
         # D-Bus value to the value expected by the ProposalSettings setter.
         SETTINGS_CONVERSIONS = {
           "CandidateDevices"   => ["candidate_devices=", proc { |v| v }],
-          "LVM"                => ["use_lvm=", proc { |v| v }],
+          "LVM"                => ["lvm=", proc { |v| v }],
           "EncryptionPassword" => ["encryption_password=", proc { |v| v }],
           "Volumes"            => ["volumes=", proc { |v, o| o.send(:to_proposal_volumes, v) }]
         }.freeze

--- a/service/lib/dinstaller/manager.rb
+++ b/service/lib/dinstaller/manager.rb
@@ -154,7 +154,7 @@ module DInstaller
 
     # Storage manager
     #
-    # @return [Storage::Manager]
+    # @return [DBus::Clients::Storage]
     def storage
       @storage ||= DBus::Clients::Storage.new.tap do |client|
         client.on_service_status_change do |status|

--- a/service/lib/dinstaller/storage/manager.rb
+++ b/service/lib/dinstaller/storage/manager.rb
@@ -24,6 +24,7 @@ require "bootloader/proposal_client"
 require "bootloader/finish_client"
 require "y2storage/storage_manager"
 require "dinstaller/storage/proposal"
+require "dinstaller/storage/proposal_settings"
 require "dinstaller/storage/callbacks"
 require "dinstaller/with_progress"
 require "dinstaller/can_ask_question"
@@ -51,7 +52,7 @@ module DInstaller
         start_progress(4)
         progress.step("Activating storage devices") { activate_devices }
         progress.step("Probing storage devices") { probe_devices }
-        progress.step("Calculating the storage proposal") { proposal.calculate }
+        progress.step("Calculating the storage proposal") { calculate_proposal }
         progress.step("Selecting Linux Security Modules") { security.probe }
       end
 
@@ -125,6 +126,16 @@ module DInstaller
       def probe_devices
         # TODO: probe callbacks
         Y2Storage::StorageManager.instance.probe
+      end
+
+      # Calculates the default proposal
+      def calculate_proposal
+        settings = ProposalSettings.new
+        # FIXME: by now, the UI only allows to select one disk
+        device = proposal.available_devices.first&.name
+        settings.candidate_devices << device if device
+
+        proposal.calculate(settings)
       end
 
       # Adds the required packages to the list of resolvables to install

--- a/service/lib/dinstaller/storage/proposal.rb
+++ b/service/lib/dinstaller/storage/proposal.rb
@@ -44,11 +44,6 @@ module DInstaller
     class Proposal
       include WithProgress
 
-      # Settings that were used to calculate the proposal
-      #
-      # @return [ProposalSettings, nil]
-      attr_reader :settings
-
       # Constructor
       #
       # @param logger [Logger]
@@ -103,27 +98,25 @@ module DInstaller
       #
       # @return [Array<Volumes>]
       def volume_templates
-        VolumesGenerator.new(default_specs).volumes
+        converter = VolumeConverter.new(default_specs: default_specs)
+
+        default_specs.map { |s| converter.to_dinstaller(s) }
       end
 
-      # Volumes from the specs used during the calculation of the storage proposal
+      # Settings with the data used during the calculation of the storage proposal
       #
-      # Not to be confused with settings.volumes, which are used as starting point for creating the
-      # volume specs for the storage proposal.
+      # Not to be confused with the settings passed to {#calculate}, which are used as starting
+      # point for creating the settings for the storage proposal.
       #
-      # @return [Array<Volumes>]
-      def calculated_volumes
-        return [] unless proposal
+      # @return [ProposalSettings]
+      def calculated_settings
+        return nil unless proposal
 
-        generator = VolumesGenerator.new(specs_from_proposal,
-          planned_devices: proposal.planned_devices)
-        volumes = generator.volumes(only_proposed: true)
+        settings = proposal.settings.dup
+        settings.volumes = settings.volumes.select(&:proposed?)
 
-        # FIXME: setting this should be a responsibility of VolumesGenerator or any other component,
-        # but this is good enough until we implement fine-grained control on encryption
-        volumes.each { |v| v.encrypted = proposal.settings.use_encryption }
-
-        volumes
+        to_dinstaller_settings(settings,
+          default_specs: proposal.settings.volumes, devices: proposal.planned_devices)
       end
 
       # Calculates a new proposal
@@ -131,9 +124,9 @@ module DInstaller
       # @param settings [ProposalSettings] settings to calculate the proposal
       # @return [Boolean] whether the proposal was correctly calculated
       def calculate(settings = nil)
-        @settings = settings || ProposalSettings.new
-        @settings.freeze
-        proposal_settings = to_y2storage_settings(@settings)
+        settings ||= ProposalSettings.new
+        settings.freeze
+        proposal_settings = to_y2storage_settings(settings)
 
         @proposal = new_proposal(proposal_settings)
         storage_manager.proposal = proposal
@@ -214,15 +207,6 @@ module DInstaller
         config_volumes.map { |v| Y2Storage::VolumeSpecification.new(v) }
       end
 
-      # Volume specs from the setting used for the storage proposal
-      #
-      # @return [Array<Y2Storage::VolumeSpecification>]
-      def specs_from_proposal
-        return [] unless proposal
-
-        proposal.settings.volumes
-      end
-
       # Converts a DInstaller::Storage::ProposalSettings object to its equivalent
       # Y2Storage::ProposalSettings one
       #
@@ -230,6 +214,19 @@ module DInstaller
       # @return [Y2Storage::ProposalSettings]
       def to_y2storage_settings(settings)
         ProposalSettingsConverter.new(default_specs: default_specs).to_y2storage(settings)
+      end
+
+      # Converts a Y2Storage::ProposalSettings object to its equivalent
+      # DInstaller::Storage::ProposalSettings one
+      #
+      # @param settings [Y2Storage::ProposalSettings]
+      # @param default_specs [Array<Y2Storage::VolumeSpecification>]
+      # @param devices [Array<Y2Storage::Planned::Device>]
+      #
+      # @return [ProposalSettings]
+      def to_dinstaller_settings(settings, default_specs: [], devices: [])
+        converter = ProposalSettingsConverter.new(default_specs: default_specs)
+        converter.to_dinstaller(settings, devices: devices)
       end
 
       # @return [Y2Storage::DiskAnalyzer]
@@ -275,46 +272,6 @@ module DInstaller
         return if available_devices.empty? || candidate_devices.any?
 
         ValidationError.new("No devices are selected for installation")
-      end
-
-      # Helper class to generate volumes from volume specs
-      class VolumesGenerator
-        # Constructor
-        #
-        # @param specs [Array<Y2Storage::VolumeSpecification>]
-        # @param planned_devices [Array<Y2Storage::Planned::Device>]
-        def initialize(specs, planned_devices: [])
-          @specs = specs
-          @planned_devices = planned_devices
-        end
-
-        # Generates volumes
-        #
-        # @param only_proposed [Boolean] Whether to generate volumes only for specs with proposed
-        #   equal to true.
-        # @return [Array<Volume>]
-        def volumes(only_proposed: false)
-          specs = self.specs
-          specs = specs.select(&:proposed?) if only_proposed
-          specs.map { |s| converter.to_dinstaller(s, devices: planned_devices) }
-        end
-
-      private
-
-        # Volume specs used for generating volumes
-        #
-        # @return [Array<Y2Storage::VolumeSpecification>]
-        attr_reader :specs
-
-        # Planned devices used for completing some volume settings
-        #
-        # @return [Array<Y2Storage::Planned::Device>]
-        attr_reader :planned_devices
-
-        # Object to perform the conversion of the volumes
-        def converter
-          @converter ||= VolumeConverter.new(default_specs: specs)
-        end
       end
     end
   end

--- a/service/lib/dinstaller/storage/proposal.rb
+++ b/service/lib/dinstaller/storage/proposal.rb
@@ -112,11 +112,7 @@ module DInstaller
       def calculated_settings
         return nil unless proposal
 
-        settings = proposal.settings.dup
-        settings.volumes = settings.volumes.select(&:proposed?)
-
-        to_dinstaller_settings(settings,
-          default_specs: proposal.settings.volumes, devices: proposal.planned_devices)
+        to_dinstaller_settings(proposal.settings, devices: proposal.planned_devices)
       end
 
       # Calculates a new proposal
@@ -220,11 +216,10 @@ module DInstaller
       # DInstaller::Storage::ProposalSettings one
       #
       # @param settings [Y2Storage::ProposalSettings]
-      # @param default_specs [Array<Y2Storage::VolumeSpecification>]
       # @param devices [Array<Y2Storage::Planned::Device>]
       #
       # @return [ProposalSettings]
-      def to_dinstaller_settings(settings, default_specs: [], devices: [])
+      def to_dinstaller_settings(settings, devices: [])
         converter = ProposalSettingsConverter.new(default_specs: default_specs)
         converter.to_dinstaller(settings, devices: devices)
       end

--- a/service/lib/dinstaller/storage/proposal_settings.rb
+++ b/service/lib/dinstaller/storage/proposal_settings.rb
@@ -29,19 +29,18 @@ module DInstaller
 
       # Whether to use LVM
       #
-      # @return [Boolean]
-      attr_accessor :use_lvm
-      alias_method :use_lvm?, :use_lvm
+      # @return [Boolean, nil] nil if undetermined
+      attr_accessor :lvm
 
       # @!attribute encryption_password
       #   Password to use when creating new encryption devices
-      #   @return [String]
+      #   @return [String, nil] nil if undetermined
       secret_attr :encryption_password
 
       # Device names of the disks that can be used for the installation. If nil, the proposal will
       # try find suitable devices
       #
-      # @return [Array<String>, nil]
+      # @return [Array<String>]
       attr_accessor :candidate_devices
 
       # Set of volumes to create
@@ -53,7 +52,7 @@ module DInstaller
       attr_accessor :volumes
 
       def initialize
-        @use_lvm = false
+        @candidate_devices = []
         @volumes = []
       end
     end

--- a/service/lib/dinstaller/storage/proposal_settings_converter.rb
+++ b/service/lib/dinstaller/storage/proposal_settings_converter.rb
@@ -151,7 +151,9 @@ module DInstaller
             settings.candidate_devices = y2storage_settings.candidate_devices
             settings.lvm = y2storage_settings.lvm
             settings.encryption_password = y2storage_settings.encryption_password
-            settings.volumes = y2storage_settings.volumes.map { |v| convert_volume(v) }
+
+            specs = y2storage_settings.volumes.select(&:proposed?)
+            settings.volumes = specs.map { |s| to_volume(s) }
           end
         end
 
@@ -173,7 +175,7 @@ module DInstaller
         #
         # @param spec [Y2Storage::VolumeSpecification]
         # @return [Volume]
-        def convert_volume(spec)
+        def to_volume(spec)
           volume_converter.to_dinstaller(spec, devices: devices).tap do |volume|
             volume.encrypted = y2storage_settings.use_encryption
           end

--- a/service/lib/dinstaller/storage/proposal_settings_converter.rb
+++ b/service/lib/dinstaller/storage/proposal_settings_converter.rb
@@ -45,6 +45,10 @@ module DInstaller
         ToY2Storage.new(settings, default_specs).convert
       end
 
+      def to_dinstaller(settings, devices: [])
+        ToDInstaller.new(settings, default_specs, devices).convert
+      end
+
     private
 
       # @see #initialize
@@ -54,23 +58,24 @@ module DInstaller
       class ToY2Storage
         # Constructor
         #
-        # @param settings see {#settings}
-        # @param default_specs see #{default_specs}
+        # @param settings [ProposalSettings]
+        # @param default_specs [Array<Y2Storage::VolumeSpecification>]
         def initialize(settings, default_specs)
           @settings = settings
           @default_specs = default_specs
         end
 
+        # @return [Y2Storage::ProposalSettings]
         def convert
           # Despite the "current_product" part in the name of the constructor, it only applies
           # generic default values that are independent of the product (there is no YaST
           # ProductFeatures mechanism in place).
           y2storage_settings = Y2Storage::ProposalSettings.new_for_current_product
-          y2storage_settings.use_lvm = settings.use_lvm?
+          y2storage_settings.lvm = settings.lvm unless settings.lvm.nil?
           y2storage_settings.encryption_password = settings.encryption_password
 
           devices = settings.candidate_devices
-          y2storage_settings.candidate_devices = devices if devices&.any?
+          y2storage_settings.candidate_devices = devices if devices.any?
 
           volume_specs = calculate_volume_specs
           # If no volumes are specified, just leave the default ones (hardcoded at Y2Storage)
@@ -82,8 +87,11 @@ module DInstaller
       private
 
         # @see ProposalSettingsConverter#to_y2storage
+        # @return [ProposalSettings]
         attr_reader :settings
+
         # @see ProposalSettingsConverter#initialize
+        # @return [Array<Y2Storage::VolumeSpecification>]
         attr_reader :default_specs
 
         # Calculate volume specs for the storage proposal settings
@@ -116,6 +124,59 @@ module DInstaller
           end
 
           specs
+        end
+
+        # Object to perform the conversion of the volumes
+        def volume_converter
+          @volume_converter ||= VolumeConverter.new(default_specs: default_specs)
+        end
+      end
+
+      # Internal class to generate a ProposalSettings object
+      class ToDInstaller
+        # Constructor
+        #
+        # @param y2storage_settings [Y2Storage::ProposalSettings]
+        # @param default_specs [Array<Y2Storage::VolumeSpecification>]
+        # @param devices [Array<Y2Storage::Planned::Device>]
+        def initialize(y2storage_settings, default_specs, devices)
+          @y2storage_settings = y2storage_settings
+          @default_specs = default_specs
+          @devices = devices
+        end
+
+        # @return [ProposalSettings]
+        def convert
+          ProposalSettings.new.tap do |settings|
+            settings.candidate_devices = y2storage_settings.candidate_devices
+            settings.lvm = y2storage_settings.lvm
+            settings.encryption_password = y2storage_settings.encryption_password
+            settings.volumes = y2storage_settings.volumes.map { |v| convert_volume(v) }
+          end
+        end
+
+      private
+
+        # @see ProposalSettingsConverter#to_dinstaller
+        # @return [Y2Storage::ProposalSettings]
+        attr_reader :y2storage_settings
+
+        # @see ProposalSettingsConverter#initialize
+        # @return [Array<Y2Storage::VolumeSpecification>]
+        attr_reader :default_specs
+
+        # @see ProposalSettingsConverter#to_dinstaller
+        # @return [Array<Y2Storage::Planned::Device>]
+        attr_reader :devices
+
+        # Converts a volume spec to a Volume
+        #
+        # @param spec [Y2Storage::VolumeSpecification]
+        # @return [Volume]
+        def convert_volume(spec)
+          volume_converter.to_dinstaller(spec, devices: devices).tap do |volume|
+            volume.encrypted = y2storage_settings.use_encryption
+          end
         end
 
         # Object to perform the conversion of the volumes

--- a/service/test/dinstaller/storage/manager_test.rb
+++ b/service/test/dinstaller/storage/manager_test.rb
@@ -48,11 +48,18 @@ describe DInstaller::Storage::Manager do
   let(:security) { instance_double(DInstaller::Security, probe: nil, write: nil) }
 
   describe "#probe" do
-    let(:proposal) { instance_double(DInstaller::Storage::Proposal, calculate: nil) }
-
     before do
       allow(DInstaller::Storage::Proposal).to receive(:new).and_return(proposal)
     end
+
+    let(:proposal) do
+      instance_double(DInstaller::Storage::Proposal, calculate: nil, available_devices: devices)
+    end
+
+    let(:devices) { [disk1, disk2] }
+
+    let(:disk1) { instance_double(Y2Storage::Disk, name: "/dev/vda") }
+    let(:disk2) { instance_double(Y2Storage::Disk, name: "/dev/vdb") }
 
     it "probes the storage devices and calculates a proposal" do
       expect(y2storage_manager).to receive(:activate) do |callbacks|

--- a/service/test/dinstaller/storage/proposal_test.rb
+++ b/service/test/dinstaller/storage/proposal_test.rb
@@ -260,38 +260,33 @@ describe DInstaller::Storage::Proposal do
     end
   end
 
-  describe "#calculated_volumes" do
-    it "returns an empty array if #calculate has not being called" do
-      expect(proposal.calculated_volumes).to eq []
+  describe "#calculated_settings" do
+    context "if #calculate has not been called yet" do
+      it "returns nil" do
+        expect(proposal.calculated_settings).to be_nil
+      end
     end
 
-    context "with volumes that are disabled by default" do
-      let(:config_volumes) do
-        [
-          { "mount_point" => "/", "fs_type" => "btrfs", "min_size" => "10 GiB" },
-          { "mount_point" => "/enabled", "min_size" => "5 GiB" },
-          { "mount_point" => "/disabled", "proposed" => false, "min_size" => "5 GiB" }
-        ]
-      end
-
-      # Note that calling #calculate without settings means "reset to default volumes"
-      it "returns only the volumes enabled by default if #calculate was called with no settings" do
+    context "if #calculate was called without settings" do
+      before do
         proposal.calculate
-        expect(proposal.calculated_volumes.map(&:mount_point)).to contain_exactly("/", "/enabled")
       end
-    end
-  end
 
-  describe "#settings" do
-    let(:settings) { DInstaller::Storage::ProposalSettings.new }
+      context "and the config has disabled volumes" do
+        let(:config_volumes) do
+          [
+            { "mount_point" => "/", "fs_type" => "btrfs", "min_size" => "10 GiB" },
+            { "mount_point" => "/enabled", "min_size" => "5 GiB" },
+            { "mount_point" => "/disabled", "proposed" => false, "min_size" => "5 GiB" }
+          ]
+        end
 
-    it "returns nil if #calculate has not being called" do
-      expect(proposal.settings).to be_nil
-    end
-
-    it "returns the settings previously passed to #calculate" do
-      proposal.calculate(settings)
-      expect(proposal.settings).to eq settings
+        # Note that calling #calculate without settings means "reset to default"
+        it "returns settings with only the volumes enabled by default" do
+          expect(proposal.calculated_settings.volumes.map(&:mount_point))
+            .to contain_exactly("/", "/enabled")
+        end
+      end
     end
   end
 

--- a/service/test/dinstaller/storage/proposal_volumes_test.rb
+++ b/service/test/dinstaller/storage/proposal_volumes_test.rb
@@ -144,11 +144,11 @@ describe DInstaller::Storage::Proposal do
       end
     end
 
-    describe "#calculated_volumes" do
-      it "returns the correct set of volumes" do
+    describe "#calculated_settings" do
+      it "returns settings with the correct set of volumes" do
         proposal.calculate(settings)
 
-        expect(proposal.calculated_volumes).to contain_exactly(
+        expect(proposal.calculated_settings.volumes).to contain_exactly(
           an_object_having_attributes(
             mount_point: "/", optional: false, encrypted: false, device_type: :partition,
             fs_type: fs_type(:btrfs), fs_types: [fs_type(:btrfs), fs_type(:ext4)],
@@ -179,11 +179,11 @@ describe DInstaller::Storage::Proposal do
       end
     end
 
-    describe "#calculated_volumes" do
-      it "returns the correct set of mandatory volumes" do
+    describe "#calculated_settings" do
+      it "returns settings with the correct set of mandatory volumes" do
         proposal.calculate(settings)
 
-        expect(proposal.calculated_volumes).to contain_exactly(
+        expect(proposal.calculated_settings.volumes).to contain_exactly(
           an_object_having_attributes(
             mount_point: "/", optional: false, snapshots: false,
             fs_type: fs_type(:btrfs), fs_types: [fs_type(:btrfs), fs_type(:ext4)],
@@ -209,11 +209,11 @@ describe DInstaller::Storage::Proposal do
       end
     end
 
-    describe "#calculated_volumes" do
-      it "returns the correct set of volumes" do
+    describe "#calculated_settings" do
+      it "returns settings with the correct set of volumes" do
         proposal.calculate(settings)
 
-        expect(proposal.calculated_volumes).to contain_exactly(
+        expect(proposal.calculated_settings.volumes).to contain_exactly(
           an_object_having_attributes(
             mount_point: "/", optional: false, snapshots: true,
             fs_type: fs_type(:btrfs), fs_types: [fs_type(:btrfs), fs_type(:ext4)]
@@ -241,11 +241,11 @@ describe DInstaller::Storage::Proposal do
       end
     end
 
-    describe "#calculated_volumes" do
-      it "returns a set of volumes with fixed limits and adjusted sizes" do
+    describe "#calculated_settings" do
+      it "returns settings with a set of volumes with fixed limits and adjusted sizes" do
         proposal.calculate(settings)
 
-        expect(proposal.calculated_volumes).to contain_exactly(
+        expect(proposal.calculated_settings.volumes).to contain_exactly(
           an_object_having_attributes(
             mount_point: "/", snapshots: false, fixed_size_limits: false,
             size_relevant_volumes: ["/two"], min_size: Y2Storage::DiskSize.GiB(15)
@@ -272,11 +272,11 @@ describe DInstaller::Storage::Proposal do
       end
     end
 
-    describe "#calculated_volumes" do
-      it "returns a set of volumes with fixed limits and adjusted sizes" do
+    describe "#calculated_settings" do
+      it "returns settings with a set of volumes with fixed limits and adjusted sizes" do
         proposal.calculate(settings)
 
-        expect(proposal.calculated_volumes).to contain_exactly(
+        expect(proposal.calculated_settings.volumes).to contain_exactly(
           an_object_having_attributes(
             mount_point: "/", snapshots: true, fixed_size_limits: false,
             min_size: Y2Storage::DiskSize.GiB(40)
@@ -304,11 +304,11 @@ describe DInstaller::Storage::Proposal do
       end
     end
 
-    describe "#calculated_volumes" do
-      it "returns a set of volumes with fixed limits and adjusted sizes" do
+    describe "#calculated_settings" do
+      it "returns settings with a set of volumes with fixed limits and adjusted sizes" do
         proposal.calculate(settings)
 
-        expect(proposal.calculated_volumes).to contain_exactly(
+        expect(proposal.calculated_settings.volumes).to contain_exactly(
           an_object_having_attributes(
             mount_point: "/", snapshots: true, fixed_size_limits: false,
             size_relevant_volumes: ["/two"], min_size: Y2Storage::DiskSize.GiB(60)
@@ -337,11 +337,11 @@ describe DInstaller::Storage::Proposal do
       end
     end
 
-    describe "#calculated_volumes" do
-      it "returns a set of volumes with fixed limits and adjusted sizes" do
+    describe "#calculated_settings" do
+      it "returns settings with a set of volumes with fixed limits and adjusted sizes" do
         proposal.calculate(settings)
 
-        expect(proposal.calculated_volumes).to contain_exactly(
+        expect(proposal.calculated_settings.volumes).to contain_exactly(
           an_object_having_attributes(
             mount_point: "/", snapshots: true, fixed_size_limits: true,
             size_relevant_volumes: ["/two"], min_size: Y2Storage::DiskSize.GiB(6)


### PR DESCRIPTION
## Problem

The new D-Bus API for the storage proposal (see https://github.com/yast/d-installer/pull/268) allows asking for some info, for example, the candidate devices or whether LVM was used for calculating the proposal. Some of that values could be nil if the proposal was calculated with incomplete data:

~~~
 busctl call org.opensuse.DInstaller.Storage /org/opensuse/DInstaller/Storage/Proposal1 org.opensuse.DInstaller.Storage.Proposal1 Calculate a{sv} 1 LVM b true 
~~~

With the previous call, asking for `#candidate_devices` would return nil.

## Solution

Do not use the incomplete settings from the call to the D-Bus `Calculate` method. Instead of that, use settings with data from the actual Y2Storage proposal settings, which always contains all the information used to calculate the proposal.

This PR also limits the default proposal calculated during the config phase. Now such a proposal is calculated with a single candidate device (the first availabe device). Note that the UI only allows selecting a single device, and the storage proposal could use more than one candidate device if none is indicated. This is a temporary fix meanwhile the UI is adapted to use more than one device.

## Testing

* Adapted new unit tests
* Tested manually
