### PR TITLE
Storage service applies the product's configuration

### DIFF
--- a/service/lib/dinstaller/dbus/clients/software.rb
+++ b/service/lib/dinstaller/dbus/clients/software.rb
@@ -60,9 +60,12 @@ module DInstaller
 
         # Product selected to install
         #
-        # @return [String] name of the product
+        # @return [String, nil] name of the product
         def selected_product
-          dbus_object["org.opensuse.DInstaller.Software1"]["SelectedBaseProduct"]
+          product = dbus_object["org.opensuse.DInstaller.Software1"]["SelectedBaseProduct"]
+          return nil if product.empty?
+
+          product
         end
 
         # Selects the product to install

--- a/service/lib/dinstaller/dbus/manager.rb
+++ b/service/lib/dinstaller/dbus/manager.rb
@@ -146,9 +146,9 @@ module DInstaller
           dbus_properties_changed(MANAGER_INTERFACE, { "BusyServices" => busy_services }, [])
         end
 
-        backend.software.on_product_selected do |product|
+        backend.software.on_product_selected do |_product|
           safe_run do
-            busy_while { backend.select_product(product) }
+            busy_while { backend.config_phase }
           end
         end
       end

--- a/service/lib/dinstaller/manager.rb
+++ b/service/lib/dinstaller/manager.rb
@@ -63,8 +63,7 @@ module DInstaller
     # Runs the startup phase
     def startup_phase
       installation_phase.startup
-
-      probe_single_product unless config.multi_product?
+      config_phase if software.selected_product
 
       logger.info("Startup phase done")
     end
@@ -163,14 +162,6 @@ module DInstaller
       end
     end
 
-    # Actions to perform when a product is selected
-    #
-    # @note The config phase is executed.
-    def select_product(product)
-      config.pick_product(product)
-      config_phase
-    end
-
     # Name of busy services
     #
     # @see ServiceStatusRecorder
@@ -204,17 +195,6 @@ module DInstaller
     # Copy the logs to the target system
     def copy_logs
       Yast::WFM.CallFunction("copy_logs_finish", ["Write"])
-    end
-
-    # Runs the config phase for the first product found
-    #
-    # Adjust the configuration and run the config phase.
-    #
-    # This method is expected to be used on single-product scenarios.
-    def probe_single_product
-      selected = config.data["products"].keys.first
-      config.pick_product(selected)
-      config_phase
     end
   end
 end

--- a/service/lib/dinstaller/storage/manager.rb
+++ b/service/lib/dinstaller/storage/manager.rb
@@ -30,6 +30,7 @@ require "dinstaller/with_progress"
 require "dinstaller/can_ask_question"
 require "dinstaller/security"
 require "dinstaller/dbus/clients/questions_manager"
+require "dinstaller/dbus/clients/software"
 require "dinstaller/helpers"
 
 Yast.import "PackagesProposal"
@@ -50,6 +51,7 @@ module DInstaller
       # Probes storage devices and performs an initial proposal
       def probe
         start_progress(4)
+        config.pick_product(software.selected_product)
         progress.step("Activating storage devices") { activate_devices }
         progress.step("Probing storage devices") { probe_devices }
         progress.step("Calculating the storage proposal") { calculate_proposal }
@@ -160,6 +162,13 @@ module DInstaller
       # @return [DInstaller::DBus::Clients::QuestionsManager]
       def questions_manager
         @questions_manager ||= DInstaller::DBus::Clients::QuestionsManager.new
+      end
+
+      # Returns the client to ask the software service
+      #
+      # @return [DInstaller::DBus::Clients::Software]
+      def software
+        @software ||= DBus::Clients::Software.new
       end
     end
   end

--- a/service/test/dinstaller/dbus/clients/software_test.rb
+++ b/service/test/dinstaller/dbus/clients/software_test.rb
@@ -71,11 +71,23 @@ describe DInstaller::DBus::Clients::Software do
 
   describe "#selected_product" do
     before do
-      allow(software_iface).to receive(:[]).with("SelectedBaseProduct").and_return("Tumbleweed")
+      allow(software_iface).to receive(:[]).with("SelectedBaseProduct").and_return(product)
     end
 
-    it "returns the name of the selected product" do
-      expect(subject.selected_product).to eq("Tumbleweed")
+    context "when there is no selected product" do
+      let(:product) { "" }
+
+      it "returns nil" do
+        expect(subject.selected_product).to be_nil
+      end
+    end
+
+    context "when there is a selected product" do
+      let(:product) { "Tumbleweed" }
+
+      it "returns the name of the selected product" do
+        expect(subject.selected_product).to eq("Tumbleweed")
+      end
     end
   end
 

--- a/service/test/dinstaller/storage/manager_test.rb
+++ b/service/test/dinstaller/storage/manager_test.rb
@@ -37,6 +37,8 @@ describe DInstaller::Storage::Manager do
     allow(Y2Storage::StorageManager).to receive(:instance).and_return(y2storage_manager)
     allow(DInstaller::DBus::Clients::QuestionsManager).to receive(:new)
       .and_return(questions_manager)
+    allow(DInstaller::DBus::Clients::Software).to receive(:new)
+      .and_return(software)
     allow(Bootloader::FinishClient).to receive(:new)
       .and_return(bootloader_finish)
     allow(DInstaller::Security).to receive(:new).and_return(security)
@@ -44,6 +46,9 @@ describe DInstaller::Storage::Manager do
 
   let(:y2storage_manager) { instance_double(Y2Storage::StorageManager, probe: nil) }
   let(:questions_manager) { instance_double(DInstaller::DBus::Clients::QuestionsManager) }
+  let(:software) do
+    instance_double(DInstaller::DBus::Clients::Software, selected_product: "ALP")
+  end
   let(:bootloader_finish) { instance_double(Bootloader::FinishClient, write: nil) }
   let(:security) { instance_double(DInstaller::Security, probe: nil, write: nil) }
 
@@ -62,6 +67,7 @@ describe DInstaller::Storage::Manager do
     let(:disk2) { instance_double(Y2Storage::Disk, name: "/dev/vdb") }
 
     it "probes the storage devices and calculates a proposal" do
+      expect(config).to receive(:pick_product).with("ALP")
       expect(y2storage_manager).to receive(:activate) do |callbacks|
         expect(callbacks).to be_a(DInstaller::Storage::Callbacks::Activate)
       end


### PR DESCRIPTION
The storage service takes the selected product into account before performing the probing. It fixes #311.

PS: we should do something similar for the network service, but there is no network configuration in the YAML file, so we can keep it as it is now.