### PR TITLE
yupdate support

### DIFF
--- a/.yupdate.post
+++ b/.yupdate.post
@@ -1,0 +1,48 @@
+#! /bin/bash
+
+#
+# This is a hook script for the yupdate tool, it is automatically executed
+# after running "rake install" command.
+#
+# The script does several tasks:
+# - it restarts the DBus service when any file in the d-installer ruby gem
+#   was updated
+# - saves the installed NPM packages to a cache so they can be reused in the
+#   next yupdate run
+#
+
+# restart the D-Installer service if needed
+function restart_service() {
+  # get the service start time
+  SERVICE_START=$(systemctl show d-installer | grep "^ExecMainStartTimestamp=" | sed -e "s/^ExecMainStartTimestamp=\(.*\)\$/\\1/")
+
+  if [ -n "$SERVICE_START" ]; then
+    SERVICE_START_UNIX_TIME=$(date -d "$SERVICE_START" +"%s")
+    # find the date of the latest file in the d-installer gem
+    # the regexp is used to ignore the d-installer-cli files
+    NEWEST_FILE_TIME=$(find /usr/lib*/ruby/gems/*/gems -type f -regex '\(.*/\)?d-installer-[0-9].*\(/.*\)?' -exec stat --format '%Y' "{}" \; | sort -nr | head -n 1)
+
+    # when a file is newer than the start time then restart the service
+    if [ -n "$NEWEST_FILE_TIME" ] && [ "$SERVICE_START_UNIX_TIME" -lt "$NEWEST_FILE_TIME" ]; then
+      echo "Restarting D-Installer service..."
+      systemctl restart d-installer
+    fi
+  fi
+}
+
+# copy installed NPM packages to cache
+function save_npm_cache() {
+  echo "Saving NPM cache..."
+  CACHEDIR="$HOME/.cache/d-installer-devel/"
+  mkdir -p "$CACHEDIR"
+
+  MYDIR=$(realpath "$(dirname "$0")")
+  cp -aR "$MYDIR/web/node_modules" "$CACHEDIR"
+}
+
+restart_service
+
+# cache the installed NPM packages
+if [ "$NPM_CACHE" = "1" ] ; then
+  save_npm_cache
+fi

--- a/.yupdate.pre
+++ b/.yupdate.pre
@@ -1,0 +1,79 @@
+#! /bin/bash
+
+#
+# This is a hook script for the yupdate tool, it is automatically executed
+# before running "rake install" command.
+#
+# This script prepares the live system for compiling and installing new
+# D-Installer code.
+#
+# The script does several tasks:
+# - it checks if there is enough RAM, if there is not enough RAM the system
+#   might freeze completely
+# - installs some packages required for compilations (mainly make, npm and nodejs),
+# - if there is no package repository configured it adds the main OSS repository
+#   automatically
+# - optionally caches the installed NPM packages, this is useful if you want to
+#   run the yupdate script several times
+#
+
+# the needed packages for compiling the d-installer cockpit module
+PACKAGES=(appstream-glib-devel make npm)
+
+# add repositories
+function add_repos() {
+  # only if no repository is defined
+  if zypper lr | grep -q "No repositories defined"; then
+    SYSTEM=$(. /etc/os-release && echo "$ID")
+
+    # check the installed system, add the proper repo for TW or Leap
+    if [ "$SYSTEM" = "opensuse-tumbleweed" ]; then
+      URL="http://download.opensuse.org/tumbleweed/repo/oss"
+    elif [ "$SYSTEM" = "opensuse-leap" ]; then
+      URL="http://download.opensuse.org/distribution/leap/\${releasever}/repo/oss/"
+    else
+      echo "Unsupported system: $SYSTEM"
+      exit 1
+    fi
+
+    zypper addrepo "$URL" main-repo
+    zypper --gpg-auto-import-keys refresh
+  fi
+}
+
+function install_packages() {
+  add_repos
+  zypper --non-interactive install --no-recommends "${PACKAGES[@]}"
+}
+
+# restore the NPM cache if it is present
+function load_npm_cache() {
+  CACHEDIR="$HOME/.cache/d-installer-devel/"
+
+  if [ -d "$CACHEDIR/node_modules" ]; then
+    echo "Restoring NPM cache..."
+    MYDIR=$(realpath "$(dirname "$0")")
+    cp -aR "$CACHEDIR/node_modules" "$MYDIR/web/"
+  fi
+}
+
+# memory check, with not enough memory the system freezes
+RAM=$(grep "MemTotal:" /proc/meminfo | sed -e "s/MemTotal:[[:space:]]*\([0-9]\+\) kB/\\1/")
+# less than ~4GB RAM
+if [ "$RAM" -lt 4000000 ] && [ "$SKIP_MEM_CHECK" != "1" ]; then
+  echo >&2
+  echo "ERROR: The system has too low memory ($RAM kB) for applying the update." >&2
+  echo "The system could completely freeze and become unresposible." >&2
+  echo "You can skip this check with SKIP_MEM_CHECK=1 environment variable." >&2
+  echo >&2
+
+  exit 1
+fi
+
+# check if all needed packages are installed, if not then install them
+rpm -q --whatprovides "${PACKAGES[@]}" > /dev/null || install_packages
+
+# optionally restore the cached NPM packages
+if [ "$NPM_CACHE" = "1" ] ; then
+  load_npm_cache
+fi

--- a/.yupdate.pre
+++ b/.yupdate.pre
@@ -63,7 +63,7 @@ RAM=$(grep "MemTotal:" /proc/meminfo | sed -e "s/MemTotal:[[:space:]]*\([0-9]\+\
 if [ "$RAM" -lt 4000000 ] && [ "$SKIP_MEM_CHECK" != "1" ]; then
   echo >&2
   echo "ERROR: The system has too low memory ($RAM kB) for applying the update." >&2
-  echo "The system could completely freeze and become unresposible." >&2
+  echo "The system could completely freeze and become unresponsive." >&2
   echo "You can skip this check with SKIP_MEM_CHECK=1 environment variable." >&2
   echo >&2
 

--- a/service/share/systemd.service
+++ b/service/share/systemd.service
@@ -7,6 +7,7 @@ After=network-online.target
 Type=dbus
 BusName=org.opensuse.DInstaller
 ExecStart=/usr/bin/d-installer manager
+ExecStop=/usr/bin/d-installer -k
 User=root
 TimeoutStopSec=5
 


### PR DESCRIPTION
## Problem

It is quite difficult to update the D-Installer on the live medium, there should be an easy way for testing the fixes or new features.

## Solution

- Allow patching the live medium using the `yupdate` script.
- Related PR: https://github.com/yast/yast-installation/pull/1072
- Created a new documentation
- Also fixed a problem with restarting the DBus services.

## Testing

- Tested manually, I could apply the changes from the https://github.com/yast/d-installer/pull/381 from my local checkout and see the result in the browser.

