### PR TITLE
Require NPM 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: ["18.x"]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/setup.sh
+++ b/setup.sh
@@ -4,7 +4,7 @@
 # package. This script is supposed to run within a repository clone.
 
 sudo zypper --non-interactive install gcc gcc-c++ make openssl-devel ruby-devel \
-  npm git augeas-devel cockpit jemalloc-devel || exit 1
+  'npm>=18' git augeas-devel cockpit jemalloc-devel || exit 1
 
 sudo systemctl start cockpit
 

--- a/web/Makefile
+++ b/web/Makefile
@@ -190,7 +190,9 @@ $(LIB_TEST):
 	    git reset -- ../pkg/lib'
 	mv ../pkg/lib src/ && rmdir ../pkg
 
-$(NODE_MODULES_TEST):
+# run 'npm install' if node_modules is missing
+# or whenever package.json changes afterwards
+$(NODE_MODULES_TEST): package.json
 	# unset NODE_ENV, skips devDependencies otherwise
 	env -u NODE_ENV npm install
 	env -u NODE_ENV npm prune

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -75,6 +75,9 @@
         "typescript": "^4.8.4",
         "webpack": "^5.54.0",
         "webpack-cli": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,11 @@
 {
   "name": "d-installer",
-  "description": "Scaffolding for a cockpit module",
-  "repository": "git@github.com:cockpit/starter-kit.git",
+  "description": "A Service-based Linux Installer",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/yast/d-installer.git",
+    "directory": "web"
+  },
   "author": "",
   "license": "LGPL-2.1",
   "scripts": {

--- a/web/package.json
+++ b/web/package.json
@@ -13,6 +13,7 @@
     "jsdoc": "npx typedoc src src/client && echo Tip: && echo xdg-open jsdoc.out/index.html",
     "test": "jest"
   },
+  "engines": { "node": ">=18" },
   "devDependencies": {
     "@babel/core": "^7.5.4",
     "@babel/eslint-parser": "^7.13.14",


### PR DESCRIPTION



## Problem

We spent some hours debugging a problem where the web frontend was not updated because the machine had NPM 17 which is no longer enough

## Solution

Tell zypper, and npm, to install v 18 at least

## Testing

- Tested manually: ran `./setup.sh` with 
```diff
-  "engines": { "node": ">=18" },
+  "engines": { "node": ">=1899" },
 ```

```
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: undefined,
npm WARN EBADENGINE   required: { node: '>=1899' },
npm WARN EBADENGINE   current: { node: 'v19.1.0', npm: '8.19.3' }
npm WARN EBADENGINE }
```