### PR TITLE
[web] Drop support for disabled fieldsets

### DIFF
--- a/web/src/components/core/Fieldset.jsx
+++ b/web/src/components/core/Fieldset.jsx
@@ -38,27 +38,14 @@ import "./fieldset.scss";
  *     <EncryptionPassword />
  *   </Fieldset>
  *
- * @example <caption>Using a complex legend and isDisabled prop</caption>
- *   <Fieldset
- *     legend={
- *       <Switch label="Use Encryption" isChecked={isChecked} onChange={handleChange} isReversed />
- *     }
- *     isDisabled={!encryptionAllowed}
- *   >
- *     <EncryptionType />
- *     <EncryptionPassword />
- *   </Fieldset>
- *
  * @param {object} props
  * @param {React.ReactNode} props.legend - The lengend
- * @param {boolean} [props.isDisabled=false] - whether the descendant form controls, except any inside legend, are disable
  * @param {string} [props.className] - additionally CSS class names
  * @param {JSX.Element} [props.children] - the section content
  * @param {object} [props.otherProps] fieldset element attributes, see {@link https://html.spec.whatwg.org/#the-fieldset-element}
  */
 export default function Fieldset({
   legend,
-  isDisabled,
   className,
   children,
   ...otherProps
@@ -66,7 +53,6 @@ export default function Fieldset({
   return (
     <fieldset
       className={classNames("d-installer-fieldset", className)}
-      disabled={isDisabled}
       {...otherProps}
     >
       {legend && <legend>{legend}</legend>}

--- a/web/src/components/core/Fieldset.test.jsx
+++ b/web/src/components/core/Fieldset.test.jsx
@@ -51,25 +51,4 @@ describe("Fieldset", () => {
     const checkbox = within(fieldset).getByRole("checkbox");
     expect(checkbox).toBeInTheDocument();
   });
-
-  it("sets children (except legend) as disabled when isDisabled prop is given", () => {
-    installerRender(
-      <Fieldset legend={<ComplexLegend />} isDisabled>
-        <label htmlFor="username">Username</label>
-        <input type="text" id="username" />
-        <label htmlFor="superuser">Superuser</label>
-        <input type="checkbox" id="superuser" />
-      </Fieldset>
-    );
-
-    const fieldset = screen.getByRole("group", { name: /Using a checkbox/i });
-    const legendCheckbox = within(fieldset).getByRole("checkbox", { name: "Using a checkbox in the legend" });
-    const inputText = within(fieldset).getByRole("textbox", { name: "Username" });
-    const checkbox = within(fieldset).getByRole("checkbox", { name: "Superuser" });
-
-    expect(fieldset).toHaveAttribute("disabled");
-    expect(legendCheckbox).not.toBeDisabled();
-    expect(inputText).toBeDisabled();
-    expect(checkbox).toBeDisabled();
-  });
 });

--- a/web/src/components/core/PasswordAndConfirmationInput.jsx
+++ b/web/src/components/core/PasswordAndConfirmationInput.jsx
@@ -25,7 +25,7 @@ import {
   TextInput
 } from "@patternfly/react-core";
 
-const PasswordAndConfirmationInput = ({ value, onChange, onValidation }) => {
+const PasswordAndConfirmationInput = ({ value, onChange, onValidation, isDisabled }) => {
   const [confirmation, setConfirmation] = useState(value || "");
   const [error, setError] = useState("");
 
@@ -61,6 +61,7 @@ const PasswordAndConfirmationInput = ({ value, onChange, onValidation }) => {
           type="password"
           aria-label="User password"
           value={value}
+          isDisabled={isDisabled}
           onChange={onChangeValue}
           onBlur={() => validate(value, confirmation)}
         />
@@ -77,6 +78,7 @@ const PasswordAndConfirmationInput = ({ value, onChange, onValidation }) => {
           type="password"
           aria-label="User password confirmation"
           value={confirmation}
+          isDisabled={isDisabled}
           onChange={onChangeConfirmation}
           onBlur={() => validate(value, confirmation)}
           validated={error === "" ? "default" : "error"}

--- a/web/src/components/core/PasswordAndConfirmationInput.test.jsx
+++ b/web/src/components/core/PasswordAndConfirmationInput.test.jsx
@@ -38,8 +38,8 @@ describe("when the passwords do not match", () => {
 });
 
 it("uses the given password value for confirmation too", async () => {
-  const { user } = plainRender(
-    <PasswordAndConfirmationInput value={"12345"} />
+  plainRender(
+    <PasswordAndConfirmationInput value="12345" />
   );
 
   const passwordInput = screen.getByLabelText("Password");
@@ -47,4 +47,16 @@ it("uses the given password value for confirmation too", async () => {
 
   expect(passwordInput.value).toEqual("12345");
   expect(passwordInput.value).toEqual(confirmationInput.value);
+});
+
+it("disables both, password and confirmation, when isDisabled prop is given", async () => {
+  plainRender(
+    <PasswordAndConfirmationInput value="12345" isDisabled />
+  );
+
+  const passwordInput = screen.getByLabelText("Password");
+  const confirmationInput = screen.getByLabelText("Password confirmation");
+
+  expect(passwordInput).toBeDisabled();
+  expect(confirmationInput).toBeDisabled();
 });

--- a/web/src/components/storage/ProposalSettingsForm.jsx
+++ b/web/src/components/storage/ProposalSettingsForm.jsx
@@ -91,7 +91,6 @@ export default function ProposalSettingsForm({ id, proposal, onSubmit, onValidat
         onChange={onLvmChange}
       />
       <Fieldset
-        isDisabled={!state.encryption}
         legend={
           <Switch
             id="encryption"
@@ -105,6 +104,7 @@ export default function ProposalSettingsForm({ id, proposal, onSubmit, onValidat
         <PasswordAndConfirmationInput
           id="encryptionPassword"
           value={state.encryptionPassword}
+          isDisabled={!state.encryption}
           onChange={onPasswordChange}
           onValidation={onEncryptionValidate}
         />


### PR DESCRIPTION
## Problem

Firefox does not seem to follow the [fieldset's disabled attr specification]( https://html.spec.whatwg.org/#attr-fieldset-disabled), preventing the event propagation of elements contained within the first descendant of the legend and breaking the intended behavior of the `Encrypt devices` group in the `ProposalSettingsForm`.

* Related Mozilla issue report: **Disabled fieldset stops event bubbling from its legend -  https://bugzilla.mozilla.org/show_bug.cgi?id=1200127**

## Solution

To disable each fieldset child manually until finding a better solution. Fortunately, it's only a `PasswordAndConfirmationInput` component right now.

## Testing

- Unit tests updated
- Tested manually too
