### PR TITLE
Only show the link for connecting to a WiFI network if wireless is enabled

### DIFF
--- a/web/package/cockpit-d-installer.changes
+++ b/web/package/cockpit-d-installer.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Dec 15 10:14:22 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
+
+- Do not show the link to configure wifi networks when wireless is
+  not enabled (gh#yast/d-installer#323).
+
+-------------------------------------------------------------------
 Thu Dec 15 08:55:02 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Display questions during the software installation (related to

--- a/web/src/client/network.test.js
+++ b/web/src/client/network.test.js
@@ -50,7 +50,9 @@ const adapter = {
   deleteConnection: jest.fn(),
   accessPoints: jest.fn(),
   connectTo: jest.fn(),
-  addAndConnectTo: jest.fn()
+  addAndConnectTo: jest.fn(),
+  wirelessEnabled: jest.fn().mockReturnValue(true),
+  wifiHardwareEnabled: jest.fn().mockReturnValue(true)
 };
 
 describe("NetworkClient", () => {
@@ -73,6 +75,20 @@ describe("NetworkClient", () => {
     it("returns the hostname from the adapter", () => {
       const client = new NetworkClient(adapter);
       expect(client.hostname()).toEqual("localhost.localdomain");
+    });
+  });
+
+  describe("#wirelessEnabled", () => {
+    it("returns whether the wireless is currently enabled or not from the adapter", () => {
+      const client = new NetworkClient(adapter);
+      expect(client.wirelessEnabled()).toEqual(true);
+    });
+  });
+
+  describe("#wifiHardwareEnabled", () => {
+    it("returns whether the wireless hardware is currently enabled or not from the adapter", () => {
+      const client = new NetworkClient(adapter);
+      expect(client.wifiHardwareEnabled()).toEqual(true);
     });
   });
 });

--- a/web/src/client/network.test.js
+++ b/web/src/client/network.test.js
@@ -38,11 +38,15 @@ const conn = {
   addresses: [{ address: "192.168.122.1", prefix: 24 }]
 };
 
+const settings = {
+  wireless: true,
+  hostname: "localhost.localdomain"
+};
+
 const adapter = {
   setUp: jest.fn(),
   activeConnections: jest.fn().mockReturnValue([active_conn]),
   connections: jest.fn().mockReturnValue([conn]),
-  hostname: jest.fn().mockReturnValue("localhost.localdomain"),
   subscribe: jest.fn(),
   getConnection: jest.fn(),
   addConnection: jest.fn(),
@@ -51,8 +55,7 @@ const adapter = {
   accessPoints: jest.fn(),
   connectTo: jest.fn(),
   addAndConnectTo: jest.fn(),
-  wirelessEnabled: jest.fn().mockReturnValue(true),
-  wifiHardwareEnabled: jest.fn().mockReturnValue(true)
+  settings: jest.fn().mockReturnValue(settings),
 };
 
 describe("NetworkClient", () => {
@@ -71,24 +74,11 @@ describe("NetworkClient", () => {
     });
   });
 
-  describe("#hostname", () => {
-    it("returns the hostname from the adapter", () => {
+  describe("#settings", () => {
+    it("returns network general settings", () => {
       const client = new NetworkClient(adapter);
-      expect(client.hostname()).toEqual("localhost.localdomain");
-    });
-  });
-
-  describe("#wirelessEnabled", () => {
-    it("returns whether the wireless is currently enabled or not from the adapter", () => {
-      const client = new NetworkClient(adapter);
-      expect(client.wirelessEnabled()).toEqual(true);
-    });
-  });
-
-  describe("#wifiHardwareEnabled", () => {
-    it("returns whether the wireless hardware is currently enabled or not from the adapter", () => {
-      const client = new NetworkClient(adapter);
-      expect(client.wifiHardwareEnabled()).toEqual(true);
+      expect(client.settings().hostname).toEqual("localhost.localdomain");
+      expect(client.settings().wireless).toEqual(true);
     });
   });
 });

--- a/web/src/client/network/index.js
+++ b/web/src/client/network/index.js
@@ -25,6 +25,7 @@ import { NetworkManagerAdapter } from "./network_manager";
 import { ConnectionTypes, ConnectionState } from "./model";
 
 /**
+ * @typedef {import("./model").NetworkSettings} NetworkSettings
  * @typedef {import("./model").Connection} Connection
  * @typedef {import("./model").ActiveConnection} ActiveConnection
  * @typedef {import("./model").IPAddress} IPAddress
@@ -37,7 +38,8 @@ const NetworkEventTypes = Object.freeze({
   ACTIVE_CONNECTION_REMOVED: "active_connection_removed",
   CONNECTION_ADDED: "connection_added",
   CONNECTION_UPDATED: "connection_updated",
-  CONNECTION_REMOVED: "connection_removed"
+  CONNECTION_REMOVED: "connection_removed",
+  SETTINGS_UPDATED: "settings_updated"
 });
 
 /**
@@ -52,9 +54,7 @@ const NetworkEventTypes = Object.freeze({
  * @property {(connection: Connection) => Promise<any>} addConnection
  * @property {(connection: Connection) => Promise<any>} updateConnection
  * @property {(connection: Connection) => void} deleteConnection
- * @property {() => string} wirelessEnabled
- * @property {() => string} wifiHardwareEnabled
- * @property {() => string} hostname
+ * @property {() => NetworkSettings} settings
  * @property {() => void} setUp
  */
 
@@ -213,30 +213,10 @@ o  *   NetworkManagerAdapter.
   }
 
   /*
-   * Returns whether wifi hardware is enabled or not
-   *
-   * @return {boolean}
-   */
-  wirelessEnabled() {
-    return this.adapter.wirelessEnabled();
-  }
-
-  /*
-   * Returns whether wifi hardware is enabled or not
-   *
-   * @return {boolean}
-   */
-  wifiHardwareEnabled() {
-    return this.adapter.wifiHardwareEnabled();
-  }
-
-  /**
-   * Returns the computer's hostname
-   *
-   * @return {string}
-   */
-  hostname() {
-    return this.adapter.hostname();
+  * Returns network general settings
+  */
+  settings() {
+    return this.adapter.settings();
   }
 }
 

--- a/web/src/client/network/index.js
+++ b/web/src/client/network/index.js
@@ -52,6 +52,8 @@ const NetworkEventTypes = Object.freeze({
  * @property {(connection: Connection) => Promise<any>} addConnection
  * @property {(connection: Connection) => Promise<any>} updateConnection
  * @property {(connection: Connection) => void} deleteConnection
+ * @property {() => string} wirelessEnabled
+ * @property {() => string} wifiHardwareEnabled
  * @property {() => string} hostname
  * @property {() => void} setUp
  */
@@ -208,6 +210,24 @@ o  *   NetworkManagerAdapter.
   addresses() {
     const conns = this.adapter.activeConnections();
     return conns.flatMap(c => c.addresses);
+  }
+
+  /*
+   * Returns whether wifi hardware is enabled or not
+   *
+   * @return {boolean}
+   */
+  wirelessEnabled() {
+    return this.adapter.wirelessEnabled();
+  }
+
+  /*
+   * Returns whether wifi hardware is enabled or not
+   *
+   * @return {boolean}
+   */
+  wifiHardwareEnabled() {
+    return this.adapter.wifiHardwareEnabled();
   }
 
   /**

--- a/web/src/client/network/model.js
+++ b/web/src/client/network/model.js
@@ -108,6 +108,11 @@ const SecurityProtocols = Object.freeze({
  */
 
 /**
+* @typedef {object} NetworkSettings
+* @property {boolean} wireless
+* @property {string} hostname
+
+/**
  * Returns an IPv4 configuration object
  *
  * Defaults values can be overriden

--- a/web/src/client/network/network_manager.js
+++ b/web/src/client/network/network_manager.js
@@ -177,6 +177,7 @@ class NetworkManagerAdapter {
       accessPoints: {},
       activeConnections: {},
       ip4Configs: {},
+      manager: null,
       settings: null,
       connections: {}
     };
@@ -196,10 +197,15 @@ class NetworkManagerAdapter {
         ACTIVE_CONNECTION_IFACE, ACTIVE_CONNECTION_NAMESPACE
       ),
       ip4Configs: await this.client.proxies(IP4CONFIG_IFACE, IP4CONFIG_NAMESPACE),
+      manager: await this.client.proxy(IFACE),
       settings: await this.client.proxy(SETTINGS_IFACE),
       connections: await this.client.proxies(CONNECTION_IFACE, SETTINGS_NAMESPACE)
     };
     this.subscribeToEvents();
+  }
+
+  wirelessHardware() {
+    return !!this.proxies.manager?.WirelessHardwareEnabled;
   }
 
   /**
@@ -484,6 +490,26 @@ class NetworkManagerAdapter {
    */
   connectionIPAddress(data) {
     return { address: data.address.v, prefix: parseInt(data.prefix.v) };
+  }
+
+  /**
+  *
+  * Returns whether WiFi hardware is enabled or not
+  *
+  * @return [boolean] true if it enabled; false otherwise
+  */
+  wirelessEnabled() {
+    return !!this.proxies.manager?.WirelessEnabled;
+  }
+
+  /**
+  *
+  * Returns whether WiFi hardware is enabled or not
+  *
+  * @return [boolean] true if it enabled; false otherwise
+  */
+  wifiHardwareEnabled() {
+    return !!this.proxies.manager?.WifiHardwareEnabled;
   }
 
   /**

--- a/web/src/client/network/network_manager.js
+++ b/web/src/client/network/network_manager.js
@@ -205,10 +205,6 @@ class NetworkManagerAdapter {
     this.subscribeToEvents();
   }
 
-  wirelessHardware() {
-    return !!this.proxies.manager?.WirelessHardwareEnabled;
-  }
-
   /**
    * Returns the list of active connections
    *

--- a/web/src/client/network/network_manager.test.js
+++ b/web/src/client/network/network_manager.test.js
@@ -125,10 +125,15 @@ const addressesData = {
 };
 
 const ActivateConnectionFn = jest.fn();
+const WirelessEnabled = false;
+const WifiHardwareEnabled = true;
+
 const networkProxy = () => ({
   wait: jest.fn(),
   ActivateConnection: ActivateConnectionFn,
   ActiveConnections: Object.keys(activeConnections),
+  WirelessEnabled: WirelessEnabled,
+  WifiHardwareEnabled: WifiHardwareEnabled
 });
 
 const AddConnectionFn = jest.fn();
@@ -350,6 +355,22 @@ describe("NetworkManagerAdapter", () => {
       const client = new NetworkManagerAdapter(dbusClient);
       await client.setUp();
       expect(client.hostname()).toEqual("testing-machine");
+    });
+  });
+
+  describe("#wirelessEnabled", () => {
+    it("returns whether wireless is currently enabled or not", async() => {
+      const client = new NetworkManagerAdapter(dbusClient);
+      await client.setUp();
+      expect(client.wirelessEnabled()).toEqual(false);
+    });
+  });
+
+  describe("#wifiHardwareEnabled", () => {
+    it("returns whether wireless hardware is currently enabled or not", async() => {
+      const client = new NetworkManagerAdapter(dbusClient);
+      await client.setUp();
+      expect(client.wifiHardwareEnabled()).toEqual(true);
     });
   });
 });

--- a/web/src/client/network/network_manager.test.js
+++ b/web/src/client/network/network_manager.test.js
@@ -95,12 +95,15 @@ const connections = {
   }
 };
 
+// Reminder: by default, properties added using Object.defineProperties() are not enumerable.
+// We use #defineProperties here, so it doesn't show up as a "connection" in these objects.
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperties#enumerable
 Object.defineProperties(activeConnections, {
-  addEventListener: { value: jest.fn(), enumerable: false }
+  addEventListener: { value: jest.fn() }
 });
 
 Object.defineProperties(connections, {
-  addEventListener: { value: jest.fn(), enumerable: false }
+  addEventListener: { value: jest.fn() }
 });
 
 const addressesData = {
@@ -125,30 +128,23 @@ const addressesData = {
 };
 
 const ActivateConnectionFn = jest.fn();
-const WirelessEnabled = false;
-const WifiHardwareEnabled = true;
 
-const networkProxyFn = () => ({
+const networkProxy = {
   wait: jest.fn(),
   ActivateConnection: ActivateConnectionFn,
   ActiveConnections: Object.keys(activeConnections),
-  WirelessEnabled,
-  WifiHardwareEnabled
-});
+  WirelessEnabled: false,
+  WifiHardwareEnabled: true
+};
 
 const AddConnectionFn = jest.fn();
-const networkSettingsProxyFn = () => ({
+const networkSettingsProxy = {
   wait: jest.fn(),
   Hostname: "testing-machine",
   GetConnectionByUuid: () => "/org/freedesktop/NetworkManager/Settings/1",
   AddConnection: AddConnectionFn,
-});
-const networkSettingsProxy = networkSettingsProxyFn();
-const networkProxy = networkProxyFn();
-
-Object.defineProperties(networkSettingsProxy, {
-  addEventListener: { value: jest.fn(), enumerable: false }
-});
+  addEventListener: () => ({ value: jest.fn(), enumerable: false })
+};
 
 Object.defineProperties(networkProxy, {
   addEventListener: { value: jest.fn(), enumerable: false }

--- a/web/src/components/network/Network.jsx
+++ b/web/src/components/network/Network.jsx
@@ -31,12 +31,14 @@ export default function Network() {
   const [initialized, setInitialized] = useState(false);
   const [connections, setConnections] = useState([]);
   const [wifiSelectorOpen, setWifiSelectorOpen] = useState(false);
+  const [wirelessEnabled, setWirelessEnabled] = useState(false);
 
   useEffect(() => {
     if (!initialized) return;
 
+    setWirelessEnabled(client.network.wirelessEnabled());
     setConnections(client.network.activeConnections());
-  }, [client.network, initialized]);
+  }, [client.network, initialized, wirelessEnabled]);
 
   useEffect(() => {
     return client.network.onNetworkEvent(({ type, payload }) => {
@@ -81,10 +83,11 @@ export default function Network() {
       <StackItem>
         <NetworkWifiStatus connections={activeWifiConnections} />
       </StackItem>
-      <StackItem>
-        <Button variant="link" onClick={() => setWifiSelectorOpen(true)}>Connect to a Wi-Fi network</Button>
-        <WifiSelector isOpen={wifiSelectorOpen} onClose={() => setWifiSelectorOpen(false)} />
-      </StackItem>
+      { wirelessEnabled &&
+        <StackItem>
+          <Button variant="link" onClick={() => setWifiSelectorOpen(true)}>Connect to a Wi-Fi network</Button>
+          <WifiSelector isOpen={wifiSelectorOpen} onClose={() => setWifiSelectorOpen(false)} />
+        </StackItem> }
     </Stack>
   );
 }

--- a/web/src/components/network/Network.jsx
+++ b/web/src/components/network/Network.jsx
@@ -31,14 +31,14 @@ export default function Network() {
   const [initialized, setInitialized] = useState(false);
   const [connections, setConnections] = useState([]);
   const [wifiSelectorOpen, setWifiSelectorOpen] = useState(false);
-  const [wirelessEnabled, setWirelessEnabled] = useState(false);
+  const [wireless, setWireless] = useState(false);
 
   useEffect(() => {
     if (!initialized) return;
 
-    setWirelessEnabled(client.network.wirelessEnabled());
+    setWireless(client.network.settings().wireless);
     setConnections(client.network.activeConnections());
-  }, [client.network, initialized, wirelessEnabled]);
+  }, [client.network, initialized]);
 
   useEffect(() => {
     return client.network.onNetworkEvent(({ type, payload }) => {
@@ -61,6 +61,11 @@ export default function Network() {
 
         case NetworkEventTypes.ACTIVE_CONNECTION_REMOVED: {
           setConnections(conns => conns.filter(c => c.id !== payload.id));
+          break;
+        }
+
+        case NetworkEventTypes.SETTINGS_UPDATED: {
+          setWireless(payload.wireless);
         }
       }
     });
@@ -83,7 +88,7 @@ export default function Network() {
       <StackItem>
         <NetworkWifiStatus connections={activeWifiConnections} />
       </StackItem>
-      { wirelessEnabled &&
+      { wireless &&
         <StackItem>
           <Button variant="link" onClick={() => setWifiSelectorOpen(true)}>Connect to a Wi-Fi network</Button>
           <WifiSelector isOpen={wifiSelectorOpen} onClose={() => setWifiSelectorOpen(false)} />

--- a/web/src/components/network/Network.test.jsx
+++ b/web/src/components/network/Network.test.jsx
@@ -30,6 +30,7 @@ jest.mock("@components/network/NetworkWiredStatus", () => () => "Wired Connectio
 jest.mock("@components/network/NetworkWifiStatus", () => () => "WiFi Connections");
 
 let wirelessEnabled = false;
+const networkSettings = { wireless: wirelessEnabled, hostname: "test" };
 
 beforeEach(() => {
   createClient.mockImplementation(() => {
@@ -39,8 +40,8 @@ beforeEach(() => {
         activeConnections: () => [],
         connections: () => Promise.resolve([]),
         accessPoints: () => [],
-        wirelessEnabled: jest.fn(wirelessEnabled),
-        onNetworkEvent: jest.fn()
+        onNetworkEvent: jest.fn(),
+        settings: jest.fn().mockReturnValue(networkSettings)
       }
     };
   });

--- a/web/src/components/network/TargetIpsPopup.jsx
+++ b/web/src/components/network/TargetIpsPopup.jsx
@@ -45,7 +45,7 @@ export default function TargetIpsPopup() {
 
     const refreshState = () => {
       setAddresses(client.network.addresses());
-      setHostname(client.network.hostname());
+      setHostname(client.network.settings().hostname);
     };
 
     refreshState();

--- a/web/src/components/network/TargetIpsPopup.test.jsx
+++ b/web/src/components/network/TargetIpsPopup.test.jsx
@@ -34,7 +34,8 @@ const addresses = [
   { address: "5.6.7.8", prefix: 16 },
 ];
 const addressFn = jest.fn().mockReturnValue(addresses);
-const hostnameFn = jest.fn().mockReturnValue("example.net");
+const networkSettings = { wireless: false, hostname: "example.net" };
+const settingsFn = jest.fn().mockReturnValue(networkSettings);
 
 describe("TargetIpsPopup", () => {
   let callbacks;
@@ -46,7 +47,7 @@ describe("TargetIpsPopup", () => {
         network: {
           onNetworkEvent: onNetworkEventFn,
           addresses: addressFn,
-          hostname: hostnameFn,
+          settings: settingsFn,
           setUp: jest.fn().mockResolvedValue()
         }
       };
@@ -77,7 +78,7 @@ describe("TargetIpsPopup", () => {
     await screen.findByRole("button", { name: /1.2.3.4\/24 \(example.net\)/i });
 
     addressFn.mockReturnValue([{ address: "5.6.7.8", prefix: 24 }]);
-    hostnameFn.mockReturnValue("localhost.localdomain");
+    settingsFn.mockReturnValue({ wireless: false, hostname: "localhost.localdomain" });
     act(() => {
       callbacks.forEach(cb => cb());
     });

--- a/web/src/components/network/WifiSelector.jsx
+++ b/web/src/components/network/WifiSelector.jsx
@@ -84,7 +84,7 @@ function WifiSelector({ isOpen = false, onClose }) {
       setNetworks(data);
       setActiveNetwork(networksFromValues(data).find(d => d.connection));
     });
-  }, [client.network, connections, activeConnections]);
+  }, [client.network, connections, activeConnections, isOpen]);
 
   useEffect(() => {
     return client.network.onNetworkEvent(({ type, payload }) => {


### PR DESCRIPTION
## Problem

In #292 we added support for configuring a WiFi connection but it shows the link to connect to a network even when wireless is currently not enabled which is not correct at all.

## Solution

Do not show the link to connect to a Wireless when it is not enabled.


## Testing

- Added unit test for the backend, the Network.jsx component still lacks of it as there is some problem with the useEffect and maybe waitFor with a callback needs to be added.
- Tested manually

## Screenshots
| Wireless Enabled | Wireless Disabled |
| --- | --- |
| ![localhost_9090_cockpit_@localhost_d-installer_index html (9)](https://user-images.githubusercontent.com/7056681/202655742-b18837b0-7026-4fa8-beb5-7d89e72e346e.png) | ![localhost_9090_cockpit_@localhost_d-installer_index html (10)](https://user-images.githubusercontent.com/7056681/202655757-81300761-5655-41df-aeff-5479defe0288.png) |

![D-Installer_NetworkSettings](https://user-images.githubusercontent.com/7056681/207842323-6fc72f36-7c04-4bfe-b308-9cb52d14470d.gif)
