### PR TITLE
Temporary hack to unlock the encryption using the TPM if possible 

### DIFF
--- a/service/etc/d-installer.yaml
+++ b/service/etc/d-installer.yaml
@@ -161,10 +161,13 @@ ALP:
     optional_patterns: null # no optional pattern shared
     mandatory_packages:
       - device-mapper # Apparently needed if devices at /dev/mapper are used at boot (eg. FDE)
+      - fde-tools # Needed for FDE with TPM, hardcoded here temporarily
+      - libtss2-tcti-device0 # Same than fde-tools
     optional_packages: null
     base_product: ALP
 
   security:
+    tpm_luks_open: true
     lsm: selinux
     available_lsms:
       # apparmor:

--- a/service/lib/dinstaller/storage/manager.rb
+++ b/service/lib/dinstaller/storage/manager.rb
@@ -20,6 +20,8 @@
 # find current contact information at www.suse.com.
 
 require "yast"
+require "yast2/execute"
+require "yast2/systemd/service"
 require "bootloader/proposal_client"
 require "bootloader/finish_client"
 require "y2storage/storage_manager"
@@ -79,12 +81,18 @@ module DInstaller
 
       # Unmounts the target file system
       def finish
-        start_progress(5)
+        steps = tpm_key? ? 6 : 5
+        start_progress(steps)
 
         on_target do
           progress.step("Writing Linux Security Modules configuration") { security.write }
           progress.step("Installing bootloader") do
             ::Bootloader::FinishClient.new.write
+          end
+          if tpm_key?
+            progress.step("Preparing the system to unlock the encryption using the TPM") do
+              prepare_tpm_key
+            end
           end
           progress.step("Configuring file systems snapshots") do
             Yast::WFM.CallFunction("snapshots_finish", ["Write"])
@@ -175,6 +183,62 @@ module DInstaller
       # @return [DInstaller::DBus::Clients::Software]
       def software
         @software ||= DBus::Clients::Software.new
+      end
+
+      def tpm_key?
+        tpm_product? && tpm_proposal? && tpm_system?
+      end
+
+      def tpm_proposal?
+        settings = proposal.calculated_settings
+        settings.encrypt? && !settings.lvm
+      end
+
+      def tpm_system?
+        Y2Storage::Arch.new.efiboot? && tpm_present?
+      end
+
+      def tpm_present?
+        return @tpm_present unless @tpm_present.nil?
+
+        @tpm_present =
+          begin
+            execute_fdectl("tpm-present")
+            logger.info "FDE: TPMv2 detected"
+            true
+          rescue Cheetah::ExecutionFailed
+            logger.info "FDE: TPMv2 not detected"
+            false
+          end
+      end
+
+      def tpm_product?
+        config.data.fetch("security", {}).fetch("tpm_luks_open", false)
+      end
+
+      def prepare_tpm_key
+        keyfile_path = File.join(Yast::Installation.destdir, "root", ".root.keyfile")
+        execute_fdectl(
+          "add-secondary-key", "--keyfile", keyfile_path,
+          stdin:    "#{proposal.calculated_settings.encryption_password}\n",
+          recorder: Yast::ReducedRecorder.new(skip: :stdin)
+        )
+
+        service = Yast2::Systemd::Service.find("fde-tpm-enroll.service")
+        logger.info "FDE: TPM enroll service: #{service}"
+        service&.enable
+      rescue Cheetah::ExecutionFailed
+        false
+      end
+
+      def execute_fdectl(*args)
+        # Some subcommands like "tpm-present" should not require a --device argument, but they
+        # currently do. Let's always us until the problem at fdectl is fully fixed.
+        Yast::Execute.locally!("fdectl", "--device", fdectl_device, *args)
+      end
+
+      def fdectl_device
+        Yast::Installation.destdir
       end
     end
   end

--- a/service/lib/dinstaller/storage/proposal.rb
+++ b/service/lib/dinstaller/storage/proposal.rb
@@ -123,7 +123,6 @@ module DInstaller
         settings ||= ProposalSettings.new
         settings.freeze
         proposal_settings = to_y2storage_settings(settings)
-        hack_olaf_password(proposal_settings)
 
         @proposal = new_proposal(proposal_settings)
         storage_manager.proposal = proposal
