### PR TITLE
Document libvirt + PXE + Iguana setup

### DIFF
--- a/doc/pxe.md
+++ b/doc/pxe.md
@@ -45,7 +45,7 @@ timeout		50
 Do not worry about the kernel, the initrd or the `d-installer.yaml` file, we will jump into it
 later.
 
-### Configure libvirt to server TFTP files
+### Configure libvirt to serve TFTP files
 
 To instruct libvirt to serve the TFTP files, you must add the `tftp` and `bootp` elements to the
 network configuration. Use the `virsh net-edit default` command to edit the configuration and adapt

--- a/doc/pxe.md
+++ b/doc/pxe.md
@@ -1,0 +1,111 @@
+# Using PXE and Iguana
+
+This document explains how to run D-Installer on PXE with the help of Iguana. The described setup
+uses libvirt, but you can adapt the overall approach to other scenarios (like running your own
+TFTP server).
+
+The process can be summarized in these steps:
+
+1. Set up the TFTP tree, defining a boot option for D-Installer + Iguana.
+2. Configure libvirt network to serve the tree.
+3. Prepare the initial ramdisk image (initrd), based on Iguana.
+4. Boot from PXE.
+
+## Set up the TFTP tree
+
+The TFTP files are available in the `tftpboot-installation-openSUSE-Tumbleweed-ARCH` packages. They
+are placed in `/usr/share/tftpboot-installation`, but you should copy them (or at least the `net`
+subdirectory) to customize them. In the example below we are just copying all of them.
+
+    zypper in tftpboot-installation-openSUSE-Tumbleweed-x86_64
+    mkdir /srv/tftpboot
+    cp -a /usr/share/tftpboot-installation/openSUSE-Tumbleweed-x86_64 /srv/tftpboot
+
+To define a boot option to run D-Installer, edit the `net/pxelinux.cfg/default` to include:
+
+```
+label iguana
+  ipappend 2
+  kernel boot/x86_64/loader/iguana-new/vmlinuz-iguana
+  append initrd=boot/x86_64/loader/initrd-iguana rd.iguana.control_url=tftp://192.168.122.1/net/d-installer.yaml rd.iguana.debug=1 rd.neednet=1
+```
+
+Do not worry about the kernel, the initrd or the `d-installer.yaml` file, we will jump into it
+later.
+
+## Configure libvirt to server TFTP files
+
+To instruct libvirt to serve the TFTP files, you must add the `tftp` and `bootp` elements to the
+network configuration. Use the `virsh net-edit default` command to edit the configuration and adapt
+it accordingly. Here is an example:
+
+```xml
+<network connections='1'>
+  <name>default</name>
+  <uuid>639e02a7-fcbd-4cf3-a563-6db083aef051</uuid>
+  <forward mode='nat'>
+    <nat>
+      <port start='1024' end='65535'/>
+    </nat>
+  </forward>
+  <bridge name='virbr0' stp='on' delay='0'/>
+  <mac address='52:54:00:fb:7c:8e'/>
+  <ip address='192.168.122.1' netmask='255.255.255.0'>
+    <tftp root='/srv/tftpboot/openSUSE-Tumbleweed-x86_64'/>
+    <dhcp>
+      <range start='192.168.122.2' end='192.168.122.254'/>
+      <bootp file='net/pxelinux.0'/>
+    </dhcp>
+  </ip>
+</network>
+```
+
+## initrd preparation
+
+**Please, build the initrd on a virtual machine to avoid messing up your system.**
+
+Iguana provides a universal initrd in which actual functionality is implemented in containers. Which
+containers to use and how to set them up is defined in a *workflow definition*. The [Iguana
+repository](https://github.com/openSUSE/iguana) includes a [definition for
+D-Installer](https://github.com/openSUSE/iguana/blob/main/iguana-workflow/examples/d-installer.yaml).
+
+In the future, you should be able to get the kernel and the initrd files from the [Iguana
+package](https://build.opensuse.org/package/show/home:oholecek:iguana/iguana). However, for
+D-Installer to work, we need to do include an `/etc/NetworkManager` directory, so you need to
+rebuild the image by now.
+
+
+1. Install [dracut-iguana](https://github.com/openSUSE/iguana/tree/main/dracut-iguana) from
+[OBS](https://build.opensuse.org/package/show/home:oholecek:iguana/dracut-iguana).
+
+2. (Optional) For debugging purposes, you might want to add SSH support so you can connect to the
+   system. If that's the case, please install the `dracut-ssh` package and place your public SSH key
+   on `/root/.ssh/authorized_keys`.
+
+3. Create a `/etc/NetworkManager` directory to be included in the initrd:
+
+        mkdir -p rd.live.networkmanager/etc/NetworkManager
+
+4. Rebuild the image:
+
+       dracut --verbose --force --no-hostonly --no-hostonly-cmdline --no-hostonly-default-device --no-hostonly-i18n --reproducible --include rd.live.networkmanager / iguana-initrd
+
+5. Copy the kernel (`/boot/vmlinuz-VERSION`), the initrd and the workflow definition to the TFTP
+   tree. You must use the same paths specified in the `ìguana` boot option (see [Set up the TFTP
+   tree](#set-up-the-tftp-tree) section).
+
+## Booting from PXE
+
+To boot from PXE, you need to enable the boot menu for your VM. You can do it easily by using
+`virt-manager` and marking the `Enable boot menu` option in the `Boot options` section of your
+virtual machine. Alternatively, you can edit the XML definition (`virsh edit NAME`) and add the `bootmenu`
+element to `<os>` section:
+
+```xml
+ <os>
+   <bootmenu enable='yes'/>
+ </os>
+```
+
+After starting the machine, you should choose the option to boot from PXE and introduce `iguana` in
+the `boot:` prompt (or the name you chose in the `pxelinux.cfg/default` file).

--- a/doc/pxe.md
+++ b/doc/pxe.md
@@ -127,6 +127,6 @@ initrd following these steps:
 
 ### Accessing the serial console
 
-In case of problems, you should to inspect system messages. The best way is to enable the serial
+In case of problems, you should inspect system messages. The best way is to enable the serial
 console by adding `console=tty0 console=ttyS0,9600` to the `append` line. Then, you will be able to
 connect using `sudo virsh console DOMAIN`.

--- a/doc/pxe.md
+++ b/doc/pxe.md
@@ -83,9 +83,12 @@ repository](https://github.com/openSUSE/iguana) includes a [definition for
 D-Installer](https://github.com/openSUSE/iguana/blob/main/iguana-workflow/examples/d-installer.yaml).
 
 After installing the `iguana` package, copy the kernel (`/usr/share/iguana/vmlinuz-VERSION`), the
-initrd (`/usr/share/iguana/iguana-initrd`) and the workflow definition to the TFTP tree. You must
+initrd (`/usr/share/iguana/iguana-initrd`) and the workflow definition to the TFTP tree[^1]. You must
 use the same paths specified in the `ìguana` boot option (see [Set up the TFTP
 tree](#set-up-the-tftp-tree) section).
+
+[^1]: If you want to point always to the latest workflow definition, you can use a raw GitHub
+link: `rd.iguana.control_url=https://raw.githubusercontent.com/openSUSE/iguana/main/iguana-workflow/examples/d-installer.yaml`
 
 ### Booting from PXE
 

--- a/doc/pxe.md
+++ b/doc/pxe.md
@@ -13,21 +13,29 @@ The process can be summarized in these steps:
 
 ## Set up the TFTP tree
 
-The TFTP files are available in the `tftpboot-installation-openSUSE-Tumbleweed-ARCH` packages. They
-are placed in `/usr/share/tftpboot-installation`, but you should copy them (or at least the `net`
-subdirectory) to customize them. In the example below we are just copying all of them.
+The TFTP tree should contain the SYSLINUX boot loader. You can copy the required files from the
+`syslinux` package.
 
-    zypper in tftpboot-installation-openSUSE-Tumbleweed-x86_64
+    zypper in syslinux
     mkdir /srv/tftpboot
-    cp -a /usr/share/tftpboot-installation/openSUSE-Tumbleweed-x86_64 /srv/tftpboot
+    cp /usr/share/syslinux/pxelinux.0 /srv/tftpboot
+    mkdir /srv/tftpboot/pxelinux.cfg
 
-To define a boot option to run D-Installer, edit the `net/pxelinux.cfg/default` to include:
+To define a boot option to run D-Installer, add a `/srv/tftpboot/pxelinux.cfg/default` file with the
+following content:
 
 ```
+default iguana
+
 label iguana
   ipappend 2
-  kernel boot/x86_64/loader/iguana-new/vmlinuz-iguana
-  append initrd=boot/x86_64/loader/initrd-iguana rd.iguana.control_url=tftp://192.168.122.1/net/d-installer.yaml rd.iguana.debug=1 rd.neednet=1
+  kernel vmlinuz-iguana
+  append initrd=initrd-iguana rd.iguana.control_url=tftp://192.168.122.1/d-installer.yaml rd.iguana.debug=1
+
+display		message
+implicit	1
+prompt		1
+timeout		50
 ```
 
 Do not worry about the kernel, the initrd or the `d-installer.yaml` file, we will jump into it
@@ -51,10 +59,10 @@ it accordingly. Here is an example:
   <bridge name='virbr0' stp='on' delay='0'/>
   <mac address='52:54:00:fb:7c:8e'/>
   <ip address='192.168.122.1' netmask='255.255.255.0'>
-    <tftp root='/srv/tftpboot/openSUSE-Tumbleweed-x86_64'/>
+    <tftp root='/srv/tftpboot'/>
     <dhcp>
       <range start='192.168.122.2' end='192.168.122.254'/>
-      <bootp file='net/pxelinux.0'/>
+      <bootp file='pxelinux.0'/>
     </dhcp>
   </ip>
 </network>
@@ -107,5 +115,6 @@ element to `<os>` section:
  </os>
 ```
 
-After starting the machine, you should choose the option to boot from PXE and introduce `iguana` in
-the `boot:` prompt (or the name you chose in the `pxelinux.cfg/default` file).
+Now your virtual machine should be ready to boot from PXE and start Iguana/D-Installer. Once the
+system boots and the services are started, you should be able to access D-Installer with a browser
+on port 9090.

--- a/doc/pxe.md
+++ b/doc/pxe.md
@@ -89,16 +89,8 @@ tree](#set-up-the-tftp-tree) section).
 
 ### Booting from PXE
 
-To boot from PXE, you need to enable the boot menu for your VM. You can do it easily by using
-`virt-manager` and marking the `Enable boot menu` option in the `Boot options` section of your
-virtual machine. Alternatively, you can edit the XML definition (`virsh edit NAME`) and add the `bootmenu`
-element to `<os>` section:
-
-```xml
- <os>
-   <bootmenu enable='yes'/>
- </os>
-```
+To boot from PXE, you just need to set the network card as the first booting device. Alternatively,
+you can enable the boot menu so you can decide how to boot your system manually.
 
 Now your virtual machine should be ready to boot from PXE and start Iguana/D-Installer. Once the
 system boots and the services are started, you should be able to access D-Installer with a browser

--- a/doc/pxe.md
+++ b/doc/pxe.md
@@ -70,37 +70,18 @@ it accordingly. Here is an example:
 
 ## initrd preparation
 
-**Please, build the initrd on a virtual machine to avoid messing up your system.**
+Iguana provides a universal initrd in which actual functionality is implemented in containers. This
+ramdisk and its corresponding kernel are included in the [`iguana`
+package](https://build.opensuse.org/package/show/home:oholecek:iguana/iguana).
 
-Iguana provides a universal initrd in which actual functionality is implemented in containers. Which
-containers to use and how to set them up is defined in a *workflow definition*. The [Iguana
+Which containers to use and how to set them up is defined in a *workflow definition*. The [Iguana
 repository](https://github.com/openSUSE/iguana) includes a [definition for
 D-Installer](https://github.com/openSUSE/iguana/blob/main/iguana-workflow/examples/d-installer.yaml).
 
-In the future, you should be able to get the kernel and the initrd files from the [Iguana
-package](https://build.opensuse.org/package/show/home:oholecek:iguana/iguana). However, for
-D-Installer to work, we need to do include an `/etc/NetworkManager` directory, so you need to
-rebuild the image by now.
-
-
-1. Install [dracut-iguana](https://github.com/openSUSE/iguana/tree/main/dracut-iguana) from
-[OBS](https://build.opensuse.org/package/show/home:oholecek:iguana/dracut-iguana).
-
-2. (Optional) For debugging purposes, you might want to add SSH support so you can connect to the
-   system. If that's the case, please install the `dracut-ssh` package and place your public SSH key
-   on `/root/.ssh/authorized_keys`.
-
-3. Create a `/etc/NetworkManager` directory to be included in the initrd:
-
-        mkdir -p rd.live.networkmanager/etc/NetworkManager
-
-4. Rebuild the image:
-
-       dracut --verbose --force --no-hostonly --no-hostonly-cmdline --no-hostonly-default-device --no-hostonly-i18n --reproducible --include rd.live.networkmanager / iguana-initrd
-
-5. Copy the kernel (`/boot/vmlinuz-VERSION`), the initrd and the workflow definition to the TFTP
-   tree. You must use the same paths specified in the `ìguana` boot option (see [Set up the TFTP
-   tree](#set-up-the-tftp-tree) section).
+After installing the `iguana` package, copy the kernel (`/usr/share/iguana/vmlinuz-VERSION`), the
+initrd (`/usr/share/iguana/iguana-initrd`) and the workflow definition to the TFTP tree. You must
+use the same paths specified in the `ìguana` boot option (see [Set up the TFTP
+tree](#set-up-the-tftp-tree) section).
 
 ## Booting from PXE
 
@@ -118,3 +99,22 @@ element to `<os>` section:
 Now your virtual machine should be ready to boot from PXE and start Iguana/D-Installer. Once the
 system boots and the services are started, you should be able to access D-Installer with a browser
 on port 9090.
+
+## Appendix: connecting through SSH
+
+**Please, build the initrd on a virtual machine to avoid messing up your system.**
+
+For debugging purposes, you might be interested in connecting to the system and running commands
+like `podman` to inspect the situation. If that's the case, you can add SSH support to Iguana's
+initrd following these steps:
+
+1. Install [dracut-iguana](https://github.com/openSUSE/iguana/tree/main/dracut-iguana) from
+[OBS](https://build.opensuse.org/package/show/home:oholecek:iguana/dracut-iguana).
+
+2. Install the `dracut-ssh` package and place your public SSH key on `/root/.ssh/authorized_keys`.
+
+3. Rebuild the image:
+
+       dracut --verbose --force --no-hostonly --no-hostonly-cmdline --no-hostonly-default-device --no-hostonly-i18n --reproducible iguana-initrd
+
+4. Copy the system's kernel (`/boot/vmlinuz-VERSION`) and the generated initrd to your TFTP tree.

--- a/doc/pxe.md
+++ b/doc/pxe.md
@@ -108,7 +108,7 @@ on port 9090.
 
 ### Adding support for SSH
 
-**Please, build the initrd on a virtual machine to avoid messing up your system.**
+:warning: **Please, build the initrd on a virtual machine to avoid messing up your system.**
 
 For debugging purposes, you might be interested in connecting to the system and running commands
 like `podman` to inspect the situation. If that's the case, you can add SSH support to Iguana's

--- a/doc/pxe.md
+++ b/doc/pxe.md
@@ -1,8 +1,12 @@
 # Using PXE and Iguana
 
 This document explains how to run D-Installer on PXE with the help of Iguana. The described setup
-uses libvirt, but you can adapt the overall approach to other scenarios (like running your own
-TFTP server).
+uses libvirt, but you can adapt the overall approach to other scenarios (like running your TFTP
+server).
+
+Additionally, it offers some helpful tips for debugging D-Installer problems.
+
+## Set up
 
 The process can be summarized in these steps:
 
@@ -11,7 +15,7 @@ The process can be summarized in these steps:
 3. Prepare the initial ramdisk image (initrd), based on Iguana.
 4. Boot from PXE.
 
-## Set up the TFTP tree
+### Set up the TFTP tree
 
 The TFTP tree should contain the SYSLINUX boot loader. You can copy the required files from the
 `syslinux` package.
@@ -41,7 +45,7 @@ timeout		50
 Do not worry about the kernel, the initrd or the `d-installer.yaml` file, we will jump into it
 later.
 
-## Configure libvirt to server TFTP files
+### Configure libvirt to server TFTP files
 
 To instruct libvirt to serve the TFTP files, you must add the `tftp` and `bootp` elements to the
 network configuration. Use the `virsh net-edit default` command to edit the configuration and adapt
@@ -68,7 +72,7 @@ it accordingly. Here is an example:
 </network>
 ```
 
-## initrd preparation
+### initrd preparation
 
 Iguana provides a universal initrd in which actual functionality is implemented in containers. This
 ramdisk and its corresponding kernel are included in the [`iguana`
@@ -83,7 +87,7 @@ initrd (`/usr/share/iguana/iguana-initrd`) and the workflow definition to the TF
 use the same paths specified in the `ìguana` boot option (see [Set up the TFTP
 tree](#set-up-the-tftp-tree) section).
 
-## Booting from PXE
+### Booting from PXE
 
 To boot from PXE, you need to enable the boot menu for your VM. You can do it easily by using
 `virt-manager` and marking the `Enable boot menu` option in the `Boot options` section of your
@@ -100,7 +104,9 @@ Now your virtual machine should be ready to boot from PXE and start Iguana/D-Ins
 system boots and the services are started, you should be able to access D-Installer with a browser
 on port 9090.
 
-## Appendix: connecting through SSH
+## Tips
+
+### Adding support for SSH
 
 **Please, build the initrd on a virtual machine to avoid messing up your system.**
 
@@ -118,3 +124,9 @@ initrd following these steps:
        dracut --verbose --force --no-hostonly --no-hostonly-cmdline --no-hostonly-default-device --no-hostonly-i18n --reproducible iguana-initrd
 
 4. Copy the system's kernel (`/boot/vmlinuz-VERSION`) and the generated initrd to your TFTP tree.
+
+### Accessing the serial console
+
+In case of problems, you should to inspect system messages. The best way is to enable the serial
+console by adding `console=tty0 console=ttyS0,9600` to the `append` line. Then, you will be able to
+connect using `sudo virsh console DOMAIN`.


### PR DESCRIPTION
This document explains how to run D-Installer on PXE with the help of Iguana. The described setup uses libvirt, but you can adapt the overall approach to other scenarios (like running your own TFTP server).
