### PR TITLE
Implement the ImportGpgKey callback

### DIFF
--- a/service/lib/dinstaller/software/manager.rb
+++ b/service/lib/dinstaller/software/manager.rb
@@ -85,6 +85,7 @@ module DInstaller
         Yast::Stage.Set("normal")
 
         start_progress(3)
+        Yast::PackageCallbacks.InitPackageCallbacks(logger)
         progress.step("Initialize target repositories") { initialize_target_repos }
         progress.step("Initialize sources") { add_base_repo }
         progress.step("Making the initial proposal") do
@@ -96,7 +97,6 @@ module DInstaller
       end
 
       def initialize_target_repos
-        Yast::PackageCallbacks.InitPackageCallbacks(logger)
         Yast::Pkg.TargetInitialize("/")
         import_gpg_keys
       end

--- a/service/package/rubygem-d-installer.changes
+++ b/service/package/rubygem-d-installer.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Dec 15 13:15:10 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Implement the ImportGpgKey libzypp callback
+  (gh#yast/d-installer#371)
+
+-------------------------------------------------------------------
 Wed Dec 14 22:38:24 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Implement AcceptUnsignedFile and MediaChange libzypp callbacks

--- a/service/test/dinstaller/software/callbacks/signature_test.rb
+++ b/service/test/dinstaller/software/callbacks/signature_test.rb
@@ -71,8 +71,21 @@ describe DInstaller::Software::Callbacks::Signature do
       end
     end
 
-    context "when the repo information is not available"
-    it "includes a generic message containing the filename" do
+    context "when the repo information is not available" do
+      before do
+        allow(Yast::Pkg).to receive(:SourceGeneralData).with(1)
+          .and_return(nil)
+      end
+
+      it "includes a generic message containing the filename" do
+        expect(subject).to receive(:ask) do |question|
+          expect(question.text).to include("repomd.xml")
+        end
+        expect(subject.accept_unsigned_file("repomd.xml", 1))
+      end
+    end
+  end
+
       expect(subject).to receive(:ask) do |question|
         expect(question.text).to include("repomd.xml")
       end

--- a/service/test/dinstaller/software/callbacks/signature_test.rb
+++ b/service/test/dinstaller/software/callbacks/signature_test.rb
@@ -86,10 +86,48 @@ describe DInstaller::Software::Callbacks::Signature do
     end
   end
 
-      expect(subject).to receive(:ask) do |question|
-        expect(question.text).to include("repomd.xml")
+  describe "import_gpg_key" do
+    let(:asked_question) do
+      instance_double(DInstaller::Question, text: "Better safe than sorry", answer: answer)
+    end
+
+    let(:answer) { :Trust }
+
+    let(:key) do
+      {
+        "id"          => "0123456789ABCDEF",
+        "fingerprint" => "2E2EA448C9DDD7A91BC28441AEE969E90F05DB9D",
+        "name"        => "YaST:Head:D-Installer"
+      }
+    end
+
+    before do
+      allow(subject).to receive(:ask).and_yield(asked_question)
+    end
+
+    context "when the user answers :Trust" do
+      let(:answer) { :Trust }
+
+      it "returns true" do
+        expect(subject.import_gpg_key(key, 1)).to eq(true)
       end
-      expect(subject.accept_unsigned_file("repomd.xml", 1))
+    end
+
+    context "when the user answers :Skip" do
+      let(:answer) { :Skip }
+
+      it "returns false" do
+        expect(subject.import_gpg_key(key, 1)).to eq(false)
+      end
+    end
+
+    it "includes a message" do
+      expect(subject).to receive(:ask) do |question|
+        expect(question.text).to include(key["id"])
+        expect(question.text).to include(key["name"])
+        expect(question.text).to include("2E2E A448 C9DD")
+      end
+      subject.import_gpg_key(key, 1)
     end
   end
 end


### PR DESCRIPTION
## Problem

Although users are not expected to use their own repositories at this time, it is not uncommon that we need to try some package that lives in a development repository in OBS. In those cases, you might need to import the GPG key.

## Solution

This PR implements support to ask the user about importing a GPG key. The presentation could be improved, but let's do that after December's prototype.

## Testing

- *Added a new unit test*
- *Tested manually*

## Screenshots

![libzypp-callbacks-import-pgp-key](https://user-images.githubusercontent.com/15836/207872602-8fd1fb0c-c892-4876-b378-7fd63eccc46e.png)


