### PR TITLE
Add a D-Bus IsPackageInstalled method

### DIFF
--- a/service/lib/dinstaller/dbus/clients/software.rb
+++ b/service/lib/dinstaller/dbus/clients/software.rb
@@ -118,6 +118,13 @@ module DInstaller
           dbus_object.ProvisionsSelected(tags)
         end
 
+        # Determines whether a package with the given name is installed
+        #
+        # @param name [String] Package name
+        def package_installed?(name)
+          dbus_object.IsPackageInstalled(name)
+        end
+
         # Add the given list of resolvables to the packages proposal
         #
         # @param unique_id [String] Unique identifier for the resolvables list

--- a/service/lib/dinstaller/dbus/software/manager.rb
+++ b/service/lib/dinstaller/dbus/software/manager.rb
@@ -74,6 +74,10 @@ module DInstaller
             [provisions.map { |p| backend.provision_selected?(p) }]
           end
 
+          dbus_method :IsPackageInstalled, "in Name:s, out Result:b" do |name|
+            backend.package_installed?(name)
+          end
+
           dbus_method(:Probe) { probe }
           dbus_method(:Propose) { propose }
           dbus_method(:Install) { install }

--- a/service/lib/dinstaller/dbus/y2dir/manager/modules/Package.rb
+++ b/service/lib/dinstaller/dbus/y2dir/manager/modules/Package.rb
@@ -18,6 +18,7 @@
 # find current contact information at www.suse.com.
 
 require "yast"
+require "dinstaller/dbus/clients/software"
 
 # :nodoc:
 module Yast
@@ -27,6 +28,7 @@ module Yast
   class PackageClass < Module
     def main
       puts "Loading mocked module #{__FILE__}"
+      @client = DInstaller::DBus::Clients::Software.new
     end
 
     # Determines whether the package is available
@@ -41,9 +43,13 @@ module Yast
     #
     # @see https://github.com/yast/yast-yast2/blob/b8cd178b7f341f6e3438782cb703f4a3ab0529ed/library/packages/src/modules/Package.rb#L121
     # @todo Perform a real D-Bus call.
-    def Installed(_package_name, target: nil)
-      false
+    def Installed(package_name, target: nil)
+      client.package_installed?(package_name)
     end
+
+  private
+
+    attr_reader :client
   end
 
   Package = PackageClass.new

--- a/service/lib/dinstaller/software.rb
+++ b/service/lib/dinstaller/software.rb
@@ -26,6 +26,7 @@ require "dinstaller/config"
 require "dinstaller/with_progress"
 require "y2packager/product"
 
+Yast.import "Package"
 Yast.import "PackageInstallation"
 Yast.import "Pkg"
 Yast.import "Stage"
@@ -147,6 +148,14 @@ module DInstaller
     # @return [Boolean] true if it is provided; false otherwise
     def provision_selected?(tag)
       Yast::Pkg.IsSelected(tag) || Yast::Pkg.IsProvided(tag)
+    end
+
+    # Determines whether a package is installed
+    #
+    # @param name [String] Package name
+    # @return [Boolean] true if it is installed; false otherwise
+    def package_installed?(name)
+      Yast::Package.Installed(name, target: :system)
     end
 
   private

--- a/service/test/dinstaller/dbus/clients/software_test.rb
+++ b/service/test/dinstaller/dbus/clients/software_test.rb
@@ -134,6 +134,27 @@ describe DInstaller::DBus::Clients::Software do
     end
   end
 
+  describe "#package_installed?" do
+    let(:dbus_object) { double(::DBus::ProxyObject, IsPackageInstalled: installed?) }
+    let(:package) { "NetworkManager" }
+
+    context "when the package is installed" do
+      let(:installed?) { true }
+
+      it "returns true" do
+        expect(subject.package_installed?(package)).to eq(true)
+      end
+    end
+
+    context "when the package is installed" do
+      let(:installed?) { false }
+
+      it "returns false" do
+        expect(subject.package_installed?(package)).to eq(false)
+      end
+    end
+  end
+
   describe "#on_product_selected" do
     before do
       allow(dbus_object).to receive(:path).and_return("/org/opensuse/DInstaller/Test")

--- a/service/test/dinstaller/dbus/software/manager_test.rb
+++ b/service/test/dinstaller/dbus/software/manager_test.rb
@@ -105,7 +105,9 @@ describe DInstaller::DBus::Software::Manager do
   describe "D-Bus IsPackageInstalled" do
     it "returns whether the package is installed or not" do
       expect(backend).to receive(:package_installed?).with("NetworkManager").and_return(true)
-      installed = subject.public_send("org.opensuse.DInstaller.Software1%%IsPackageInstalled", "NetworkManager")
+      installed = subject.public_send(
+        "org.opensuse.DInstaller.Software1%%IsPackageInstalled", "NetworkManager"
+      )
       expect(installed).to eq(true)
     end
   end

--- a/service/test/dinstaller/dbus/software/manager_test.rb
+++ b/service/test/dinstaller/dbus/software/manager_test.rb
@@ -101,4 +101,12 @@ describe DInstaller::DBus::Software::Manager do
       subject.finish
     end
   end
+
+  describe "D-Bus IsPackageInstalled" do
+    it "returns whether the package is installed or not" do
+      expect(backend).to receive(:package_installed?).with("NetworkManager").and_return(true)
+      installed = subject.public_send("org.opensuse.DInstaller.Software1%%IsPackageInstalled", "NetworkManager")
+      expect(installed).to eq(true)
+    end
+  end
 end

--- a/service/test/dinstaller/software_test.rb
+++ b/service/test/dinstaller/software_test.rb
@@ -203,4 +203,29 @@ describe DInstaller::Software do
       expect(File).to exist(File.join(repos_dir, "example.repo"))
     end
   end
+
+  describe "#package_installed?" do
+    before do
+      allow(Yast::Package).to receive(:Installed).with(package, target: :system)
+        .and_return(installed?)
+    end
+
+    let(:package) { "NetworkManager" }
+
+    context "when the package is installed" do
+      let(:installed?) { true }
+
+      it "returns true" do
+        expect(subject.package_installed?(package)).to eq(true)
+      end
+    end
+
+    context "when the package is not installed" do
+      let(:installed?) { false }
+
+      it "returns false" do
+        expect(subject.package_installed?(package)).to eq(false)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Add a method to ask the software layer whether a package is installed or not. It fixes a problem
that caused `NetworkManager` to not be enabled because "it was not installed".

In the future, we should do the same for the `Package.Available` method.
