### PR TITLE
Do not show WiFi configuration link if there are no WiFi devices

### DIFF
--- a/web/package/cockpit-d-installer.changes
+++ b/web/package/cockpit-d-installer.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Jan  2 11:46:37 UTC 2023 - Knut Anderssen <kanderssen@suse.com>
+
+- Do not show the link to configure wifi networks when there are no
+  wifi devices and also inform the user when no network connection
+  was detected. (gh#yast/d-installer#323).
+- Version 0.6.3
+
+-------------------------------------------------------------------
 Mon Jan  2 10:03:18 UTC 2023 - David Diaz <dgonzalez@suse.com>
 
 - Ensure custom fonts are including in the build

--- a/web/package/cockpit-d-installer.changes
+++ b/web/package/cockpit-d-installer.changes
@@ -3,7 +3,7 @@ Mon Jan  2 11:46:37 UTC 2023 - Knut Anderssen <kanderssen@suse.com>
 
 - Do not show the link to configure wifi networks when there are no
   wifi devices and also inform the user when no network connection
-  was detected. (gh#yast/d-installer#323).
+  was detected (gh#yast/d-installer#323).
 - Version 0.6.3
 
 -------------------------------------------------------------------

--- a/web/src/client/network.test.js
+++ b/web/src/client/network.test.js
@@ -39,7 +39,7 @@ const conn = {
 };
 
 const settings = {
-  wireless: true,
+  wifiScanSupported: true,
   hostname: "localhost.localdomain"
 };
 
@@ -78,7 +78,7 @@ describe("NetworkClient", () => {
     it("returns network general settings", () => {
       const client = new NetworkClient(adapter);
       expect(client.settings().hostname).toEqual("localhost.localdomain");
-      expect(client.settings().wireless).toEqual(true);
+      expect(client.settings().wifiScanSupported).toEqual(true);
     });
   });
 });

--- a/web/src/client/network/model.js
+++ b/web/src/client/network/model.js
@@ -109,7 +109,7 @@ const SecurityProtocols = Object.freeze({
 
 /**
 * @typedef {object} NetworkSettings
-* @property {boolean} wireless
+* @property {boolean} wifiScanSupported
 * @property {string} hostname
 
 /**

--- a/web/src/client/network/network_manager.js
+++ b/web/src/client/network/network_manager.js
@@ -180,6 +180,7 @@ class NetworkManagerAdapter {
     this.proxies = {
       accessPoints: {},
       activeConnections: {},
+      devices: {},
       ip4Configs: {},
       manager: null,
       settings: null,
@@ -503,16 +504,27 @@ class NetworkManagerAdapter {
   }
 
   /*
+  * Returns the list of WiFi devices available in the system
+  *
+  * @return {object[]} list of available WiFi devices
+  */
+  availableWifiDevices() {
+    return Object.values(this.proxies.devices).filter(d => d.DeviceType === NM_DEVICE_TYPE_WIFI);
+  }
+
+  /*
   * Returns whether the system is able to scan wifi networks based on rfkill and the presence of
   * some wifi device
   *
   * @return {boolean}
   */
-  wirelessScanSupported() {
-    const wEnabled = !!(this.proxies.manager?.WirelessEnabled && this.proxies.manager?.WirelessHardwareEnabled);
-    const wifiDevice = Object.values(this.proxies.devices).filter(d => d.DeviceType === NM_DEVICE_TYPE_WIFI);
+  wifiScanSupported() {
+    const { manager } = this.proxies;
 
-    return wEnabled && (wifiDevice.length > 0);
+    if (!manager) return false;
+    if (!(manager.WirelessEnabled && manager.WirelessHardwareEnabled)) return false;
+
+    return this.availableWifiDevices().length > 0;
   }
 
   /*
@@ -522,7 +534,7 @@ class NetworkManagerAdapter {
   */
   settings() {
     return {
-      wireless: this.wirelessScanSupported(),
+      wifiScanSupported: this.wifiScanSupported(),
       hostname: this.proxies.settings?.Hostname || ""
     };
   }

--- a/web/src/client/network/network_manager.js
+++ b/web/src/client/network/network_manager.js
@@ -502,6 +502,12 @@ class NetworkManagerAdapter {
     return { address: data.address.v, prefix: parseInt(data.prefix.v) };
   }
 
+  /*
+  * Returns whether the system is able to scan wifi networks based on rfkill and the presence of
+  * some wifi device
+  *
+  * @return {boolean}
+  */
   wirelessScanSupported() {
     const wEnabled = !!(this.proxies.manager?.WirelessEnabled && this.proxies.manager?.WirelessHardwareEnabled);
     const wifiDevice = Object.values(this.proxies.devices).filter(d => d.DeviceType === NM_DEVICE_TYPE_WIFI);
@@ -511,6 +517,7 @@ class NetworkManagerAdapter {
 
   /*
   * Returns NetworkManager general settings
+  *
   * @return {NetworkSettings}
   */
   settings() {

--- a/web/src/client/network/network_manager.test.js
+++ b/web/src/client/network/network_manager.test.js
@@ -35,6 +35,50 @@ const ACCESS_POINT_IFACE = "org.freedesktop.NetworkManager.AccessPoint";
 
 const dbusClient = new DBusClient("");
 
+const devices = {
+  "/org/freedesktop/NetworkManager/Devices/17": {
+    ActiveConnection: "/",
+    NmPluginMissing: false,
+    Real: true,
+    InterfaceFlags: 1,
+    DeviceType: 2,
+    Mtu: 1500,
+    Ports: [],
+    IpInterface: "",
+    DriverVersion: "6.0.12-1-default",
+    State: 30,
+    Ip6Config: "/org/freedesktop/NetworkManager/IP6Config/17",
+    Metered: 0,
+    Ip4Address: 0,
+    LldpNeighbors: [],
+    Interface: "wlp0s20u5",
+    FirmwareMissing: false,
+    Ip6Connectivity: 1,
+    Driver: "mt7601u",
+    PhysicalPortId: "",
+    Capabilities: 1,
+    Dhcp4Config: "/",
+    AvailableConnections: [
+      "/org/freedesktop/NetworkManager/Settings/3",
+      "/org/freedesktop/NetworkManager/Settings/4",
+      "/org/freedesktop/NetworkManager/Settings/5"
+    ],
+    HwAddress: "BA:FB:BE:AB:00:5B",
+    Managed: true,
+    StateReason: [
+      30,
+      42
+    ],
+    FirmwareVersion: "N/A",
+    Ip4Config: "/org/freedesktop/NetworkManager/IP4Config/17",
+    Udi: "/sys/devices/pci0000:00/0000:00:14.0/usb2/2-5/2-5:1.0/net/wlp0s20u5",
+    Autoconnect: true,
+    Ip4Connectivity: 1,
+    Path: "pci-0000:00:14.0-usb-0:5:1.0",
+    Dhcp6Config: "/"
+  }
+};
+
 const accessPoints = {
   "/org/freedesktop/NetworkManager/AccessPoint/11" : {
     Flags: 3,
@@ -134,8 +178,8 @@ const networkProxy = {
   wait: jest.fn(),
   ActivateConnection: ActivateConnectionFn,
   ActiveConnections: Object.keys(activeConnections),
-  WirelessEnabled: false,
-  WifiHardwareEnabled: true
+  WirelessEnabled: true,
+  WirelessHardwareEnabled: true
 };
 
 const AddConnectionFn = jest.fn();
@@ -359,11 +403,11 @@ describe("NetworkManagerAdapter", () => {
   });
 
   describe("#settings", () => {
-    it("returns the Network Manager settings hostname", async() => {
+    it("returns the Network Manager settings", async() => {
       const client = new NetworkManagerAdapter(dbusClient);
       await client.setUp();
       expect(client.settings().hostname).toEqual("testing-machine");
-      expect(client.settings().wireless).toEqual(false);
+      expect(client.settings().wireless).toEqual(true);
     });
   });
 });

--- a/web/src/client/network/network_manager.test.js
+++ b/web/src/client/network/network_manager.test.js
@@ -28,6 +28,7 @@ import cockpit from "../../lib/cockpit";
 const NM_IFACE = "org.freedesktop.NetworkManager";
 const NM_SETTINGS_IFACE = "org.freedesktop.NetworkManager.Settings";
 const IP4CONFIG_IFACE = "org.freedesktop.NetworkManager.IP4Config";
+const DEVICE_IFACE = "org.freedesktop.NetworkManager.Device";
 const NM_CONNECTION_IFACE = "org.freedesktop.NetworkManager.Settings.Connection";
 const ACTIVE_CONNECTION_IFACE = "org.freedesktop.NetworkManager.Connection.Active";
 const ACCESS_POINT_IFACE = "org.freedesktop.NetworkManager.AccessPoint";
@@ -191,6 +192,7 @@ describe("NetworkManagerAdapter", () => {
     dbusClient.proxies = jest.fn().mockImplementation(iface => {
       if (iface === ACCESS_POINT_IFACE) return accessPoints;
       if (iface === ACTIVE_CONNECTION_IFACE) return activeConnections;
+      if (iface === DEVICE_IFACE) return devices;
       if (iface === NM_CONNECTION_IFACE) return connections;
       if (iface === IP4CONFIG_IFACE) return addressesData;
       return {};

--- a/web/src/components/network/Network.jsx
+++ b/web/src/components/network/Network.jsx
@@ -79,15 +79,20 @@ export default function Network() {
 
   const activeWiredConnections = connections.filter(c => c.type === ConnectionTypes.ETHERNET);
   const activeWifiConnections = connections.filter(c => c.type === ConnectionTypes.WIFI);
+  const showNetwork = (activeWiredConnections.length > 0 || activeWifiConnections.length > 0);
 
   return (
     <Stack className="overview-network">
-      <StackItem>
-        <NetworkWiredStatus connections={activeWiredConnections} />
-      </StackItem>
-      <StackItem>
-        <NetworkWifiStatus connections={activeWifiConnections} />
-      </StackItem>
+      { showNetwork &&
+        <>
+          <StackItem>
+            <NetworkWiredStatus connections={activeWiredConnections} />
+          </StackItem>
+          <StackItem>
+            <NetworkWifiStatus connections={activeWifiConnections} />
+          </StackItem>
+        </> }
+      { !showNetwork && <StackItem>No network connection was detected</StackItem> }
       { wifiScanSupported &&
         <StackItem>
           <Button variant="link" onClick={() => setWifiSelectorOpen(true)}>Connect to a Wi-Fi network</Button>

--- a/web/src/components/network/Network.jsx
+++ b/web/src/components/network/Network.jsx
@@ -31,12 +31,12 @@ export default function Network() {
   const [initialized, setInitialized] = useState(false);
   const [connections, setConnections] = useState([]);
   const [wifiSelectorOpen, setWifiSelectorOpen] = useState(false);
-  const [wireless, setWireless] = useState(false);
+  const [wifiScanSupported, setWifiScanSupported] = useState(false);
 
   useEffect(() => {
     if (!initialized) return;
 
-    setWireless(client.network.settings().wireless);
+    setWifiScanSupported(client.network.settings().wifiScanSupported);
     setConnections(client.network.activeConnections());
   }, [client.network, initialized]);
 
@@ -65,7 +65,7 @@ export default function Network() {
         }
 
         case NetworkEventTypes.SETTINGS_UPDATED: {
-          setWireless(payload.wireless);
+          setWifiScanSupported(payload.wifiScanSupported);
         }
       }
     });
@@ -88,7 +88,7 @@ export default function Network() {
       <StackItem>
         <NetworkWifiStatus connections={activeWifiConnections} />
       </StackItem>
-      { wireless &&
+      { wifiScanSupported &&
         <StackItem>
           <Button variant="link" onClick={() => setWifiSelectorOpen(true)}>Connect to a Wi-Fi network</Button>
           <WifiSelector isOpen={wifiSelectorOpen} onClose={() => setWifiSelectorOpen(false)} />

--- a/web/src/components/network/Network.test.jsx
+++ b/web/src/components/network/Network.test.jsx
@@ -23,6 +23,7 @@ import React from "react";
 import { screen, within, waitFor } from "@testing-library/react";
 import { installerRender } from "@/test-utils";
 import Network from "@components/network/Network";
+import { ConnectionState, ConnectionTypes } from "@client/network";
 import { createClient } from "@client";
 
 jest.mock("@client");
@@ -32,22 +33,40 @@ jest.mock("@components/network/NetworkWifiStatus", () => () => "WiFi Connections
 const networkSettings = { wifiScanSupported: false, hostname: "test" };
 let settingsFn = jest.fn().mockReturnValue(networkSettings);
 
-beforeEach(() => {
-  createClient.mockImplementation(() => {
-    return {
-      network: {
-        setUp: () => Promise.resolve(true),
-        activeConnections: () => [],
-        connections: () => Promise.resolve([]),
-        accessPoints: () => [],
-        onNetworkEvent: jest.fn(),
-        settings: settingsFn
-      }
-    };
-  });
-});
+const wiredConnection = {
+  id: "wired-1",
+  name: "Wired 1",
+  type: ConnectionTypes.ETHERNET,
+  addresses: [{ address: "192.168.122.20", prefix: 24 }]
+};
+const wiFiConnection = {
+  id: "wifi-1",
+  name: "WiFi 1",
+  type: ConnectionTypes.WIFI,
+  addresses: [{ address: "192.168.69.200", prefix: 24 }]
+};
+
+const defaultConns = [wiredConnection, wiFiConnection];
+
+let activeConnectionsFn = [];
 
 describe("Network", () => {
+  beforeEach(() => {
+    activeConnectionsFn = jest.fn().mockReturnValue(Object.values(defaultConns));
+    createClient.mockImplementation(() => {
+      return {
+        network: {
+          setUp: () => Promise.resolve(true),
+          activeConnections: () => activeConnectionsFn,
+          connections: () => Promise.resolve([]),
+          accessPoints: () => [],
+          onNetworkEvent: jest.fn(),
+          settings: settingsFn
+        }
+      };
+    });
+  });
+
   describe("when it has not been initialized", () => {
     it("renders nothing", async () => {
       const { container } = installerRender(<Network />, { usingLayout: false });
@@ -56,11 +75,25 @@ describe("Network", () => {
   });
 
   describe("when it has been initialized", () => {
-    it("renders a summary for wired and wifi connections", async () => {
-      installerRender(<Network />);
+    describe("and no connection was detected", () => {
+      beforeEach(() => {
+        activeConnectionsFn = jest.fn().mockReturnValue([]);
+      });
 
-      await screen.findByText("Wired Connections");
-      await screen.findByText("WiFi Connections");
+      it("renders a summary alerting the user about it", async () => {
+        installerRender(<Network />);
+
+        await screen.findByText("No network connection was detected");
+      });
+    });
+
+    describe("and there is some connection detected", () => {
+      it("renders a summary for wired and wifi connections", async () => {
+        installerRender(<Network />);
+
+        await screen.findByText("Wired Connections");
+        await screen.findByText("WiFi Connections");
+      });
     });
 
     describe("when Wireless is currently not enabled", () => {

--- a/web/src/components/network/Network.test.jsx
+++ b/web/src/components/network/Network.test.jsx
@@ -29,7 +29,7 @@ jest.mock("@client");
 jest.mock("@components/network/NetworkWiredStatus", () => () => "Wired Connections");
 jest.mock("@components/network/NetworkWifiStatus", () => () => "WiFi Connections");
 
-const networkSettings = { wireless: false, hostname: "test" };
+const networkSettings = { wifiScanSupported: false, hostname: "test" };
 let settingsFn = jest.fn().mockReturnValue(networkSettings);
 
 beforeEach(() => {
@@ -72,7 +72,7 @@ describe("Network", () => {
 
     describe("when Wireless is currently enabled", () => {
       beforeEach(() => {
-        settingsFn = jest.fn().mockReturnValue({ ...networkSettings, wireless: true });
+        settingsFn = jest.fn().mockReturnValue({ ...networkSettings, wifiScanSupported: true });
       });
 
       it("shows a link to open the WiFi selector", async () => {

--- a/web/src/components/network/TargetIpsPopup.test.jsx
+++ b/web/src/components/network/TargetIpsPopup.test.jsx
@@ -34,7 +34,7 @@ const addresses = [
   { address: "5.6.7.8", prefix: 16 },
 ];
 const addressFn = jest.fn().mockReturnValue(addresses);
-const networkSettings = { wireless: false, hostname: "example.net" };
+const networkSettings = { wifiScanSupported: false, hostname: "example.net" };
 const settingsFn = jest.fn().mockReturnValue(networkSettings);
 
 describe("TargetIpsPopup", () => {
@@ -78,7 +78,7 @@ describe("TargetIpsPopup", () => {
     await screen.findByRole("button", { name: /1.2.3.4\/24 \(example.net\)/i });
 
     addressFn.mockReturnValue([{ address: "5.6.7.8", prefix: 24 }]);
-    settingsFn.mockReturnValue({ wireless: false, hostname: "localhost.localdomain" });
+    settingsFn.mockReturnValue({ wifiScanSupported: false, hostname: "localhost.localdomain" });
     act(() => {
       callbacks.forEach(cb => cb());
     });


### PR DESCRIPTION
## Problem

In #316 we added logic to hide the link for connecting to a WiFi network but only in case the WiFi was enable based on rfkill but if there are no WiFi devices at all then it does not makes sense to show the link.

## Solution

Do not show the link for connecting to a WiFi network if there are no WiFi devices.

Update: and also do not show an empty network section when there is no connection detected and no WiFi device available.

## Testing

- *Added a new unit test*
- *Tested manually*

## Screenshots

| With a network connection | Whitout network connection |
| --- | --- |
| ![Screenshot from 2023-01-02 11-29-04](https://user-images.githubusercontent.com/7056681/210225473-bfaa7277-991a-4b6f-9376-03a8c6d8f913.png) | ![Screenshot from 2023-01-02 11-26-53](https://user-images.githubusercontent.com/7056681/210225333-42842fa9-e4f5-4d40-9b31-d0d18d665632.png) |
| ![Screenshot from 2023-01-02 11-33-33](https://user-images.githubusercontent.com/7056681/210226384-a98afe2a-4594-485d-a69f-40b533edefcb.png) | ![Screenshot from 2023-01-02 11-36-22](https://user-images.githubusercontent.com/7056681/210226383-0d7ddbfe-0527-4f7f-b9dc-36b020f74d9d.png) |

