### PR TITLE
Replace PackageInstallation.Commit with Pkg.Commit

### DIFF
--- a/service/lib/dinstaller/software.rb
+++ b/service/lib/dinstaller/software.rb
@@ -27,7 +27,7 @@ require "dinstaller/with_progress"
 require "y2packager/product"
 
 Yast.import "Package"
-Yast.import "PackageInstallation"
+Yast.import "Packages"
 Yast.import "Pkg"
 Yast.import "Stage"
 
@@ -120,7 +120,7 @@ module DInstaller
       PackageCallbacks.setup(count_packages, progress)
 
       # TODO: error handling
-      commit_result = Yast::PackageInstallation.Commit({})
+      commit_result = Yast::Pkg.Commit({})
 
       if commit_result.nil? || commit_result.empty?
         logger.error("Commit failed")

--- a/service/test/dinstaller/software_test.rb
+++ b/service/test/dinstaller/software_test.rb
@@ -152,11 +152,11 @@ describe DInstaller::Software do
     let(:commit_result) { [250, [], [], [], []] }
 
     before do
-      allow(Yast::PackageInstallation).to receive(:Commit).and_return(commit_result)
+      allow(Yast::Pkg).to receive(:Commit).and_return(commit_result)
     end
 
     it "installs the packages" do
-      expect(Yast::PackageInstallation).to receive(:Commit).with({})
+      expect(Yast::Pkg).to receive(:Commit).with({})
         .and_return(commit_result)
       subject.install
     end


### PR DESCRIPTION
* A good share of the PackageInstallation.Commit method has to do with
  reporting the results of the software installation.
* If a package fails to install, the process cannot report the problem
  to the user and the installation gets blocked with tons of messages
  like:
  `[ui-component] YUIComponent.cc(createUI):156 Using dummy UI, NOT creating a UI`
* To make things worse, YaST log rotation causes the useful lines to be
  replaced by lines like the one above.