@@ -295,16 +294,6 @@ module DInstaller
         settings.other_delete_mode = :all
         # Setting #linux_delete_mode to :all is not enough to prevent VG reusing in all cases
         settings.lvm_vg_reuse = false
-      end
-
-      # Temporary method for testing FDE during early development
-      #
-      # @param settings [Y2Storage::ProposalSettings]
-      def hack_olaf_password(settings)
-        password = config.data.fetch("security", {})["olaf_luks2_password"]
-        return if password.nil? || password.empty?
-
-        settings.encryption_password = password
       end
     end
   end

--- a/service/lib/dinstaller/storage/proposal_settings.rb
+++ b/service/lib/dinstaller/storage/proposal_settings.rb
@@ -55,6 +55,13 @@ module DInstaller
         @candidate_devices = []
         @volumes = []
       end
+
+      # Whether the proposal must create encrypted devices
+      #
+      # @return [Boolean]
+      def encrypt?
+        !(encryption_password.nil? || encryption_password.empty?)
+      end
     end
   end
 end

--- a/service/package/rubygem-d-installer.changes
+++ b/service/package/rubygem-d-installer.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Wed Dec 14 13:25:22 UTC 2022 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Removed previous temporary setting "olaf_luks2_password" and all
+  the code supporting it.
+- Added new temporary setting "tpm_luks_open" to try to configure
+  TPM-based unlocking of the LUKS devices during the first system
+  boot (gh#yast/d-installer#363).
+
+-------------------------------------------------------------------
 Mon Dec  5 13:17:56 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Write snapshots configuration (gh#yast/d-installer#350).


### PR DESCRIPTION
## Current status (before merging this pull request)

D-Installer already provides full-disk encryption (FDE). In all cases, unlocking of the devices during boot will be done by entering the passphrase chosen by the user during installation.

![FDE](https://yast.opensuse.org/assets/images/blog/2022-12-05/lvm-enc-mini.png)

If the product being installed is based on ALP, then LUKS2 will be used. That makes it possible for the user to configure the system to unlock the encrypted devices during boot using a secret stored in the TPM (instead of the passphrase). That can be done manually after the system installation using the `fde-tools` developed by Olaf Kirch, but D-Installer offers no assistance on that regard.

Note there are certain conditions that need to be met in order to be able to use `fde-tools` to configure automatic LUKS unlocking based on the TPM:

- The system must be based on ALP, the needed tools are currently not available on other (open)SUSE distributions.
- The system must boot using UEFI.
- The system must contain a capable TPMv2 unit (TPM 1.X is not enough).
- The system must use LUKS2 encryption directly at partition level, that is, LVM cannot be used.

## Content of the patch

If we merge this PR, D-Installer will automatically take care of setting TPM unlocking of the devices.

For that, all the conditions mentioned above must be met. If not, the installer will do nothing about the TPM. On the one hand the system must use UEFI and contain a TPMv2 chip. On the other hand, the user must choose "Encrypt Devices" but must not choose "Use LVM". 

The process works like this:

- D-Installer prepares everything so TPM unlocking is automatically configured during the first boot of the installed system (since the final step of the configuration CANNOT be done during installation).
- When the installation finishes, the user must reboot and must ensure the system is booting directly from the disk containing the fresh new ALP system.
- The encryption passphrase will be asked to the user in that first boot.
- When the system finishes booting, unlocking via TPM would be transparently configured and the passphrase will not be needed in subsequent reboots.

## Caveats

- The first boot in the new system will still require the passphrase to be entered. This is quite unavoidable at the current state of the art.
- There is no trace in the UI about this change (intentionally, since this is a quick&dirty implementation). The behavior must be documented.
- It's crucial that the user boots directly from the new system device in the first boot. That must be documented.  If the system reboots again to the ISO and then the option "Boot from hard disk" is used, `fde-tools` will not be able to automatically configure the TPM unlocking during the first boot.

![boot](https://user-images.githubusercontent.com/3638289/207595910-38b7eadf-52ca-44f2-81d3-c1bed5d45972.png)

## Testing

- Tested manually on a virtual machine with a virtual TPMv2
- Still pending: testing in a real bare-metal machine with a real TPMv2 chip
- Still pending: regression tests to ensure this does not affect any other scenario (installing non-ALP distributions, installing without encryption and so on).
