### PR TITLE
Set PATH to a known value

### DIFF
--- a/service/bin/d-installer
+++ b/service/bin/d-installer
@@ -22,8 +22,10 @@
 # find current contact information at www.suse.com.
 
 # TEMPORARY overwrite of Y2DIR to use DBus for communication with dependent yast modules
-
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
+
+# Set the PATH to a known value
+ENV["PATH"] = "/sbin:/usr/sbin:/usr/bin:/bin"
 
 require "rubygems"
 # find Gemfile when D-Bus activates a git checkout


### PR DESCRIPTION
The PATH is different when `d-installer` is automatically started by D-Bus and when it is started manually. It causes helper tools, like `grub2-mkconfig`, to fail.

Set the PATH to a known value.

We might call [config_env](https://github.com/yast/yast-ruby-bindings/blob/d99f5b6b76fed45b598b3f675be109bd7ed7bc1f/src/ruby/yast/y2start_helpers.rb#L19) but, at this point, we do not need to do anything else (like setting the `GODEBUG`) and the code there might be related to `y2start` (and we are not using it).