### PR TITLE
Log D-Bus settings

### DIFF
--- a/service/lib/dinstaller/dbus/storage/proposal.rb
+++ b/service/lib/dinstaller/dbus/storage/proposal.rb
@@ -144,6 +144,8 @@ module DInstaller
         #
         # @param dbus_settings [DInstaller::Storage::ProposalSettings]
         def calculate(dbus_settings)
+          logger.info("Calculating storage proposal from D-Bus settings: #{dbus_settings}")
+
           backend.calculate(to_proposal_settings(dbus_settings))
         end
 


### PR DESCRIPTION
## Problem

Currently, the storage proposal is forced to be calculated with a single candidate device. But, according to reported YaST logs, it seems a proposal was calculated with two candidate devices. It is not clear why and how that happened. The initial proposal is forced to use the first available device, and the proposal calculated from the UI only allows to select a single device.

The only way to make the storage backend to use more than one candidate device is to call to #Calculate D-Bus method without indicating any candidate device. But the UI always indicate a candidate device.  

## Solution

I was not able to repoduce this issue. I have even used the very same devicegraph reported in logs. We need some logging method to trace the actions performed by the user. For now, I have logged the D-Bus settings sent from the UI when calculating a new proposal. 

https://trello.com/c/ahHvjN7I/3244-d-installer-enable-debugging-of-user-problems
