### PR TITLE
[web] Fix "font: download failed" complain

### DIFF
--- a/web/package/cockpit-d-installer.changes
+++ b/web/package/cockpit-d-installer.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jan  2 10:03:18 UTC 2023 - David Diaz <dgonzalez@suse.com>
+
+- Ensure custom fonts are including in the build
+  (gh#yast/d-installer#385).
+
+-------------------------------------------------------------------
 Fri Dec 30 11:56:46 UTC 2022 - David Diaz <dgonzalez@suse.com>
 
 - Switch to Material Symbols icon set and refactor how icons

--- a/web/src/index.js
+++ b/web/src/index.js
@@ -37,6 +37,9 @@ import { Overview } from "@components/overview";
 import { ProductSelectionPage } from "@components/software";
 import { ProposalPage as StoragePage } from "@components/storage";
 
+// D-Installer fonts
+import "@assets/fonts.scss";
+
 /*
  * PF4 overrides need to come after the JSX components imports because
  * these are importing CSS stylesheets that we are overriding


### PR DESCRIPTION
## Problem

Custom fonts are not being included in the final bundle, as expected. Most probably, current webpack configuration is not able to understand the Sass _@use_ at rule as an _import_ and thus is not applying the custom configuration for the fonts.scss file

```js
 // Load D-Intaller fonts
 {
    test: /fonts.scss/,
    use: [
      { loader: 'css-loader' },
      { loader: 'sass-loader' }
    ]
  },
  {
    test: /\.(eot|ttf|woff|woff2)$/,
    type: 'asset/resource',
    generator: {
      filename: 'fonts/[name][ext]',
    }
  },
```

<table>
<tr>
<th>Browser complain</th>
<th>Content of dist/ directory</th>
</tr>
<tr>
<td>

![Screenshot from 2023-01-02 09-46-15](https://user-images.githubusercontent.com/1691872/210216594-b831c91c-599d-46b8-be15-57263d850a6e.png)

</td>

<td>

```

➜ ls -alh dist                           
total 8,9M
drwxr-xr-x  2 4,0K ene  2 09:44 .
drwxr-xr-x 11 4,0K ene  2 09:44 ..
-rw-r--r--  1 618K ene  2 09:44 index.css
-rw-r--r--  1 930K ene  2 09:44 index.css.map
-rw-r--r--  1  405 ene  2 09:44 index.html
-rw-r--r--  1 3,9M ene  2 09:44 index.js
-rw-r--r--  1 3,5M ene  2 09:44 index.js.map
-rw-r--r--  1  167 ene  2 09:44 manifest.json
-rw-r--r--  1  183 ene  2 09:44 po.de.js

```
</td>
</tr>
</table>

## Solution

Explicitly import the fonts.scss file for ensuring that build contains the desired fonts to be downloaded when needed.

> ➜ ls -alh dist
> total 8,9M
> drwxr-xr-x  3 4,0K ene  2 09:47 .
> drwxr-xr-x 11 4,0K ene  2 09:47 ..
> **drwxr-xr-x  2 4,0K ene  2 09:47 fonts**
> -rw-r--r--  1 618K ene  2 09:47 index.css
> -rw-r--r--  1 930K ene  2 09:47 index.css.map
> -rw-r--r--  1  405 ene  2 09:47 index.html
> -rw-r--r--  1 3,9M ene  2 09:47 index.js
> -rw-r--r--  1 3,5M ene  2 09:47 index.js.map
> -rw-r--r--  1  167 ene  2 09:47 manifest.json
> -rw-r--r--  1  183 ene  2 09:47 po.de.js
>
> ➜ ls -alh dist/fonts
> total 896K
> drwxr-xr-x 2 4,0K ene  2 09:47 .
> drwxr-xr-x 3 4,0K ene  2 09:47 ..
> -rw-r--r-- 1  44K ene  2 09:47 LatoLatin-BoldItalic.woff2
> -rw-r--r-- 1  44K ene  2 09:47 LatoLatin-Bold.woff2
> -rw-r--r-- 1  45K ene  2 09:47 LatoLatin-Italic.woff2
> -rw-r--r-- 1  43K ene  2 09:47 LatoLatin-Regular.woff2
> -rw-r--r-- 1  75K ene  2 09:47 poppins-v19-latin-ext_latin_devanagari-300italic.woff
> -rw-r--r-- 1  56K ene  2 09:47 poppins-v19-latin-ext_latin_devanagari-300italic.woff2
> -rw-r--r-- 1  65K ene  2 09:47 poppins-v19-latin-ext_latin_devanagari-300.woff
> -rw-r--r-- 1  49K ene  2 09:47 poppins-v19-latin-ext_latin_devanagari-300.woff2
> -rw-r--r-- 1  74K ene  2 09:47 poppins-v19-latin-ext_latin_devanagari-500italic.woff
> -rw-r--r-- 1  55K ene  2 09:47 poppins-v19-latin-ext_latin_devanagari-500italic.woff2
> -rw-r--r-- 1  65K ene  2 09:47 poppins-v19-latin-ext_latin_devanagari-500.woff
> -rw-r--r-- 1  48K ene  2 09:47 poppins-v19-latin-ext_latin_devanagari-500.woff2
> -rw-r--r-- 1  66K ene  2 09:47 poppins-v19-latin-ext_latin_devanagari-regular.woff
> -rw-r--r-- 1  49K ene  2 09:47 poppins-v19-latin-ext_latin_devanagari-regular.woff2
> -rw-r--r-- 1  47K ene  2 09:47 roboto-mono-v13-vietnamese_latin-ext_latin_greek_cyrillic-ext_cyrillic-regular.woff
> -rw-r--r-- 1  37K ene  2 09:47 roboto-mono-v13-vietnamese_latin-ext_latin_greek_cyrillic-ext_cyrillic-regular.woff2

## Testing

Manually tested.