### PR TITLE
Add device-mapper to the selection of packages of ALP

### DIFF
--- a/service/etc/d-installer.yaml
+++ b/service/etc/d-installer.yaml
@@ -133,7 +133,8 @@ ALP:
       - alp_cockpit
       - alp-container_runtime
     optional_patterns: null # no optional pattern shared
-    mandatory_packages: null
+    mandatory_packages:
+      - device-mapper # Apparently needed if devices at /dev/mapper are used at boot (eg. FDE)
     optional_packages: null
     base_product: ALP
 


### PR DESCRIPTION
## Problem

When installing an encrypted system (something that at this moment can only be done tweaking some values at the configuration file), the system was unable to boot. Dracut thrown some errors related to devices and timeouts.

The problem is fully described in [this bugzilla comment](https://bugzilla.opensuse.org/show_bug.cgi?id=1205309#c16). Everything seemed to work with the Olaf variant, so I initially assumed Grub2 was to blame (it used to be the only difference with the regular version of the D-Installer ISO).

## Solution

Turns out what made the Olaf version to work was not the differences in the Grub2 package, but the inclusion of the package `device-manager` in the selection of software. Tested that adding just that makes encryption work in general for the normal variants.

## Testing

Tested manually
