### PR TITLE
Simplify the building and releasing process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+*.spec
 .log/
 .yardoc/

--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -4,17 +4,22 @@ D-Installer packages are available in the [YaST:Head:D-Installer project in
 OBS](https://build.opensuse.org/project/show/YaST:Head:D-Installer). This document summarizes the
 process we follow to build those packages.
 
-## Update release information
+The process to build the Ruby-based ones (`rubygem-d-installer` and `rubygem-d-installer-cli`) is
+different from the one we use to build the web UI (`cockpit-d-installer`). The former packages are
+built in the same way that other YaST packages (through Rake tasks), while the latter package is
+automatically built in the Open Build Service.
 
-Before releasing a new version, you are expected to update the version and the changelogs
-and commit those changes to the repository.
+## Releasing a new version
 
-* `VERSION` contains the version number for the Ruby packages (the service and the CLI). This value
-  is read and injected in the corresponding `gemspec` files when building the Ruby gems. Do not
-  forget to run `bundle` to update the version in the `Gemfile.lock` file.
-* `web/package/_service` defines the configuration of the build service. The version
-  number is specified as a param of the `set_version` service.
-* The changes files are included in the corresponding `package` directories.
+In order to release a new version, we need to:
+
+* Update the version number in the `VERSION` file. This file is read by the Ruby-based packages
+  when building the gems.
+* Tag the repository with the proper number. The process to build `cockpit-d-installer` uses this
+  information to infer the version. You can set the tag with something like:
+
+      git tag --sign 0.5 --message "Version 0.5"
+      git push --tags
 
 ## Building the packages
 
@@ -23,41 +28,38 @@ to update the packages in the build service.
 
 ### Service and CLI
 
-The process to release new version of the service and the CLI is pretty much the same. You can check
-the current packages in
+You can check the current packages in
 [YaST:Head:D-Installer/rubygem-d-installer](https://build.opensuse.org/package/show/YaST:Head:D-Installer/rubygem-d-installer)
 and
 [YaST:Head:D-Installer/rubygem-d-installer-cli](https://build.opensuse.org/package/show/YaST:Head:D-Installer/rubygem-d-installer-cli).
 
-Given that you are in the `service` or the `cli` directories, the process to release a new version
-can be summarized in these steps:
+Given that you are in the `service` or the `cli` directory, just type the following command to
+update the packages in the build service:
 
-1. Build the `gem` by running `gem build d-installer.gemspec` or `gem build
-   d-installer-cli.gemspec`.
-2. Update the `spec` file using the `gem2rpm` tool. The configuration is [included in the
-   repository](./service/package/gem2rpm.yml). To regenerate the spec, you might type something
-   like:
+      rake osc:commit
 
-       gem2rpm --config package/gem2rpm.yml d-installer-0.1.gem > package/rubygem-d-installer.spec
+If you just want to build the package locally, run:
 
-3. Checkout the OBS package and copy the `gem`, the `spec` and the `changes` files from the
-   repository.
-4. Commit the changes.
+      rake osc:build
 
 ### The Cockpit module
 
 The current package is
 [YaST:Head:D-Installer/cockpit-d-installer](https://build.opensuse.org/package/show/YaST:Head:D-Installer/cockpit-d-installer).
-You can figure out most details by checking the [_service](_./web/package/_service) file. It might
-happen that you get out of RAM when building the package, so in this case, it is better to build it
-remotely.
+It relies on [OBS Source
+Services](https://openbuildservice.org/help/manuals/obs-user-guide/cha.obs.source_service.html) to
+fetch the sources (including the dependencies), set the version and build the package. You can
+figure out most details by checking the [_service](_./web/package/_service) file. 
 
-Given that you are in the `web` directory, the process to update the package is:
+To update the package in the build service, you just need to type:
 
-1. Checkout the OBS package and copy `package/*` and `package-lock.json` files from the repository.
-2. In your package checkout, run `osc service manualrun`. It will update D-Installer sources and
-   dependencies (`node_modules`).
-3. Commit the changes.
+      osc rebuild YaST:Head:D-Installer cockpit-d-installer
+
+If you want to build the pacakge locally, just checkout (or branch) the package and run `osc build`.
+
+The version number is inferred from the repository tags (see [Releasing a new
+version](#releasing-a-new-version)): it uses the latest tag and the abbreviated hash of the last
+commit (e.g., `0.5.49e6a2a`).
 
 You can read more about the overall approach of this package in the following article: [Git work
 flows in the upcoming 2.7 release](https://openbuildservice.org/2016/04/08/new_git_in_27/).

--- a/README.md
+++ b/README.md
@@ -54,7 +54,16 @@ There are two ways of running this project: a) by using a D-Installer live ISO i
 
 ### Live ISO Image
 
-The easiest way to give D-Installer a try is to grab a [live ISO image](https://build.opensuse.org/package/binaries/YaST:Head:D-Installer/d-installer-live/images) and boot it in a virtual machine. This is also the recommended way if you only want to play and see it in action. If you want to have a closer look, then clone and configure the project as explained in the next section.
+The easiest way to give D-Installer a try is to grab a live ISO image and boot it in a virtual
+machine. This is also the recommended way if you only want to play and see it in action. If you want
+to have a closer look, then clone and configure the project as explained in the next section.
+
+* [multi-product](https://build.opensuse.org/package/binaries/YaST:Head:D-Installer/d-installer-live:default/images):
+  it can be used to install different products, like *openSUSE Tumbleweed*, *Leap*, *Leap Micro* or
+  an experimental version of the *Adaptable Linux Platform Host OS*.
+* [ALP only](https://build.opensuse.org/package/binaries/YaST:Head:D-Installer/d-installer-live:ALP/images):
+  it only contains the definition for the experimental *Adaptable Linux Platform Host OS*, although
+  the rest of the content is pretty much the same than the multi-product version.
 
 ### Manual Configuration
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast/rake"
+
+# Infers the gem name from the source code
+#
+# It searches for a gemspec to deduct the name.
+#
+# @param directory [String] sources directory
+# @return [String,nil]
+def gem_name_from(directory)
+  gemspec = Dir.glob(File.join(directory, "*.gemspec")).first
+  return nil unless gemspec
+
+  gemspec_file = File.basename(gemspec)
+  gemspec_file[/(.+)\.gemspec/, 1]
+end
+
+# Infers the package name from the source code
+#
+# @param directory [String] source directory
+# @return [String,nil]
+def package_name_from(directory)
+  gem = gem_name_from(directory)
+  return nil if gem.nil?
+
+  "rubygem-#{gem}"
+end
+
+# Finds the gems in the source directory
+#
+# @param directory [String] source directory
+# @return [<String>]
+def find_gem(directory)
+  name = gem_name_from(directory)
+  Dir.glob(File.join(directory, "#{name}-*.gem"))
+end
+
+Yast::Tasks.configuration do |conf|
+  conf.obs_api = "https://api.opensuse.org"
+  conf.obs_project = "YaST:Head:D-Installer"
+  conf.package_dir = File.join(Rake.original_dir, "package")
+  conf.obs_target = "openSUSE_Tumbleweed"
+  package_name = package_name_from(Rake.original_dir)
+  conf.package_name = package_name if package_name
+end
+
+# Removes the "package" task to redefine it later.
+Rake::Task["package"].clear
+# Disables the osc:build
+# Rake::Task["osc:build"].clear
+
+# TODO: redefine :tarball instead of :package
+desc "Prepare sources for rpm build"
+task package: [] do
+  Dir.chdir(Rake.original_dir) do |dir|
+    name = gem_name_from(dir)
+    sh "gem build #{name}.gemspec"
+    gem = find_gem(dir).first
+    gem2rpm = File.join(package_dir, "gem2rpm.yml")
+    sh "gem2rpm --config #{gem2rpm} #{gem} > package/#{package_name}.spec"
+    FileUtils.mv(gem, package_dir)
+  end
+end

--- a/web/package/_service
+++ b/web/package/_service
@@ -1,23 +1,22 @@
 <services>
-  <service name="obs_scm" mode="manual">
-    <!-- <param name="versionformat">@PARENT_TAG@</param> -->
+  <service name="obs_scm">
+    <param name="versionformat">@PARENT_TAG@.%h</param>
     <param name="url">http://github.com/yast/d-installer.git</param>
     <param name="scm">git</param>
     <param name="revision">master</param>
-    <param name="without-version">enable</param>
     <param name="subdir">web</param>
+    <param name="extract">package-lock.json</param>
+    <param name="extract">package/cockpit-d-installer.spec</param>
   </service>
-  <service name="node_modules" mode="manual">
+  <service name="node_modules">
     <param name="cpio">node_modules.obscpio</param>
     <param name="output">node_modules.spec.inc</param>
     <param name="source-offset">1000</param>
   </service>
   <service mode="buildtime" name="tar">
     <param name="obsinfo">d-installer.obsinfo</param>
-    <param name="filename">d-installer</param>
   </service>
   <service mode="buildtime" name="set_version">
     <param name="basename">d-installer</param>
-    <param name="version">0.5</param>
   </service>
 </services>

--- a/web/package/cockpit-d-installer.spec
+++ b/web/package/cockpit-d-installer.spec
@@ -24,7 +24,7 @@ License:        GPL-2.0-only
 URL:            https://github.com/yast/d-installer
 # source_validator insists that if obscpio has no version then
 # tarball must neither
-Source0:        d-installer.tar
+Source0:        d-installer-%{version}.tar
 Source10:       package-lock.json
 Source11:       node_modules.spec.inc
 Source12:       node_modules.sums
@@ -40,7 +40,7 @@ BuildRequires:  appstream-glib
 Cockpit module for the experimental YaST D-Installer.
 
 %prep
-%autosetup -p1 -n d-installer
+%autosetup -p1 -n d-installer-%{version}
 rm -f package-lock.json
 local-npm-registry %{_sourcedir} install --with=dev --legacy-peer-deps || ( find ~/.npm/_logs -name '*-debug.log' -print0 | xargs -0 cat; false)
 


### PR DESCRIPTION
This PR aims to make it easier to build and release new versions of the project.

* You can use `rake osc:build` or `rake osc:commit` to build or commit the Ruby-based packages to the build service.
* The Cockpit module is automatically rebuilt by the build service (including fetching sources, dependencies, and setting the version) by just retriggering the rebuild (`osc rebuild YaST:Head:D-Installer cockpit-d-installer`).

## Future

In a near future, we would like to add a Jenkins job to make the process fully unattended after merging a PR. For the Cockpit module, we might not even need Jenkins. However, we still need to build the `.gem` file for the Ruby-based packages (I am not willing to upload them to rubygems.org as I plan to do many updates).