### PR TITLE
Fix ALP config

### DIFF
--- a/service/etc/d-installer.yaml
+++ b/service/etc/d-installer.yaml
@@ -186,7 +186,6 @@ ALP:
         fs_type: btrfs
         desired_size: 20 GiB
         min_size: 5 GiB
-        max_size: 20 GiB
         fs_types:
           - btrfs
         weight: 20


### PR DESCRIPTION
## Problem

The config for ALP sets max size to 20 GiB for root, but there is no reason for limiting it because root is the only volume to create.

## Solution

Remove max size limit from config file.
