### PR TITLE
Added `image/_constraints` file

### DIFF
--- a/image/README.md
+++ b/image/README.md
@@ -5,6 +5,7 @@
 This directory contains a set of files that are used to build the Live ISO image.
 
 * The `_service` file defines the OBS services to fetch the required files from the Git repository.
+* The `_constraints` file tells OBS to build the image on the hosts with enough resources.
 * `d-installer-live.kiwi` (and `config.sh`) are used by [kiwi](https://github.com/OSInside/kiwi/) to
   build the image.
 * The `extrastuff` directory contains a set of configuration files that are placed in the ISO but

--- a/image/_constraints
+++ b/image/_constraints
@@ -1,0 +1,7 @@
+<constraints>
+  <hardware>
+    <disk>
+      <size unit="G">20</size>
+    </disk>
+  </hardware>
+</constraints>


### PR DESCRIPTION
## Problem

Image build often failed with `No space left on device` error.

## Solution

Add a config file which tells OBS to use build hosts with enough resources.