### PR TITLE
Simplify network configuration

### DIFF
--- a/service/lib/dinstaller/manager.rb
+++ b/service/lib/dinstaller/manager.rb
@@ -73,8 +73,6 @@ module DInstaller
       installation_phase.config
 
       storage.probe
-      network.probe
-
       logger.info("Config phase done")
     rescue StandardError => e
       logger.error "Startup error: #{e.inspect}. Backtrace: #{e.backtrace}"

--- a/service/lib/dinstaller/network.rb
+++ b/service/lib/dinstaller/network.rb
@@ -24,7 +24,6 @@ require "yast"
 require "yast2/systemd/service"
 require "y2network/proposal_settings"
 
-Yast.import "Lan"
 Yast.import "Installation"
 
 module DInstaller
@@ -32,16 +31,6 @@ module DInstaller
   class Network
     def initialize(logger)
       @logger = logger
-    end
-
-    # Probes the network configuration
-    def probe
-      logger.info "Probing network"
-      Yast::Lan.read_config
-      settings = Y2Network::ProposalSettings.instance
-      settings.apply_defaults
-      # force NetworkManager as we are not supporting other backends
-      settings.enable_network_manager!
     end
 
     # Writes the network configuration to the installed system

--- a/service/package/rubygem-d-installer.changes
+++ b/service/package/rubygem-d-installer.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Jan 16 14:57:59 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Simplify the network configuration to just copying the
+  NetworkManager connections and enabling the service
+  (gh#yast/d-installer#397).
+
+-------------------------------------------------------------------
 Tue Jan 10 10:29:00 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Use a dedicated D-Bus server (gh#yast/d-installer#384).

--- a/service/test/dinstaller/manager_test.rb
+++ b/service/test/dinstaller/manager_test.rb
@@ -49,7 +49,7 @@ describe DInstaller::Manager do
     )
   end
   let(:language) { instance_double(DInstaller::DBus::Clients::Language, finish: nil) }
-  let(:network) { instance_double(DInstaller::Network, probe: nil, install: nil) }
+  let(:network) { instance_double(DInstaller::Network, install: nil) }
   let(:storage) do
     instance_double(
       DInstaller::DBus::Clients::Storage, probe: nil, install: nil, finish: nil,
@@ -105,7 +105,6 @@ describe DInstaller::Manager do
     end
 
     it "calls #probe method of each module" do
-      expect(network).to receive(:probe)
       expect(storage).to receive(:probe)
       subject.config_phase
     end

--- a/service/test/dinstaller/network_test.rb
+++ b/service/test/dinstaller/network_test.rb
@@ -28,32 +28,6 @@ describe DInstaller::Network do
   subject(:network) { described_class.new(logger) }
 
   let(:logger) { Logger.new($stdout, level: :warn) }
-  let(:proposal) do
-    instance_double(Y2Network::ProposalSettings,
-      apply_defaults: nil, refresh_packages: nil, enable_network_manager!: true)
-  end
-
-  describe "#probe" do
-    before do
-      allow(Yast::Lan).to receive(:read_config)
-      allow(Y2Network::ProposalSettings).to receive(:instance).and_return(proposal)
-    end
-
-    it "reads the network configuration" do
-      expect(Yast::Lan).to receive(:read_config)
-      network.probe
-    end
-
-    it "apply the defaults" do
-      expect(proposal).to receive(:apply_defaults)
-      network.probe
-    end
-
-    it "forces a selection of NetworkManager as the backend to be used" do
-      expect(proposal).to receive(:enable_network_manager!)
-      network.probe
-    end
-  end
 
   describe "#install" do
     let(:rootdir) { Dir.mktmpdir }


### PR DESCRIPTION
## Problem

The `save_network` client does not work correctly when D-Installer runs on Iguana. 

## Solution

Given that we are relying on *NetworkManager* and supporting just a minimal set of use cases, we decided to simplify the network configuration as much as possible. We will pull the needed bits from `save_network` as they are needed.

## Testing

- Added a new unit test
- Tested manually