### PR TITLE
[service] Set the SELinux policy in the general d-installer.yaml file

### DIFF
--- a/service/etc/d-installer.yaml
+++ b/service/etc/d-installer.yaml
@@ -176,7 +176,7 @@ ALP:
       selinux:
         patterns:
           - alp_selinux
-        policy: permissive
+        policy: enforcing
       none:
         patterns: null
 


### PR DESCRIPTION
* Switch SELinux policy for ALP in the generic `d-installer.yaml` file.
* Related to #360.