### PR TITLE
Adapt the ALP Host OS name

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ to have a closer look, then clone and configure the project as explained in the 
 
 * [multi-product](https://build.opensuse.org/package/binaries/YaST:Head:D-Installer/d-installer-live:default/images):
   it can be used to install different products, like *openSUSE Tumbleweed*, *Leap*, *Leap Micro* or
-  an experimental version of the *Adaptable Linux Platform Host OS*.
+  an experimental version of the *SUSE ALP ContainerHost OS*.
 * [ALP only](https://build.opensuse.org/package/binaries/YaST:Head:D-Installer/d-installer-live:ALP/images):
-  it only contains the definition for the experimental *Adaptable Linux Platform Host OS*, although
+  it only contains the definition for the experimental *SUSE ALP ContainerHost OS*, although
   the rest of the content is pretty much the same than the multi-product version.
 
 ### Manual Configuration

--- a/service/etc/d-installer.yaml
+++ b/service/etc/d-installer.yaml
@@ -1,9 +1,10 @@
 products:
   ALP:
-    name: SUSE Adaptable Linux Platform Host OS
+    name: SUSE ALP ContainerHost OS
     description: 'The Adaptable Linux Platform (ALP), the next generation of Linux,
       allow users to focus on their workloads while abstracting from the hardware
-      and the application layer.'
+      and the application layer. The preview of ContainerHost OS is one of the
+      first prototypes based on that platform.'
   Tumbleweed:
     name: openSUSE Tumbleweed
     description: 'The Tumbleweed distribution is a pure rolling release version


### PR DESCRIPTION
All recent documents mention ContainerHost instead of the previously used Host OS. So I guess we should start using that name... for now.