### PR TITLE
Always use the 'opensuse' template for gem2rpm

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -77,7 +77,7 @@ task package: [] do
     sh "gem build #{name}.gemspec"
     gem = find_gem(dir).first
     gem2rpm = File.join(package_dir, "gem2rpm.yml")
-    sh "gem2rpm --config #{gem2rpm} #{gem} > package/#{package_name}.spec"
+    sh "gem2rpm --config #{gem2rpm} --template opensuse #{gem} > package/#{package_name}.spec"
     FileUtils.mv(gem, package_dir)
   end
 end


### PR DESCRIPTION
Fixes the rake `package task` in openSUSE Leap systems (it tried to use `opensuse-leap`, which does not exist).