### PR TITLE
Allow defining a list of packages to install

### DIFF
--- a/service/etc/d-installer.yaml
+++ b/service/etc/d-installer.yaml
@@ -37,6 +37,8 @@ Tumbleweed:
     mandatory_patterns:
       - enhanced_base # only pattern that is shared among all roles on TW
     optional_patterns: null # no optional pattern shared
+    mandatory_packages: null
+    optional_packages: null
     base_product: openSUSE
 
   security:
@@ -131,6 +133,8 @@ ALP:
       - alp_cockpit
       - alp-container_runtime
     optional_patterns: null # no optional pattern shared
+    mandatory_packages: null
+    optional_packages: null
     base_product: ALP
 
   security:
@@ -194,6 +198,8 @@ Leap:
     mandatory_patterns:
       - enhanced_base # For now lets pick some minimal one
     optional_patterns: null # no optional pattern shared
+    mandatory_packages: null
+    optional_packages: null
     base_product: Leap
 
   security:
@@ -287,6 +293,8 @@ Leap Micro:
       - microos-defaults
       - microos-basesystem
     optional_patterns: null # no optional pattern shared
+    mandatory_packages: null
+    optional_packages: null
     base_product: Leap-Micro
 
   security:

--- a/service/etc/d-installer.yaml
+++ b/service/etc/d-installer.yaml
@@ -133,7 +133,14 @@ ALP:
       - alp_cockpit
       - alp-container_runtime
     optional_patterns: null # no optional pattern shared
-    mandatory_packages: null
+    mandatory_packages:
+      - device-mapper
+      - system-user-tss
+      - libtss2-fapi1
+      - libtss2-tcti-device0
+      - tpm2.0-tools 
+      - tpm2-0-tss
+      - fde-tools
     optional_packages: null
     base_product: ALP
 

--- a/service/lib/dinstaller/software.rb
+++ b/service/lib/dinstaller/software.rb
@@ -168,6 +168,13 @@ module DInstaller
       optional_patterns = @config.data["software"]["optional_patterns"] || []
       Yast::PackagesProposal.SetResolvables("d-installer", :pattern, optional_patterns,
         optional: true)
+
+      mandatory_packages = @config.data["software"]["mandatory_packages"] || []
+      Yast::PackagesProposal.SetResolvables("d-installer", :package, mandatory_packages)
+
+      optional_packages = @config.data["software"]["optional_packages"] || []
+      Yast::PackagesProposal.SetResolvables("d-installer", :package, optional_packages,
+        optional: true)
     end
 
     # call solver to satisfy dependency or log error

--- a/service/test/dinstaller/software_test.rb
+++ b/service/test/dinstaller/software_test.rb
@@ -139,11 +139,15 @@ describe DInstaller::Software do
       subject.propose
     end
 
-    it "adds the packages to install" do
+    it "adds the patterns and packages to install" do
       expect(Yast::PackagesProposal).to receive(:SetResolvables)
         .with("d-installer", :pattern, ["enhanced_base"])
       expect(Yast::PackagesProposal).to receive(:SetResolvables)
         .with("d-installer", :pattern, ["optional_base"], optional: true)
+      expect(Yast::PackagesProposal).to receive(:SetResolvables)
+        .with("d-installer", :package, ["mandatory_pkg"])
+      expect(Yast::PackagesProposal).to receive(:SetResolvables)
+        .with("d-installer", :package, ["optional_pkg"], optional: true)
       subject.propose
     end
   end

--- a/service/test/fixtures/root_dir/etc/d-installer.yaml
+++ b/service/test/fixtures/root_dir/etc/d-installer.yaml
@@ -34,6 +34,10 @@ Tumbleweed:
       - enhanced_base # only pattern that is shared among all roles on TW
     optional_patterns:
       - optional_base
+    mandatory_packages:
+      - mandatory_pkg
+    optional_packages:
+      - optional_pkg
     base_product: openSUSE
 
   security:


### PR DESCRIPTION
Allow defining a list of packages to install per-product.

```yaml
  software:
    installation_repositories:
      - https://download.opensuse.org/tumbleweed/repo/oss/
      - https://download.opensuse.org/tumbleweed/repo/non-oss/
      - https://download.opensuse.org/update/tumbleweed/
    mandatory_patterns:
      - enhanced_base # only pattern that is shared among all roles on TW
    optional_patterns:
      - optional_base
    mandatory_packages:
      - mandatory_pkg
    optional_packages:
      - optional_pkg
    base_product: openSUSE
```
