### PR TITLE
[service] Copy logs just before unmouting filesystem

### DIFF
--- a/service/lib/dinstaller/manager.rb
+++ b/service/lib/dinstaller/manager.rb
@@ -86,7 +86,7 @@ module DInstaller
     def install_phase
       installation_phase.install
 
-      start_progress(9)
+      start_progress(8)
 
       progress.step("Reading software repositories") do
         software.probe
@@ -107,7 +107,6 @@ module DInstaller
         progress.step("Writing Network Configuration") { network.install }
         progress.step("Saving Language Settings") { language.finish }
         progress.step("Writing repositories information") { software.finish }
-        progress.step("Copying logs") { copy_logs }
         progress.step("Finishing storage configuration") { storage.finish }
       end
 
@@ -191,10 +190,5 @@ module DInstaller
 
     # @return [ServiceStatusRecorder]
     attr_reader :service_status_recorder
-
-    # Copy the logs to the target system
-    def copy_logs
-      Yast::WFM.CallFunction("copy_logs_finish", ["Write"])
-    end
   end
 end

--- a/service/lib/dinstaller/storage/manager.rb
+++ b/service/lib/dinstaller/storage/manager.rb
@@ -79,7 +79,7 @@ module DInstaller
 
       # Unmounts the target file system
       def finish
-        start_progress(4)
+        start_progress(5)
 
         on_target do
           progress.step("Writing Linux Security Modules configuration") { security.write }
@@ -89,6 +89,9 @@ module DInstaller
           end
           progress.step("Configuring file systems snapshots") do
             Yast::WFM.CallFunction("snapshots_finish", ["Write"])
+          end
+          progress.step("Copying logs") do
+            Yast::WFM.CallFunction("copy_logs_finish", ["Write"])
           end
           progress.step("Unmounting storage devices") do
             Yast::WFM.CallFunction("umount_finish", ["Write"])

--- a/service/test/dinstaller/storage/manager_test.rb
+++ b/service/test/dinstaller/storage/manager_test.rb
@@ -119,10 +119,11 @@ describe DInstaller::Storage::Manager do
   end
 
   describe "#finish" do
-    it "installs the bootloader, sets up the snapshots and umounts the file systems" do
+    it "installs the bootloader, sets up the snapshots, copy logs, and umounts the file systems" do
       expect(security).to receive(:write)
       expect(bootloader_finish).to receive(:write)
       expect(Yast::WFM).to receive(:CallFunction).with("snapshots_finish", ["Write"])
+      expect(Yast::WFM).to receive(:CallFunction).with("copy_logs_finish", ["Write"])
       expect(Yast::WFM).to receive(:CallFunction).with("umount_finish", ["Write"])
       storage.finish
     end


### PR DESCRIPTION
## Problem

Currently, the installation logs are copied too early to the target system. 

- https://trello.com/c/ihX3kxvR (internal link)

## Solution

To copy them just before unmounting the file systems.

## Testing

- Unit tests adapted
- Tested manually
   
  ```
  ➜ grep "Calling YaST client" ~/yast-installation-logs/YaST2/y2log
  2022-12-09 16:07:23 <1> localhost.localdomain(1601) [Interpreter] storage/manager.rb:71 Calling YaST client inst_prepdisk
  2022-12-09 16:07:26 <1> localhost.localdomain(1601) [Interpreter] storage/manager.rb:76 Calling YaST client inst_bootloader
  2022-12-09 16:14:46 <1> localhost.localdomain(1595) [Interpreter] dinstaller/network.rb:46 Calling YaST client save_network
  2022-12-09 16:15:06 <1> localhost.localdomain(1601) [Interpreter] storage/manager.rb:91 Calling YaST client snapshots_finish
  2022-12-09 16:15:07 <1> localhost.localdomain(1601) [Interpreter] storage/manager.rb:94 Calling YaST client copy_logs_finish
  2022-12-09 16:15:08 <1> localhost.localdomain(1601) [Interpreter] installation/copy_logs_finish.rb:94 Calling YaST client save_y2logs
  ```