### PR TITLE
Check for installed packages in the target system

### DIFF
--- a/service/lib/dinstaller/software/manager.rb
+++ b/service/lib/dinstaller/software/manager.rb
@@ -22,6 +22,7 @@
 require "yast"
 require "fileutils"
 require "dinstaller/config"
+require "dinstaller/helpers"
 require "dinstaller/with_progress"
 require "y2packager/product"
 require "yast2/arch_filter"
@@ -37,6 +38,7 @@ module DInstaller
   module Software
     # This class is responsible for software handling
     class Manager
+      include Helpers
       include WithProgress
 
       GPG_KEYS_GLOB = "/usr/lib/rpm/gnupg/keys/gpg-*"
@@ -161,7 +163,7 @@ module DInstaller
       # @param name [String] Package name
       # @return [Boolean] true if it is installed; false otherwise
       def package_installed?(name)
-        Yast::Package.Installed(name, target: :system)
+        on_target { Yast::Package.Installed(name, target: :system) }
       end
 
     private

--- a/service/package/rubygem-d-installer.changes
+++ b/service/package/rubygem-d-installer.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jan 16 17:02:21 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Check for installed packages in the target system, instead of the
+  installation medium (gh#yast/d-installer#393).
+
+-------------------------------------------------------------------
 Mon Jan 16 14:57:59 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Simplify the network configuration to just copying the


### PR DESCRIPTION
Properly asks for installed packages *in the target system* (not in the instsys). We detected this problem while running D-Installer on top of Iguana.