### PR TITLE
[web] Update aliases for using ~/ instead of @ 

### DIFF
--- a/web/package/cockpit-d-installer.changes
+++ b/web/package/cockpit-d-installer.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jan 19 07:58:00 UTC 2023 - David Diaz <dgonzalez@suse.com>
+
+- Update aliases for using "~/" instead of "@"
+  (gh#yast/d-installer#400).
+
+-------------------------------------------------------------------
 Wed Jan 18 08:06:05 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
 
 - Allow user downloading logs (gh#yast/d-installer#379)

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -22,12 +22,12 @@
 import React, { useEffect, useState } from "react";
 import { Outlet } from "react-router-dom";
 
-import { useInstallerClient } from "@context/installer";
-import { STARTUP, INSTALL } from "@client/phase";
-import { BUSY } from "@client/status";
+import { useInstallerClient } from "~/context/installer";
+import { STARTUP, INSTALL } from "~/client/phase";
+import { BUSY } from "~/client/status";
 
-import { Layout, Title, LoadingEnvironment, DBusError } from "@components/layout";
-import { InstallationProgress, InstallationFinished } from "@components/core";
+import { Layout, Title, LoadingEnvironment, DBusError } from "~/components/layout";
+import { InstallationProgress, InstallationFinished } from "~/components/core";
 
 function App() {
   const client = useInstallerClient();

--- a/web/src/App.test.jsx
+++ b/web/src/App.test.jsx
@@ -21,27 +21,27 @@
 
 import React from "react";
 import { act, screen } from "@testing-library/react";
-import { installerRender, mockComponent, mockLayout } from "@/test-utils";
+import { installerRender, mockComponent, mockLayout } from "~/test-utils";
 import App from "./App";
-import { createClient } from "@client";
-import { STARTUP, CONFIG, INSTALL } from "@client/phase";
-import { IDLE, BUSY } from "@client/status";
+import { createClient } from "~/client";
+import { STARTUP, CONFIG, INSTALL } from "~/client/phase";
+import { IDLE, BUSY } from "~/client/status";
 
-jest.mock("@client");
+jest.mock("~/client");
 
 jest.mock('react-router-dom', () => ({
   Outlet: mockComponent("Content"),
 }));
 
-jest.mock("@components/layout/Layout", () => mockLayout());
+jest.mock("~/components/layout/Layout", () => mockLayout());
 
 // Mock some components,
 // See https://www.chakshunyu.com/blog/how-to-mock-a-react-component-in-jest/#default-export
-jest.mock("@components/layout/DBusError", () => mockComponent("D-BusError Mock"));
-jest.mock("@components/layout/LoadingEnvironment", () => mockComponent("LoadingEnvironment Mock"));
-jest.mock("@components/questions/Questions", () => mockComponent("Questions Mock"));
-jest.mock("@components/core/InstallationProgress", () => mockComponent("InstallationProgress Mock"));
-jest.mock("@components/core/InstallationFinished", () => mockComponent("InstallationFinished Mock"));
+jest.mock("~/components/layout/DBusError", () => mockComponent("D-BusError Mock"));
+jest.mock("~/components/layout/LoadingEnvironment", () => mockComponent("LoadingEnvironment Mock"));
+jest.mock("~/components/questions/Questions", () => mockComponent("Questions Mock"));
+jest.mock("~/components/core/InstallationProgress", () => mockComponent("InstallationProgress Mock"));
+jest.mock("~/components/core/InstallationFinished", () => mockComponent("InstallationFinished Mock"));
 
 const callbacks = {};
 const getStatusFn = jest.fn();

--- a/web/src/Main.jsx
+++ b/web/src/Main.jsx
@@ -21,7 +21,7 @@
 
 import React from "react";
 import { Outlet } from "react-router-dom";
-import { Questions } from "@components/questions";
+import { Questions } from "~/components/questions";
 
 function Main() {
   return (

--- a/web/src/Main.test.jsx
+++ b/web/src/Main.test.jsx
@@ -21,11 +21,11 @@
 
 import React from "react";
 import { screen } from "@testing-library/react";
-import { installerRender, mockComponent } from "@/test-utils";
+import { installerRender, mockComponent } from "~/test-utils";
 
-import Main from "@/Main";
+import Main from "~/Main";
 
-jest.mock("@components/questions/Questions", () => mockComponent("Questions Mock"));
+jest.mock("~/components/questions/Questions", () => mockComponent("Questions Mock"));
 jest.mock('react-router-dom', () => ({
   Outlet: mockComponent("Content"),
 }));

--- a/web/src/assets/styles/index.scss
+++ b/web/src/assets/styles/index.scss
@@ -1,11 +1,11 @@
-@use "@assets/styles/variables.scss";
+@use "~/assets/styles/variables.scss";
 // TODO: merge app and global
-@use "@assets/styles/global.scss";
-@use "@assets/styles/app.scss";
-@use "@assets/styles/layout.scss";
-@use "@assets/styles/utilities.scss";
-@use "@assets/styles/composition.scss";
-@use "@assets/styles/blocks.scss";
+@use "~/assets/styles/global.scss";
+@use "~/assets/styles/app.scss";
+@use "~/assets/styles/layout.scss";
+@use "~/assets/styles/utilities.scss";
+@use "~/assets/styles/composition.scss";
+@use "~/assets/styles/blocks.scss";
 
 // PatternFly overrides
-@use "@assets/styles/patternfly-overrides.scss";
+@use "~/assets/styles/patternfly-overrides.scss";

--- a/web/src/components/core/About.jsx
+++ b/web/src/components/core/About.jsx
@@ -20,10 +20,10 @@
  */
 
 import React, { useState } from "react";
-import { noop } from "@/utils";
+import { noop } from "~/utils";
 import { Button, Text } from "@patternfly/react-core";
-import { Icon } from "@components/layout";
-import { Popup } from "@components/core";
+import { Icon } from "~/components/layout";
+import { Popup } from "~/components/core";
 
 export default function About({ onClickCallback = noop }) {
   const [isOpen, setIsOpen] = useState(false);

--- a/web/src/components/core/About.test.jsx
+++ b/web/src/components/core/About.test.jsx
@@ -22,7 +22,7 @@
 import React from "react";
 
 import { screen, waitFor, within } from "@testing-library/react";
-import { plainRender } from "@/test-utils";
+import { plainRender } from "~/test-utils";
 
 import About from "./About";
 

--- a/web/src/components/core/ChangeProductButton.jsx
+++ b/web/src/components/core/ChangeProductButton.jsx
@@ -22,9 +22,9 @@
 import React from "react";
 import { Button } from "@patternfly/react-core";
 import { useNavigate } from "react-router-dom";
-import { useSoftware } from "@context/software";
-import { Icon } from "@components/layout";
-import { noop } from "@/utils";
+import { useSoftware } from "~/context/software";
+import { Icon } from "~/components/layout";
+import { noop } from "~/utils";
 
 export default function ChangeProductButton({ onClickCallback = noop }) {
   const { products } = useSoftware();

--- a/web/src/components/core/ChangeProductButton.test.jsx
+++ b/web/src/components/core/ChangeProductButton.test.jsx
@@ -21,16 +21,16 @@
 
 import React from "react";
 import { screen, waitFor } from "@testing-library/react";
-import { plainRender } from "@/test-utils";
-import { createClient } from "@client";
-import { ChangeProductButton } from "@components/core";
+import { plainRender } from "~/test-utils";
+import { createClient } from "~/client";
+import { ChangeProductButton } from "~/components/core";
 
 let mockProducts;
 const mockNavigateFn = jest.fn();
 
-jest.mock("@client");
-jest.mock("@context/software", () => ({
-  ...jest.requireActual("@context/software"),
+jest.mock("~/client");
+jest.mock("~/context/software", () => ({
+  ...jest.requireActual("~/context/software"),
   useSoftware: () => {
     return {
       products: mockProducts,

--- a/web/src/components/core/Fieldset.jsx
+++ b/web/src/components/core/Fieldset.jsx
@@ -22,7 +22,7 @@
 // @ts-check
 
 import React from "react";
-import { classNames } from "@/utils";
+import { classNames } from "~/utils";
 
 import "./fieldset.scss";
 

--- a/web/src/components/core/Fieldset.test.jsx
+++ b/web/src/components/core/Fieldset.test.jsx
@@ -21,8 +21,8 @@
 
 import React from "react";
 import { screen, within } from "@testing-library/react";
-import { installerRender } from "@/test-utils";
-import { Fieldset } from "@components/core";
+import { installerRender } from "~/test-utils";
+import { Fieldset } from "~/components/core";
 
 const ComplexLegend = () => {
   return (

--- a/web/src/components/core/InstallButton.jsx
+++ b/web/src/components/core/InstallButton.jsx
@@ -20,10 +20,10 @@
  */
 
 import React, { useState } from "react";
-import { useInstallerClient } from "@context/installer";
+import { useInstallerClient } from "~/context/installer";
 
 import { Button, Text } from "@patternfly/react-core";
-import { Popup } from "@components/core";
+import { Popup } from "~/components/core";
 
 const InstallConfirmationPopup = ({ onAccept, onClose }) => (
   <Popup

--- a/web/src/components/core/InstallButton.test.jsx
+++ b/web/src/components/core/InstallButton.test.jsx
@@ -21,13 +21,13 @@
 
 import React from "react";
 import { screen, waitFor } from "@testing-library/react";
-import { installerRender } from "@/test-utils";
-import { createClient } from "@client";
-import { InstallButton } from "@components/core";
+import { installerRender } from "~/test-utils";
+import { createClient } from "~/client";
+import { InstallButton } from "~/components/core";
 
 const startInstallationFn = jest.fn().mockName("startInstallation");
 
-jest.mock("@client", () => ({
+jest.mock("~/client", () => ({
   createClient: jest.fn()
 }));
 

--- a/web/src/components/core/InstallationFinished.jsx
+++ b/web/src/components/core/InstallationFinished.jsx
@@ -29,8 +29,8 @@ import {
   EmptyStateBody
 } from "@patternfly/react-core";
 
-import { Center, Icon, Title as SectionTitle, PageIcon, MainActions } from "@components/layout";
-import { useInstallerClient } from "@context/installer";
+import { Center, Icon, Title as SectionTitle, PageIcon, MainActions } from "~/components/layout";
+import { useInstallerClient } from "~/context/installer";
 
 function InstallationFinished() {
   const client = useInstallerClient();

--- a/web/src/components/core/InstallationFinished.test.jsx
+++ b/web/src/components/core/InstallationFinished.test.jsx
@@ -22,13 +22,13 @@
 import React from "react";
 
 import { screen } from "@testing-library/react";
-import { installerRender, mockLayout } from "@/test-utils";
-import { createClient } from "@client";
+import { installerRender, mockLayout } from "~/test-utils";
+import { createClient } from "~/client";
 
 import InstallationFinished from "./InstallationFinished";
 
-jest.mock("@client");
-jest.mock("@components/layout/Layout", () => mockLayout());
+jest.mock("~/client");
+jest.mock("~/components/layout/Layout", () => mockLayout());
 
 const rebootSystemFn = jest.fn();
 

--- a/web/src/components/core/InstallationProgress.jsx
+++ b/web/src/components/core/InstallationProgress.jsx
@@ -22,8 +22,8 @@
 import React from "react";
 
 import ProgressReport from "./ProgressReport";
-import { Center, Icon, Title, PageIcon } from "@components/layout";
-import { Questions } from "@components/questions";
+import { Center, Icon, Title, PageIcon } from "~/components/layout";
+import { Questions } from "~/components/questions";
 
 function InstallationProgress() {
   return (

--- a/web/src/components/core/InstallationProgress.test.jsx
+++ b/web/src/components/core/InstallationProgress.test.jsx
@@ -22,12 +22,12 @@
 import React from "react";
 
 import { screen } from "@testing-library/react";
-import { installerRender, mockComponent, mockLayout } from "@/test-utils";
+import { installerRender, mockComponent, mockLayout } from "~/test-utils";
 
 import InstallationProgress from "./InstallationProgress";
 
-jest.mock("@components/layout/Layout", () => mockLayout());
-jest.mock("@components/core/ProgressReport", () => mockComponent("ProgressReport Mock"));
+jest.mock("~/components/layout/Layout", () => mockLayout());
+jest.mock("~/components/core/ProgressReport", () => mockComponent("ProgressReport Mock"));
 
 describe("InstallationProgress", () => {
   it("uses 'Installing' as title", async () => {

--- a/web/src/components/core/KebabMenu.jsx
+++ b/web/src/components/core/KebabMenu.jsx
@@ -21,7 +21,7 @@
 
 import React, { useState } from "react";
 import { Dropdown, DropdownToggle } from "@patternfly/react-core";
-import { Icon } from "@components/layout";
+import { Icon } from "~/components/layout";
 
 export default function KebabMenu({ items, position = "right", id = Date.now(), ...props }) {
   const [isOpen, setIsOpen] = useState(false);

--- a/web/src/components/core/LogsButton.jsx
+++ b/web/src/components/core/LogsButton.jsx
@@ -20,11 +20,11 @@
  */
 
 import React, { useState } from "react";
-import { useInstallerClient } from "@context/installer";
-import { useCancellablePromise } from "@/utils";
+import { useInstallerClient } from "~/context/installer";
+import { useCancellablePromise } from "~/utils";
 
 import { Alert, Button } from "@patternfly/react-core";
-import { Icon } from "@components/layout";
+import { Icon } from "~/components/layout";
 
 const FILENAME = "y2logs.tar.xz";
 const FILETYPE = "application/x-xz";

--- a/web/src/components/core/LogsButton.test.jsx
+++ b/web/src/components/core/LogsButton.test.jsx
@@ -21,11 +21,11 @@
 
 import React from "react";
 import { screen } from "@testing-library/react";
-import { installerRender } from "@/test-utils";
-import { createClient } from "@client";
-import { LogsButton } from "@components/core";
+import { installerRender } from "~/test-utils";
+import { createClient } from "~/client";
+import { LogsButton } from "~/components/core";
 
-jest.mock("@client");
+jest.mock("~/client");
 
 const originalCreateElement = document.createElement;
 

--- a/web/src/components/core/PasswordAndConfirmationInput.test.jsx
+++ b/web/src/components/core/PasswordAndConfirmationInput.test.jsx
@@ -21,7 +21,7 @@
 
 import React from "react";
 import { screen } from "@testing-library/react";
-import { plainRender } from "@/test-utils";
+import { plainRender } from "~/test-utils";
 import PasswordAndConfirmationInput from "./PasswordAndConfirmationInput";
 
 describe("when the passwords do not match", () => {

--- a/web/src/components/core/Popup.jsx
+++ b/web/src/components/core/Popup.jsx
@@ -21,7 +21,7 @@
 
 import React from "react";
 import { Button, Modal } from "@patternfly/react-core";
-import { partition } from "@/utils";
+import { partition } from "~/utils";
 
 /**
  * Wrapper component for holding Popup actions

--- a/web/src/components/core/Popup.test.jsx
+++ b/web/src/components/core/Popup.test.jsx
@@ -22,9 +22,9 @@
 import React from "react";
 
 import { screen, within } from "@testing-library/react";
-import { installerRender } from "@/test-utils";
+import { installerRender } from "~/test-utils";
 
-import { Popup } from "@components/core";
+import { Popup } from "~/components/core";
 
 let isOpen;
 const confirmFn = jest.fn();

--- a/web/src/components/core/ProgressReport.jsx
+++ b/web/src/components/core/ProgressReport.jsx
@@ -20,8 +20,8 @@
  */
 
 import React, { useState, useEffect } from "react";
-import { useCancellablePromise } from "@/utils";
-import { useInstallerClient } from "@context/installer";
+import { useCancellablePromise } from "~/utils";
+import { useInstallerClient } from "~/context/installer";
 
 import { Progress, Text } from "@patternfly/react-core";
 

--- a/web/src/components/core/ProgressReport.test.jsx
+++ b/web/src/components/core/ProgressReport.test.jsx
@@ -22,12 +22,12 @@
 import React from "react";
 
 import { act, screen } from "@testing-library/react";
-import { installerRender, createCallbackMock } from "@/test-utils";
-import { createClient } from "@client";
+import { installerRender, createCallbackMock } from "~/test-utils";
+import { createClient } from "~/client";
 
-import { ProgressReport } from "@components/core";
+import { ProgressReport } from "~/components/core";
 
-jest.mock("@client");
+jest.mock("~/client");
 
 let callbacks;
 let onManagerProgressChange = jest.fn();

--- a/web/src/components/core/Section.jsx
+++ b/web/src/components/core/Section.jsx
@@ -30,8 +30,8 @@ import {
   Tooltip
 } from "@patternfly/react-core";
 
-import { Icon } from '@components/layout';
-import { ValidationErrors } from "@components/core";
+import { Icon } from '~/components/layout';
+import { ValidationErrors } from "~/components/core";
 
 /**
  * Helper method for rendering section icon
@@ -91,7 +91,7 @@ const renderIcon = (name, size = 32) => {
  * @param {string} [props.actionIconName="settings"] - name for the icon for linking to section settings, when needed
  * @param {React.ReactNode} [props.actionTooltip] - text to be shown as a tooltip when user hovers action icon, if present
  * @param {React.MouseEventHandler} [props.onActionClick] - callback to be triggered when user clicks on action icon, if present
- * @param {import("@client/mixins").ValidationError[]} [props.errors] - Validation errors to be shown before the title
+ * @param {import("~/client/mixins").ValidationError[]} [props.errors] - Validation errors to be shown before the title
  * @param {JSX.Element} [props.children] - the section content
  */
 export default function Section({

--- a/web/src/components/core/Section.test.jsx
+++ b/web/src/components/core/Section.test.jsx
@@ -21,8 +21,8 @@
 
 import React, { useState } from "react";
 import { screen } from "@testing-library/react";
-import { installerRender } from "@/test-utils";
-import { Section } from "@components/core";
+import { installerRender } from "~/test-utils";
+import { Section } from "~/components/core";
 
 describe("Section", () => {
   it("renders given title", () => {

--- a/web/src/components/core/Sidebar.jsx
+++ b/web/src/components/core/Sidebar.jsx
@@ -20,9 +20,9 @@
  */
 
 import React, { useState } from "react";
-import { Icon, PageActions } from "@components/layout";
-import { About, ChangeProductButton, LogsButton } from "@components/core";
-import { TargetIpsPopup } from "@components/network";
+import { Icon, PageActions } from "~/components/layout";
+import { About, ChangeProductButton, LogsButton } from "~/components/core";
+import { TargetIpsPopup } from "~/components/network";
 
 /**
  * D-Installer sidebar navigation

--- a/web/src/components/core/Sidebar.test.jsx
+++ b/web/src/components/core/Sidebar.test.jsx
@@ -21,14 +21,14 @@
 
 import React from "react";
 import { screen, within, createEvent, fireEvent } from "@testing-library/react";
-import { plainRender, mockComponent, mockLayout } from "@/test-utils";
-import { Sidebar } from "@components/core";
+import { plainRender, mockComponent, mockLayout } from "~/test-utils";
+import { Sidebar } from "~/components/core";
 
-jest.mock("@components/layout/Layout", () => mockLayout());
-jest.mock("@components/core/About", () => mockComponent("About Mock"));
-jest.mock("@components/core/ChangeProductButton", () => mockComponent("ChangeProductButton Mock"));
-jest.mock("@components/core/LogsButton", () => mockComponent("LogsButton Mock"));
-jest.mock("@components/network/TargetIpsPopup", () => mockComponent("Host Ips Mock"));
+jest.mock("~/components/layout/Layout", () => mockLayout());
+jest.mock("~/components/core/About", () => mockComponent("About Mock"));
+jest.mock("~/components/core/ChangeProductButton", () => mockComponent("ChangeProductButton Mock"));
+jest.mock("~/components/core/LogsButton", () => mockComponent("LogsButton Mock"));
+jest.mock("~/components/network/TargetIpsPopup", () => mockComponent("Host Ips Mock"));
 
 it("renders the sidebar initially hidden", async () => {
   plainRender(<Sidebar />);

--- a/web/src/components/core/ValidationErrors.jsx
+++ b/web/src/components/core/ValidationErrors.jsx
@@ -30,10 +30,10 @@ import {
   Popover
 } from "@patternfly/react-core";
 
-import { Icon } from '@components/layout';
+import { Icon } from '~/components/layout';
 
 /**
- * @param {import("@client/mixins").ValidationError[]} errors - Validation errors
+ * @param {import("~/client/mixins").ValidationError[]} errors - Validation errors
  * @return React.JSX
  */
 const popoverContent = (errors) => {
@@ -56,7 +56,7 @@ const popoverContent = (errors) => {
  *
  * @param {object} props
  * @param {string} props.title - A title for the Popover
- * @param {import("@client/mixins").ValidationError[]} props.errors - Validation errors
+ * @param {import("~/client/mixins").ValidationError[]} props.errors - Validation errors
  */
 const ValidationErrors = ({ title = "Errors", errors }) => {
   const [popoverVisible, setPopoverVisible] = useState(false);

--- a/web/src/components/core/ValidationErrors.test.jsx
+++ b/web/src/components/core/ValidationErrors.test.jsx
@@ -21,7 +21,7 @@
 
 import React from "react";
 import { screen, waitFor } from "@testing-library/react";
-import { plainRender } from "@/test-utils";
+import { plainRender } from "~/test-utils";
 import ValidationErrors from "./ValidationErrors";
 
 describe("when there is a single error", () => {

--- a/web/src/components/language/LanguageSelector.jsx
+++ b/web/src/components/language/LanguageSelector.jsx
@@ -20,8 +20,8 @@
  */
 
 import React, { useReducer, useEffect } from "react";
-import { useCancellablePromise } from "@/utils";
-import { useInstallerClient } from "@context/installer";
+import { useCancellablePromise } from "~/utils";
+import { useInstallerClient } from "~/context/installer";
 
 import {
   Button,
@@ -31,7 +31,7 @@ import {
   FormSelectOption
 } from "@patternfly/react-core";
 
-import { Popup } from '@components/core';
+import { Popup } from '~/components/core';
 
 const reducer = (state, action) => {
   switch (action.type) {

--- a/web/src/components/language/LanguageSelector.test.jsx
+++ b/web/src/components/language/LanguageSelector.test.jsx
@@ -21,11 +21,11 @@
 
 import React from "react";
 import { act, screen } from "@testing-library/react";
-import { installerRender, createCallbackMock } from "@/test-utils";
-import { LanguageSelector } from "@components/language";
-import { createClient } from "@client";
+import { installerRender, createCallbackMock } from "~/test-utils";
+import { LanguageSelector } from "~/components/language";
+import { createClient } from "~/client";
 
-jest.mock("@client");
+jest.mock("~/client");
 
 const languages = [
   { id: "en_US", name: "English" },

--- a/web/src/components/layout/DBusError.jsx
+++ b/web/src/components/layout/DBusError.jsx
@@ -28,7 +28,7 @@ import {
   MainActions,
   PageIcon,
   Title as PageTitle,
-} from "@components/layout";
+} from "~/components/layout";
 
 // TODO: an example
 const ReloadAction = () => (

--- a/web/src/components/layout/DBusError.test.jsx
+++ b/web/src/components/layout/DBusError.test.jsx
@@ -22,11 +22,11 @@
 import React from "react";
 
 import { screen } from "@testing-library/react";
-import { plainRender, mockLayout } from "@/test-utils";
+import { plainRender, mockLayout } from "~/test-utils";
 
-import { DBusError } from "@components/layout";
+import { DBusError } from "~/components/layout";
 
-jest.mock("@components/layout/Layout", () => mockLayout());
+jest.mock("~/components/layout/Layout", () => mockLayout());
 
 describe("DBusError", () => {
   it("includes a generic D-Bus connection problem message", () => {

--- a/web/src/components/layout/Icon.jsx
+++ b/web/src/components/layout/Icon.jsx
@@ -21,36 +21,36 @@
 
 import React from 'react';
 
-// NOTE: "~icons" is an alias to use a shorter path to real icons location.
+// NOTE: "@icons" is an alias to use a shorter path to real icons location.
 //       Check the tsconfig.json file to see its value.
-import Inventory from "~icons/inventory_2.svg?component";
-import Translate from "~icons/translate.svg?component";
-import SettingsEthernet from "~icons/settings_ethernet.svg?component";
-import EditSquare from "~icons/edit_square.svg?component";
-import Edit from "~icons/edit.svg?component";
-import Download from "~icons/download.svg?component";
-import HardDrive from "~icons/hard_drive.svg?component";
-import Help from "~icons/help.svg?component";
-import ManageAccounts from "~icons/manage_accounts.svg?component";
-import Menu from "~icons/menu.svg?component";
-import MenuOpen from "~icons/menu_open.svg?component";
-import HomeStorage from "~icons/home_storage.svg?component";
-import Problem from "~icons/problem.svg?component";
-import Error from "~icons/error.svg?component";
-import CheckCircle from "~icons/check_circle.svg?component";
-import TaskAlt from "~icons/task_alt.svg?component";
-import Downloading from "~icons/downloading.svg?component";
-import MoreVert from "~icons/more_vert.svg?component";
-import Wifi from "~icons/wifi.svg?component";
-import Lan from "~icons/lan.svg?component";
-import Lock from "~icons/lock.svg?component";
-import SignalCellularAlt from "~icons/signal_cellular_alt.svg?component";
-import SettingsFill from "~icons/settings-fill.svg?component";
-import SettingsApplications from "~icons/settings_applications.svg?component";
-import Info from "~icons/info.svg?component";
-import Delete from "~icons/delete.svg?component";
-import Warning from "~icons/warning.svg?component";
-import Apps from "~icons/apps.svg?component";
+import Inventory from "@icons/inventory_2.svg?component";
+import Translate from "@icons/translate.svg?component";
+import SettingsEthernet from "@icons/settings_ethernet.svg?component";
+import EditSquare from "@icons/edit_square.svg?component";
+import Edit from "@icons/edit.svg?component";
+import Download from "@icons/download.svg?component";
+import HardDrive from "@icons/hard_drive.svg?component";
+import Help from "@icons/help.svg?component";
+import ManageAccounts from "@icons/manage_accounts.svg?component";
+import Menu from "@icons/menu.svg?component";
+import MenuOpen from "@icons/menu_open.svg?component";
+import HomeStorage from "@icons/home_storage.svg?component";
+import Problem from "@icons/problem.svg?component";
+import Error from "@icons/error.svg?component";
+import CheckCircle from "@icons/check_circle.svg?component";
+import TaskAlt from "@icons/task_alt.svg?component";
+import Downloading from "@icons/downloading.svg?component";
+import MoreVert from "@icons/more_vert.svg?component";
+import Wifi from "@icons/wifi.svg?component";
+import Lan from "@icons/lan.svg?component";
+import Lock from "@icons/lock.svg?component";
+import SignalCellularAlt from "@icons/signal_cellular_alt.svg?component";
+import SettingsFill from "@icons/settings-fill.svg?component";
+import SettingsApplications from "@icons/settings_applications.svg?component";
+import Info from "@icons/info.svg?component";
+import Delete from "@icons/delete.svg?component";
+import Warning from "@icons/warning.svg?component";
+import Apps from "@icons/apps.svg?component";
 import Loading from "./three-dots-loader-icon.svg?component";
 
 const icons = {

--- a/web/src/components/layout/Layout.jsx
+++ b/web/src/components/layout/Layout.jsx
@@ -21,9 +21,9 @@
 
 import React from "react";
 
-import logoUrl from "@assets/suse-horizontal-logo.svg";
+import logoUrl from "~/assets/suse-horizontal-logo.svg";
 import { createTeleporter } from "react-teleporter";
-import { Sidebar } from "@components/core";
+import { Sidebar } from "~/components/core";
 
 const PageTitle = createTeleporter();
 const HeaderActions = createTeleporter();

--- a/web/src/components/layout/LoadingEnvironment.jsx
+++ b/web/src/components/layout/LoadingEnvironment.jsx
@@ -22,7 +22,7 @@
 import React from "react";
 import { Title, EmptyState, EmptyStateIcon } from "@patternfly/react-core";
 
-import { Center, Icon } from "@components/layout";
+import { Center, Icon } from "~/components/layout";
 
 function LoadingEnvironment({ text = "Loading installation environment, please wait." }) {
   return (

--- a/web/src/components/layout/LoadingEnvironment.test.jsx
+++ b/web/src/components/layout/LoadingEnvironment.test.jsx
@@ -22,7 +22,7 @@
 import React from "react";
 
 import { screen } from "@testing-library/react";
-import { installerRender } from "@/test-utils";
+import { installerRender } from "~/test-utils";
 
 import LoadingEnvironment from "./LoadingEnvironment";
 

--- a/web/src/components/network/AddressesDataList.jsx
+++ b/web/src/components/network/AddressesDataList.jsx
@@ -36,8 +36,8 @@ import {
   DataListAction,
 } from "@patternfly/react-core";
 
-import { FormLabel } from "@components/core";
-import { IpAddressInput, IpPrefixInput } from "@components/network";
+import { FormLabel } from "~/components/core";
+import { IpAddressInput, IpPrefixInput } from "~/components/network";
 
 let index = 0;
 

--- a/web/src/components/network/ConnectionsDataList.jsx
+++ b/web/src/components/network/ConnectionsDataList.jsx
@@ -29,10 +29,10 @@ import {
   DataListItemCells
 } from "@patternfly/react-core";
 
-import { Icon } from "@components/layout";
+import { Icon } from "~/components/layout";
 
-import { ConnectionTypes } from "@client/network";
-import { formatIp } from "@client/network/utils";
+import { ConnectionTypes } from "~/client/network";
+import { formatIp } from "~/client/network/utils";
 
 export default function ConnectionsDataList({ conns, onSelect }) {
   if (conns.length === 0) return null;

--- a/web/src/components/network/ConnectionsDataList.test.jsx
+++ b/web/src/components/network/ConnectionsDataList.test.jsx
@@ -21,12 +21,12 @@
 
 import React from "react";
 import { screen } from "@testing-library/react";
-import { plainRender } from "@/test-utils";
+import { plainRender } from "~/test-utils";
 
-import { ConnectionTypes } from "@client/network";
-import ConnectionsDataList from "@components/network/ConnectionsDataList";
+import { ConnectionTypes } from "~/client/network";
+import ConnectionsDataList from "~/components/network/ConnectionsDataList";
 
-jest.mock("@client");
+jest.mock("~/client");
 
 const wiredConnection = {
   id: "wired-1",

--- a/web/src/components/network/DnsDataList.jsx
+++ b/web/src/components/network/DnsDataList.jsx
@@ -36,8 +36,8 @@ import {
   DataListAction
 } from "@patternfly/react-core";
 
-import { FormLabel } from "@components/core";
-import { IpAddressInput } from "@components/network";
+import { FormLabel } from "~/components/core";
+import { IpAddressInput } from "~/components/network";
 
 let index = 0;
 

--- a/web/src/components/network/IpAddressInput.jsx
+++ b/web/src/components/network/IpAddressInput.jsx
@@ -20,7 +20,7 @@
  */
 
 import React, { useState } from 'react';
-import { isValidIp } from '@client/network/utils';
+import { isValidIp } from '~/client/network/utils';
 import { TextInput, ValidatedOptions } from '@patternfly/react-core';
 
 const IpAddressInput = ({ placeholder, onError = () => null, ...props }) => {

--- a/web/src/components/network/IpPrefixInput.jsx
+++ b/web/src/components/network/IpPrefixInput.jsx
@@ -20,7 +20,7 @@
  */
 
 import React, { useState } from 'react';
-import { isValidIpPrefix } from '@client/network/utils';
+import { isValidIpPrefix } from '~/client/network/utils';
 import { TextInput, ValidatedOptions } from '@patternfly/react-core';
 
 const IpPrefixInput = ({ placeholder, onError = () => null, ...props }) => {

--- a/web/src/components/network/IpSettingsForm.jsx
+++ b/web/src/components/network/IpSettingsForm.jsx
@@ -22,9 +22,9 @@
 import React, { useState } from "react";
 import { HelperText, HelperTextItem, Form, FormGroup, FormSelect, FormSelectOption, TextInput } from "@patternfly/react-core";
 
-import { useInstallerClient } from "@context/installer";
-import { Popup } from "@components/core";
-import { AddressesDataList, DnsDataList } from "@components/network";
+import { useInstallerClient } from "~/context/installer";
+import { Popup } from "~/components/core";
+import { AddressesDataList, DnsDataList } from "~/components/network";
 
 const METHODS = {
   MANUAL: "manual",

--- a/web/src/components/network/Network.jsx
+++ b/web/src/components/network/Network.jsx
@@ -22,9 +22,9 @@
 import React, { useEffect, useState } from "react";
 import { Button } from "@patternfly/react-core";
 
-import { useInstallerClient } from "@context/installer";
-import { ConnectionTypes, NetworkEventTypes } from "@client/network";
-import { NetworkWifiStatus, NetworkWiredStatus, WifiSelector } from "@components/network";
+import { useInstallerClient } from "~/context/installer";
+import { ConnectionTypes, NetworkEventTypes } from "~/client/network";
+import { NetworkWifiStatus, NetworkWiredStatus, WifiSelector } from "~/components/network";
 
 export default function Network() {
   const client = useInstallerClient();

--- a/web/src/components/network/Network.test.jsx
+++ b/web/src/components/network/Network.test.jsx
@@ -21,14 +21,14 @@
 
 import React from "react";
 import { screen, within, waitFor } from "@testing-library/react";
-import { installerRender, mockComponent } from "@/test-utils";
-import Network from "@components/network/Network";
-import { ConnectionTypes } from "@client/network";
-import { createClient } from "@client";
+import { installerRender, mockComponent } from "~/test-utils";
+import Network from "~/components/network/Network";
+import { ConnectionTypes } from "~/client/network";
+import { createClient } from "~/client";
 
-jest.mock("@client");
-jest.mock("@components/network/NetworkWiredStatus", () => mockComponent("Wired Connections"));
-jest.mock("@components/network/NetworkWifiStatus", () => mockComponent("WiFi Connections"));
+jest.mock("~/client");
+jest.mock("~/components/network/NetworkWiredStatus", () => mockComponent("Wired Connections"));
+jest.mock("~/components/network/NetworkWifiStatus", () => mockComponent("WiFi Connections"));
 
 const networkSettings = { wifiScanSupported: false, hostname: "test" };
 let settingsFn = jest.fn().mockReturnValue(networkSettings);

--- a/web/src/components/network/NetworkWifiStatus.jsx
+++ b/web/src/components/network/NetworkWifiStatus.jsx
@@ -21,8 +21,8 @@
 
 import React, { useState } from "react";
 
-import { useInstallerClient } from "@context/installer";
-import { ConnectionsDataList, IpSettingsForm } from "@components/network";
+import { useInstallerClient } from "~/context/installer";
+import { ConnectionsDataList, IpSettingsForm } from "~/components/network";
 
 /**
  * D-Installer component to show status of wireless network connections

--- a/web/src/components/network/NetworkWiredStatus.jsx
+++ b/web/src/components/network/NetworkWiredStatus.jsx
@@ -20,10 +20,10 @@
  */
 
 import React, { useState } from "react";
-import { useInstallerClient } from "@context/installer";
+import { useInstallerClient } from "~/context/installer";
 
-import { ConnectionState } from "@client/network";
-import { IpSettingsForm, ConnectionsDataList } from "@components/network";
+import { ConnectionState } from "~/client/network";
+import { IpSettingsForm, ConnectionsDataList } from "~/components/network";
 
 /**
  * D-Installer component to show status of wired network connections

--- a/web/src/components/network/TargetIpsPopup.jsx
+++ b/web/src/components/network/TargetIpsPopup.jsx
@@ -22,12 +22,12 @@
 import React, { useEffect, useState } from "react";
 import { Button, List, ListItem, Text } from "@patternfly/react-core";
 
-import { noop, useCancellablePromise } from "@/utils";
-import { useInstallerClient } from "@context/installer";
-import { formatIp } from "@client/network/utils";
+import { noop, useCancellablePromise } from "~/utils";
+import { useInstallerClient } from "~/context/installer";
+import { formatIp } from "~/client/network/utils";
 
-import { Icon } from "@components/layout";
-import { Popup } from "@components/core";
+import { Icon } from "~/components/layout";
+import { Popup } from "~/components/core";
 
 export default function TargetIpsPopup({ onClickCallback = noop }) {
   const client = useInstallerClient();

--- a/web/src/components/network/TargetIpsPopup.test.jsx
+++ b/web/src/components/network/TargetIpsPopup.test.jsx
@@ -22,12 +22,12 @@
 import React from "react";
 
 import { act, screen, waitFor, within } from "@testing-library/react";
-import { installerRender } from "@/test-utils";
-import { createClient } from "@client";
+import { installerRender } from "~/test-utils";
+import { createClient } from "~/client";
 
-import { TargetIpsPopup } from "@components/network";
+import { TargetIpsPopup } from "~/components/network";
 
-jest.mock("@client");
+jest.mock("~/client");
 
 const addresses = [
   { address: "1.2.3.4", prefix: 24 },

--- a/web/src/components/network/WifiConnectionForm.jsx
+++ b/web/src/components/network/WifiConnectionForm.jsx
@@ -30,7 +30,7 @@ import {
   FormSelectOption,
   TextInput
 } from "@patternfly/react-core";
-import { useInstallerClient } from "@context/installer";
+import { useInstallerClient } from "~/context/installer";
 
 /*
 * FIXME: it should be moved to the SecurityProtocols enum that already exists or to a class based

--- a/web/src/components/network/WifiHiddenNetworkForm.test.jsx
+++ b/web/src/components/network/WifiHiddenNetworkForm.test.jsx
@@ -22,11 +22,11 @@
 import React from "react";
 
 import { screen } from "@testing-library/react";
-import { plainRender, mockComponent } from "@/test-utils";
+import { plainRender, mockComponent } from "~/test-utils";
 
-import { WifiHiddenNetworkForm } from "@components/network";
+import { WifiHiddenNetworkForm } from "~/components/network";
 
-jest.mock("@components/network/WifiConnectionForm", () => mockComponent("WifiConnectionForm mock"));
+jest.mock("~/components/network/WifiConnectionForm", () => mockComponent("WifiConnectionForm mock"));
 
 describe("WifiHiddenNetworkForm", () => {
   describe("when it is visible", () => {

--- a/web/src/components/network/WifiNetworkListItem.jsx
+++ b/web/src/components/network/WifiNetworkListItem.jsx
@@ -27,10 +27,10 @@ import {
   Text
 } from "@patternfly/react-core";
 
-import { ConnectionState } from "@client/network/model";
+import { ConnectionState } from "~/client/network/model";
 
-import { Icon } from "@components/layout";
-import { WifiNetworkMenu, WifiConnectionForm } from "@components/network";
+import { Icon } from "~/components/layout";
+import { WifiNetworkMenu, WifiConnectionForm } from "~/components/network";
 
 const networkState = (state) => {
   switch (state) {

--- a/web/src/components/network/WifiNetworkListItem.test.jsx
+++ b/web/src/components/network/WifiNetworkListItem.test.jsx
@@ -22,12 +22,12 @@
 import React from "react";
 
 import { screen } from "@testing-library/react";
-import { installerRender, mockComponent } from "@/test-utils";
+import { installerRender, mockComponent } from "~/test-utils";
 
-import { WifiNetworkListItem } from "@components/network";
+import { WifiNetworkListItem } from "~/components/network";
 
-jest.mock("@components/network/WifiConnectionForm", () => mockComponent("WifiConnectionForm mock"));
-jest.mock("@components/network/WifiNetworkMenu", () => mockComponent("WifiNetworkMenu mock"));
+jest.mock("~/components/network/WifiConnectionForm", () => mockComponent("WifiConnectionForm mock"));
+jest.mock("~/components/network/WifiNetworkMenu", () => mockComponent("WifiNetworkMenu mock"));
 
 const onSelectCallback = jest.fn();
 const fakeNetwork = {

--- a/web/src/components/network/WifiNetworkMenu.jsx
+++ b/web/src/components/network/WifiNetworkMenu.jsx
@@ -21,9 +21,9 @@
 
 import React from "react";
 import { DropdownItem } from "@patternfly/react-core";
-import { Icon } from "@components/layout";
-import { KebabMenu } from "@components/core";
-import { useInstallerClient } from "@context/installer";
+import { Icon } from "~/components/layout";
+import { KebabMenu } from "~/components/core";
+import { useInstallerClient } from "~/context/installer";
 
 export default function WifiNetworkMenu({ settings, position = "right" }) {
   const client = useInstallerClient();

--- a/web/src/components/network/WifiNetworksList.jsx
+++ b/web/src/components/network/WifiNetworksList.jsx
@@ -21,7 +21,7 @@
 
 import React from "react";
 
-import { WifiNetworkListItem, WifiHiddenNetworkForm } from "@components/network";
+import { WifiNetworkListItem, WifiHiddenNetworkForm } from "~/components/network";
 
 /**
  * Component for displaying a list of available Wi-Fi networks

--- a/web/src/components/network/WifiNetworksList.test.jsx
+++ b/web/src/components/network/WifiNetworksList.test.jsx
@@ -22,9 +22,9 @@
 import React from "react";
 
 import { screen, waitFor } from "@testing-library/react";
-import { installerRender } from "@/test-utils";
+import { installerRender } from "~/test-utils";
 
-import { WifiNetworksList } from "@components/network";
+import { WifiNetworksList } from "~/components/network";
 
 const onSelectionCallback = jest.fn();
 

--- a/web/src/components/network/WifiSelector.jsx
+++ b/web/src/components/network/WifiSelector.jsx
@@ -21,10 +21,10 @@
 
 import React, { useEffect, useState } from "react";
 
-import { useInstallerClient } from "@context/installer";
-import { NetworkEventTypes } from "@client/network";
-import { Popup } from "@components/core";
-import { WifiNetworksList } from "@components/network";
+import { useInstallerClient } from "~/context/installer";
+import { NetworkEventTypes } from "~/client/network";
+import { Popup } from "~/components/core";
+import { WifiNetworksList } from "~/components/network";
 
 const networksFromValues = (networks) => Object.values(networks).flat();
 const baseHiddenNetwork = { ssid: undefined, hidden: true };

--- a/web/src/components/overview/Overview.jsx
+++ b/web/src/components/overview/Overview.jsx
@@ -20,15 +20,15 @@
  */
 
 import React, { useState } from "react";
-import { useSoftware } from "@context/software";
+import { useSoftware } from "~/context/software";
 import { Navigate } from "react-router-dom";
 
-import { Icon, Title, PageIcon, MainActions } from "@components/layout";
-import { Section, InstallButton } from "@components/core";
-import { LanguageSelector } from "@components/language";
-import { SoftwareSection, StorageSection } from "@components/overview";
-import { Users } from "@components/users";
-import { Network } from "@components/network";
+import { Icon, Title, PageIcon, MainActions } from "~/components/layout";
+import { Section, InstallButton } from "~/components/core";
+import { LanguageSelector } from "~/components/language";
+import { SoftwareSection, StorageSection } from "~/components/overview";
+import { Users } from "~/components/users";
+import { Network } from "~/components/network";
 
 function Overview() {
   const { selectedProduct } = useSoftware();

--- a/web/src/components/overview/Overview.test.jsx
+++ b/web/src/components/overview/Overview.test.jsx
@@ -21,9 +21,9 @@
 
 import React from "react";
 import { screen } from "@testing-library/react";
-import { installerRender, mockComponent, mockLayout } from "@/test-utils";
+import { installerRender, mockComponent, mockLayout } from "~/test-utils";
 import Overview from "./Overview";
-import { createClient } from "@client";
+import { createClient } from "~/client";
 
 let mockProduct;
 let mockProducts = [
@@ -32,10 +32,10 @@ let mockProducts = [
 ];
 const startInstallationFn = jest.fn();
 
-jest.mock("@client");
+jest.mock("~/client");
 
-jest.mock("@context/software", () => ({
-  ...jest.requireActual("@context/software"),
+jest.mock("~/context/software", () => ({
+  ...jest.requireActual("~/context/software"),
   useSoftware: () => {
     return {
       products: mockProducts,
@@ -49,13 +49,13 @@ jest.mock('react-router-dom', () => ({
   useNavigate: () => jest.fn()
 }));
 
-jest.mock("@components/layout/Layout", () => mockLayout());
-jest.mock("@components/language/LanguageSelector", () => mockComponent("Language Selector"));
-jest.mock("@components/overview/StorageSection", () => mockComponent("Storage Section"));
-jest.mock("@components/network/Network", () => mockComponent("Network Configuration"));
-jest.mock("@components/users/Users", () => mockComponent("Users Configuration"));
-jest.mock("@components/overview/SoftwareSection", () => mockComponent("Software Section"));
-jest.mock("@components/core/InstallButton", () => mockComponent("Install Button"));
+jest.mock("~/components/layout/Layout", () => mockLayout());
+jest.mock("~/components/language/LanguageSelector", () => mockComponent("Language Selector"));
+jest.mock("~/components/overview/StorageSection", () => mockComponent("Storage Section"));
+jest.mock("~/components/network/Network", () => mockComponent("Network Configuration"));
+jest.mock("~/components/users/Users", () => mockComponent("Users Configuration"));
+jest.mock("~/components/overview/SoftwareSection", () => mockComponent("Software Section"));
+jest.mock("~/components/core/InstallButton", () => mockComponent("Install Button"));
 
 it("renders the Overview and the Install button", async () => {
   installerRender(<Overview />);

--- a/web/src/components/overview/SoftwareSection.jsx
+++ b/web/src/components/overview/SoftwareSection.jsx
@@ -21,11 +21,11 @@
 
 import React, { useReducer, useEffect } from "react";
 
-import { useCancellablePromise } from "@/utils";
-import { useInstallerClient } from "@context/installer";
-import { BUSY } from "@client/status";
-import { Icon } from "@components/layout";
-import { InstallerSkeleton, Section } from "@components/core";
+import { useCancellablePromise } from "~/utils";
+import { useInstallerClient } from "~/context/installer";
+import { BUSY } from "~/client/status";
+import { Icon } from "~/components/layout";
+import { InstallerSkeleton, Section } from "~/components/core";
 
 const initialState = {
   busy: false,

--- a/web/src/components/overview/StorageSection.jsx
+++ b/web/src/components/overview/StorageSection.jsx
@@ -24,12 +24,12 @@ import { useNavigate } from "react-router-dom";
 
 import { Button } from '@patternfly/react-core';
 
-import { useCancellablePromise } from "@/utils";
-import { useInstallerClient } from "@context/installer";
-import { BUSY } from "@client/status";
-import { Icon } from "@components/layout";
-import { InstallerSkeleton, Section } from "@components/core";
-import { ProposalSummary } from "@components/storage";
+import { useCancellablePromise } from "~/utils";
+import { useInstallerClient } from "~/context/installer";
+import { BUSY } from "~/client/status";
+import { Icon } from "~/components/layout";
+import { InstallerSkeleton, Section } from "~/components/core";
+import { ProposalSummary } from "~/components/storage";
 
 const initialState = {
   busy: false,

--- a/web/src/components/overview/StorageSection.test.jsx
+++ b/web/src/components/overview/StorageSection.test.jsx
@@ -21,14 +21,14 @@
 
 import React from "react";
 import { act, screen, waitFor } from "@testing-library/react";
-import { installerRender, createCallbackMock, mockComponent } from "@/test-utils";
-import { createClient } from "@client";
-import { BUSY, IDLE } from "@client/status";
-import { StorageSection } from "@components/overview";
+import { installerRender, createCallbackMock, mockComponent } from "~/test-utils";
+import { createClient } from "~/client";
+import { BUSY, IDLE } from "~/client/status";
+import { StorageSection } from "~/components/overview";
 
 const mockUseNavigate = jest.fn();
-jest.mock("@client");
-jest.mock("@components/core/InstallerSkeleton", () => mockComponent("Loading storage"));
+jest.mock("~/client");
+jest.mock("~/components/core/InstallerSkeleton", () => mockComponent("Loading storage"));
 jest.mock("react-router-dom", () => ({
   ...jest.requireActual("react-router-dom"),
   useNavigate: () => mockUseNavigate

--- a/web/src/components/questions/GenericQuestion.jsx
+++ b/web/src/components/questions/GenericQuestion.jsx
@@ -21,8 +21,8 @@
 
 import React from "react";
 import { Text } from "@patternfly/react-core";
-import { Popup } from "@components/core";
-import { QuestionActions } from "@components/questions";
+import { Popup } from "~/components/core";
+import { QuestionActions } from "~/components/questions";
 
 export default function GenericQuestion({ question, answerCallback }) {
   const actionCallback = (option) => {

--- a/web/src/components/questions/GenericQuestion.test.jsx
+++ b/web/src/components/questions/GenericQuestion.test.jsx
@@ -21,8 +21,8 @@
 
 import React from "react";
 import { screen } from "@testing-library/react";
-import { installerRender } from "@/test-utils";
-import { GenericQuestion } from "@components/questions";
+import { installerRender } from "~/test-utils";
+import { GenericQuestion } from "~/components/questions";
 
 const question = {
   id: 1,

--- a/web/src/components/questions/LuksActivationQuestion.jsx
+++ b/web/src/components/questions/LuksActivationQuestion.jsx
@@ -21,9 +21,9 @@
 
 import React, { useState } from "react";
 import { Alert, Form, FormGroup, Text, TextInput } from "@patternfly/react-core";
-import { Icon } from "@components/layout";
-import { Popup } from "@components/core";
-import { QuestionActions } from "@components/questions";
+import { Icon } from "~/components/layout";
+import { Popup } from "~/components/core";
+import { QuestionActions } from "~/components/questions";
 
 const renderAlert = (attempt) => {
   if (!attempt || attempt === 1) return null;

--- a/web/src/components/questions/LuksActivationQuestion.test.jsx
+++ b/web/src/components/questions/LuksActivationQuestion.test.jsx
@@ -21,8 +21,8 @@
 
 import React from "react";
 import { screen } from "@testing-library/react";
-import { installerRender } from "@/test-utils";
-import { LuksActivationQuestion } from "@components/questions";
+import { installerRender } from "~/test-utils";
+import { LuksActivationQuestion } from "~/components/questions";
 
 let question;
 const answerFn = jest.fn();

--- a/web/src/components/questions/QuestionActions.jsx
+++ b/web/src/components/questions/QuestionActions.jsx
@@ -20,8 +20,8 @@
  */
 
 import React from "react";
-import { partition } from "@/utils";
-import { Popup } from "@components/core";
+import { partition } from "~/utils";
+import { Popup } from "~/components/core";
 
 /**
  * Returns given text capitalized

--- a/web/src/components/questions/QuestionActions.test.jsx
+++ b/web/src/components/questions/QuestionActions.test.jsx
@@ -21,8 +21,8 @@
 
 import React from "react";
 import { screen } from "@testing-library/react";
-import { installerRender } from "@/test-utils";
-import { QuestionActions } from "@components/questions";
+import { installerRender } from "~/test-utils";
+import { QuestionActions } from "~/components/questions";
 
 let defaultOption = "handsdown";
 

--- a/web/src/components/questions/Questions.jsx
+++ b/web/src/components/questions/Questions.jsx
@@ -20,10 +20,10 @@
  */
 
 import React, { useState, useEffect, useCallback } from "react";
-import { useInstallerClient } from "@context/installer";
-import { useCancellablePromise } from "@/utils";
+import { useInstallerClient } from "~/context/installer";
+import { useCancellablePromise } from "~/utils";
 
-import { GenericQuestion, LuksActivationQuestion } from "@components/questions";
+import { GenericQuestion, LuksActivationQuestion } from "~/components/questions";
 
 const QUESTION_TYPES = {
   generic: GenericQuestion,

--- a/web/src/components/questions/Questions.test.jsx
+++ b/web/src/components/questions/Questions.test.jsx
@@ -22,14 +22,14 @@
 import React from "react";
 
 import { act, screen, waitFor } from "@testing-library/react";
-import { installerRender, mockComponent } from "@/test-utils";
-import { createClient } from "@client";
+import { installerRender, mockComponent } from "~/test-utils";
+import { createClient } from "~/client";
 
-import { Questions } from "@components/questions";
+import { Questions } from "~/components/questions";
 
-jest.mock("@client");
-jest.mock("@components/questions/GenericQuestion", () => mockComponent("A Generic question mock"));
-jest.mock("@components/questions/LuksActivationQuestion", () => mockComponent("A LUKS activation question mock"));
+jest.mock("~/client");
+jest.mock("~/components/questions/GenericQuestion", () => mockComponent("A Generic question mock"));
+jest.mock("~/components/questions/LuksActivationQuestion", () => mockComponent("A LUKS activation question mock"));
 
 const handlers = {};
 const genericQuestion = { id: 1, type: 'generic' };

--- a/web/src/components/software/ProductSelectionPage.jsx
+++ b/web/src/components/software/ProductSelectionPage.jsx
@@ -21,8 +21,8 @@
 
 import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { useInstallerClient } from "@context/installer";
-import { useSoftware } from "@context/software";
+import { useInstallerClient } from "~/context/installer";
+import { useSoftware } from "~/context/software";
 
 import {
   Button,
@@ -33,8 +33,8 @@ import {
   Radio
 } from "@patternfly/react-core";
 
-import { Icon, LoadingEnvironment } from "@components/layout";
-import { Title, PageIcon, MainActions } from "@components/layout/Layout";
+import { Icon, LoadingEnvironment } from "~/components/layout";
+import { Title, PageIcon, MainActions } from "~/components/layout/Layout";
 
 function ProductSelectionPage() {
   const client = useInstallerClient();

--- a/web/src/components/software/ProductSelectionPage.test.jsx
+++ b/web/src/components/software/ProductSelectionPage.test.jsx
@@ -21,9 +21,9 @@
 
 import React from "react";
 import { screen } from "@testing-library/react";
-import { installerRender, mockLayout } from "@/test-utils";
-import { ProductSelectionPage } from "@components/software";
-import { createClient } from "@client";
+import { installerRender, mockLayout } from "~/test-utils";
+import { ProductSelectionPage } from "~/components/software";
+import { createClient } from "~/client";
 
 const products = [
   {
@@ -37,7 +37,7 @@ const products = [
     description: "MicroOS description"
   }
 ];
-jest.mock("@client");
+jest.mock("~/client");
 
 const mockUseNavigate = jest.fn();
 jest.mock("react-router-dom", () => ({
@@ -45,8 +45,8 @@ jest.mock("react-router-dom", () => ({
   useNavigate: () => mockUseNavigate
 }));
 
-jest.mock("@context/software", () => ({
-  ...jest.requireActual("@context/software"),
+jest.mock("~/context/software", () => ({
+  ...jest.requireActual("~/context/software"),
   useSoftware: () => {
     return {
       products,
@@ -55,7 +55,7 @@ jest.mock("@context/software", () => ({
   }
 }));
 
-jest.mock("@components/layout/Layout", () => mockLayout());
+jest.mock("~/components/layout/Layout", () => mockLayout());
 
 const softwareMock = {
   getProducts: () => Promise.resolve(products),

--- a/web/src/components/storage/DeviceSelector.test.jsx
+++ b/web/src/components/storage/DeviceSelector.test.jsx
@@ -21,8 +21,8 @@
 
 import React, { useState } from "react";
 import { screen, waitFor, within } from "@testing-library/react";
-import { installerRender } from "@/test-utils";
-import { DeviceSelector } from "@components/storage";
+import { installerRender } from "~/test-utils";
+import { DeviceSelector } from "~/components/storage";
 
 const availableDevices = [
   { id: "/dev/sda", label: "/dev/sda, 500 GiB" },

--- a/web/src/components/storage/ProposalActions.test.jsx
+++ b/web/src/components/storage/ProposalActions.test.jsx
@@ -21,8 +21,8 @@
 
 import React from "react";
 import { screen, waitFor, within, waitForElementToBeRemoved } from "@testing-library/react";
-import { installerRender } from "@/test-utils";
-import { ProposalActions } from "@components/storage";
+import { installerRender } from "~/test-utils";
+import { ProposalActions } from "~/components/storage";
 
 const actions = [
   { text: 'Create GPT on /dev/vdc', subvol: false, delete: false },

--- a/web/src/components/storage/ProposalActionsSection.jsx
+++ b/web/src/components/storage/ProposalActionsSection.jsx
@@ -21,8 +21,8 @@
 
 import React from "react";
 
-import { Section } from "@components/core";
-import { ProposalActions } from "@components/storage";
+import { Section } from "~/components/core";
+import { ProposalActions } from "~/components/storage";
 
 export default function ProposalActionsSection({ proposal, errors }) {
   return (

--- a/web/src/components/storage/ProposalActionsSection.test.jsx
+++ b/web/src/components/storage/ProposalActionsSection.test.jsx
@@ -21,10 +21,10 @@
 
 import React from "react";
 import { screen } from "@testing-library/react";
-import { installerRender, mockComponent } from "@/test-utils";
-import { ProposalActionsSection } from "@components/storage";
+import { installerRender, mockComponent } from "~/test-utils";
+import { ProposalActionsSection } from "~/components/storage";
 
-jest.mock("@components/storage/ProposalActions", () => mockComponent("ProposalActions content"));
+jest.mock("~/components/storage/ProposalActions", () => mockComponent("ProposalActions content"));
 
 const proposal = {};
 

--- a/web/src/components/storage/ProposalPage.jsx
+++ b/web/src/components/storage/ProposalPage.jsx
@@ -27,15 +27,15 @@ import {
   Button,
 } from "@patternfly/react-core";
 
-import { useInstallerClient } from "@context/installer";
-import { useCancellablePromise } from "@/utils";
-import { Icon, Title, PageIcon, MainActions } from "@components/layout";
-import { InstallerSkeleton } from "@components/core";
+import { useInstallerClient } from "~/context/installer";
+import { useCancellablePromise } from "~/utils";
+import { Icon, Title, PageIcon, MainActions } from "~/components/layout";
+import { InstallerSkeleton } from "~/components/core";
 import {
   ProposalTargetSection,
   ProposalSettingsSection,
   ProposalActionsSection
-} from "@components/storage";
+} from "~/components/storage";
 
 const initialState = {
   busy: false,

--- a/web/src/components/storage/ProposalPage.test.jsx
+++ b/web/src/components/storage/ProposalPage.test.jsx
@@ -21,9 +21,9 @@
 
 import React from "react";
 import { screen, waitForElementToBeRemoved } from "@testing-library/react";
-import { installerRender, mockComponent } from "@/test-utils";
-import { createClient } from "@client";
-import { ProposalPage } from "@components/storage";
+import { installerRender, mockComponent } from "~/test-utils";
+import { createClient } from "~/client";
+import { ProposalPage } from "~/components/storage";
 
 const FakeProposalTargetSection = ({ calculateProposal }) => {
   return (
@@ -34,17 +34,17 @@ const FakeProposalTargetSection = ({ calculateProposal }) => {
   );
 };
 
-jest.mock("@client");
+jest.mock("~/client");
 jest.mock("react-router-dom", () => ({
   ...jest.requireActual("react-router-dom"),
   useNavigate: () => jest.fn()
 }));
 
-jest.mock("@components/core/InstallerSkeleton", () => mockComponent("Loading proposal"));
-jest.mock("@components/storage/ProposalTargetSection", () => FakeProposalTargetSection);
+jest.mock("~/components/core/InstallerSkeleton", () => mockComponent("Loading proposal"));
+jest.mock("~/components/storage/ProposalTargetSection", () => FakeProposalTargetSection);
 
-jest.mock("@components/storage/ProposalSettingsSection", () => mockComponent("Settings section"));
-jest.mock("@components/storage/ProposalActionsSection", () => mockComponent("Actions section"));
+jest.mock("~/components/storage/ProposalSettingsSection", () => mockComponent("Settings section"));
+jest.mock("~/components/storage/ProposalActionsSection", () => mockComponent("Actions section"));
 
 let proposal;
 

--- a/web/src/components/storage/ProposalSettingsForm.jsx
+++ b/web/src/components/storage/ProposalSettingsForm.jsx
@@ -26,7 +26,7 @@ import {
   Switch
 } from "@patternfly/react-core";
 
-import { Fieldset, PasswordAndConfirmationInput } from "@components/core";
+import { Fieldset, PasswordAndConfirmationInput } from "~/components/core";
 
 const reducer = (state, action) => {
   switch (action.type) {

--- a/web/src/components/storage/ProposalSettingsForm.test.jsx
+++ b/web/src/components/storage/ProposalSettingsForm.test.jsx
@@ -22,8 +22,8 @@
 import React from "react";
 
 import { screen, within } from "@testing-library/react";
-import { installerRender } from "@/test-utils";
-import { ProposalSettingsForm } from "@components/storage";
+import { installerRender } from "~/test-utils";
+import { ProposalSettingsForm } from "~/components/storage";
 
 const proposal = {
   lvm: false,

--- a/web/src/components/storage/ProposalSettingsSection.jsx
+++ b/web/src/components/storage/ProposalSettingsSection.jsx
@@ -21,8 +21,8 @@
 
 import React, { useState } from "react";
 import { Label, List, ListItem } from '@patternfly/react-core';
-import { Section, Popup } from "@components/core";
-import { ProposalSettingsForm } from "@components/storage";
+import { Section, Popup } from "~/components/core";
+import { ProposalSettingsForm } from "~/components/storage";
 
 export default function ProposalSettingsSection({ proposal, calculateProposal }) {
   const [isOpen, setIsOpen] = useState(false);

--- a/web/src/components/storage/ProposalSettingsSection.test.jsx
+++ b/web/src/components/storage/ProposalSettingsSection.test.jsx
@@ -21,8 +21,8 @@
 
 import React from "react";
 import { screen, waitFor, within } from "@testing-library/react";
-import { installerRender } from "@/test-utils";
-import { ProposalSettingsSection } from "@components/storage";
+import { installerRender } from "~/test-utils";
+import { ProposalSettingsSection } from "~/components/storage";
 
 const FakeProposalSettingsForm = ({ id, onSubmit }) => {
   const accept = (e) => {
@@ -33,7 +33,7 @@ const FakeProposalSettingsForm = ({ id, onSubmit }) => {
   return <form id={id} onSubmit={accept} aria-label="Settings form" />;
 };
 
-jest.mock("@components/storage/ProposalSettingsForm", () => FakeProposalSettingsForm);
+jest.mock("~/components/storage/ProposalSettingsForm", () => FakeProposalSettingsForm);
 
 const proposal = {
   candidateDevices: ["/dev/sda"],

--- a/web/src/components/storage/ProposalTargetForm.jsx
+++ b/web/src/components/storage/ProposalTargetForm.jsx
@@ -25,7 +25,7 @@ import {
   Form,
 } from "@patternfly/react-core";
 
-import { DeviceSelector } from "@components/storage";
+import { DeviceSelector } from "~/components/storage";
 
 export default function ProposalTargetForm({ id, proposal, onSubmit }) {
   const [candidateDevices, setCandidateDevices] = useState(proposal.candidateDevices);

--- a/web/src/components/storage/ProposalTargetForm.test.jsx
+++ b/web/src/components/storage/ProposalTargetForm.test.jsx
@@ -22,8 +22,8 @@
 import React from "react";
 
 import { screen, within } from "@testing-library/react";
-import { installerRender } from "@/test-utils";
-import { ProposalTargetForm } from "@components/storage";
+import { installerRender } from "~/test-utils";
+import { ProposalTargetForm } from "~/components/storage";
 
 const proposal = {
   availableDevices: [

--- a/web/src/components/storage/ProposalTargetSection.jsx
+++ b/web/src/components/storage/ProposalTargetSection.jsx
@@ -21,8 +21,8 @@
 
 import React, { useState } from "react";
 
-import { Section, Popup } from "@components/core";
-import { ProposalTargetForm, ProposalSummary } from "@components/storage";
+import { Section, Popup } from "~/components/core";
+import { ProposalTargetForm, ProposalSummary } from "~/components/storage";
 
 export default function ProposalTargetSection({ proposal, calculateProposal }) {
   const [isOpen, setIsOpen] = useState(false);

--- a/web/src/components/storage/ProposalTargetSection.test.jsx
+++ b/web/src/components/storage/ProposalTargetSection.test.jsx
@@ -21,8 +21,8 @@
 
 import React from "react";
 import { screen, waitFor, within } from "@testing-library/react";
-import { installerRender, mockComponent } from "@/test-utils";
-import { ProposalTargetSection } from "@components/storage";
+import { installerRender, mockComponent } from "~/test-utils";
+import { ProposalTargetSection } from "~/components/storage";
 
 const FakeProposalTargetForm = ({ id, onSubmit }) => {
   const accept = (e) => {
@@ -33,8 +33,8 @@ const FakeProposalTargetForm = ({ id, onSubmit }) => {
   return <form id={id} onSubmit={accept} aria-label="Target form" />;
 };
 
-jest.mock("@components/storage/ProposalSummary", () => mockComponent("Proposal summary"));
-jest.mock("@components/storage/ProposalTargetForm", () => FakeProposalTargetForm);
+jest.mock("~/components/storage/ProposalSummary", () => mockComponent("Proposal summary"));
+jest.mock("~/components/storage/ProposalTargetForm", () => FakeProposalTargetForm);
 
 const proposal = {
   availableDevices: [{ id: "/dev/sda", label: "/dev/sda, 500 GiB" }],

--- a/web/src/components/users/FirstUser.jsx
+++ b/web/src/components/users/FirstUser.jsx
@@ -20,9 +20,9 @@
  */
 
 import React, { useState, useEffect } from "react";
-import { useCancellablePromise } from "@/utils";
+import { useCancellablePromise } from "~/utils";
 
-import { useInstallerClient } from "@context/installer";
+import { useInstallerClient } from "~/context/installer";
 import {
   Alert,
   Button,
@@ -34,7 +34,7 @@ import {
   TextInput
 } from "@patternfly/react-core";
 
-import { PasswordAndConfirmationInput, Popup } from '@components/core';
+import { PasswordAndConfirmationInput, Popup } from '~/components/core';
 
 const initialUser = {
   userName: "",

--- a/web/src/components/users/FirstUser.test.jsx
+++ b/web/src/components/users/FirstUser.test.jsx
@@ -22,11 +22,11 @@
 import React from "react";
 
 import { act, screen, waitFor, within } from "@testing-library/react";
-import { installerRender, createCallbackMock } from "@/test-utils";
-import { createClient } from "@client";
-import { FirstUser } from "@components/users";
+import { installerRender, createCallbackMock } from "~/test-utils";
+import { createClient } from "~/client";
+import { FirstUser } from "~/components/users";
 
-jest.mock("@client");
+jest.mock("~/client");
 
 let user;
 const emptyUser = {

--- a/web/src/components/users/RootPassword.jsx
+++ b/web/src/components/users/RootPassword.jsx
@@ -20,8 +20,8 @@
  */
 
 import React, { useState, useEffect } from "react";
-import { useCancellablePromise } from "@/utils";
-import { useInstallerClient } from "@context/installer";
+import { useCancellablePromise } from "~/utils";
+import { useInstallerClient } from "~/context/installer";
 
 import {
   Button,
@@ -30,7 +30,7 @@ import {
   Text
 } from "@patternfly/react-core";
 
-import { PasswordAndConfirmationInput, Popup } from '@components/core';
+import { PasswordAndConfirmationInput, Popup } from '~/components/core';
 
 export default function RootPassword() {
   const client = useInstallerClient();

--- a/web/src/components/users/RootPassword.test.jsx
+++ b/web/src/components/users/RootPassword.test.jsx
@@ -22,12 +22,12 @@
 import React from "react";
 
 import { act, screen, waitFor, within } from "@testing-library/react";
-import { installerRender, createCallbackMock } from "@/test-utils";
-import { createClient } from "@client";
+import { installerRender, createCallbackMock } from "~/test-utils";
+import { createClient } from "~/client";
 
-import { RootPassword } from "@components/users";
+import { RootPassword } from "~/components/users";
 
-jest.mock("@client");
+jest.mock("~/client");
 
 let isRootPasswordSetFn;
 let setRootPasswordFn = jest.fn();

--- a/web/src/components/users/RootSSHKey.jsx
+++ b/web/src/components/users/RootSSHKey.jsx
@@ -20,8 +20,8 @@
  */
 
 import React, { useState, useEffect } from "react";
-import { useCancellablePromise } from "@/utils";
-import { useInstallerClient } from "@context/installer";
+import { useCancellablePromise } from "~/utils";
+import { useInstallerClient } from "~/context/installer";
 import {
   Button,
   Form,
@@ -31,7 +31,7 @@ import {
   FileUpload
 } from "@patternfly/react-core";
 
-import { Popup } from '@components/core';
+import { Popup } from '~/components/core';
 
 export default function RootSSHKey() {
   const client = useInstallerClient();

--- a/web/src/components/users/RootSSHKey.test.jsx
+++ b/web/src/components/users/RootSSHKey.test.jsx
@@ -22,11 +22,11 @@
 import React from "react";
 
 import { act, screen, waitFor, within } from "@testing-library/react";
-import { installerRender, createCallbackMock } from "@/test-utils";
-import { createClient } from "@client";
-import { RootSSHKey } from "@components/users";
+import { installerRender, createCallbackMock } from "~/test-utils";
+import { createClient } from "~/client";
+import { RootSSHKey } from "~/components/users";
 
-jest.mock("@client");
+jest.mock("~/client");
 
 let sshKey;
 const getRootSSHKeyFn = () => Promise.resolve(sshKey);

--- a/web/src/components/users/Users.jsx
+++ b/web/src/components/users/Users.jsx
@@ -21,9 +21,9 @@
 
 import React, { useEffect, useState } from "react";
 
-import { useInstallerClient } from "@context/installer";
-import { Section } from "@components/core";
-import { FirstUser, RootPassword, RootSSHKey } from "@components/users";
+import { useInstallerClient } from "~/context/installer";
+import { Section } from "~/components/core";
+import { FirstUser, RootPassword, RootSSHKey } from "~/components/users";
 
 export default function Users({ showErrors }) {
   const [errors, setErrors] = useState([]);

--- a/web/src/context/installer.jsx
+++ b/web/src/context/installer.jsx
@@ -23,14 +23,14 @@
 
 import React, { useState, useEffect } from "react";
 import cockpit from "../lib/cockpit";
-import { createClient } from "@/client";
+import { createClient } from "~/client";
 
 const InstallerClientContext = React.createContext(undefined);
 
 /**
  * Returns the D-Bus installer client
  *
- * @return {import("@client").InstallerClient}
+ * @return {import("~/client").InstallerClient}
  */
 function useInstallerClient() {
   const context = React.useContext(InstallerClientContext);
@@ -45,7 +45,7 @@ const BUS_ADDRESS_FILE = "/run/d-installer/bus.address";
 
 /**
   * @param {object} props
-  * @param {import("@client").InstallerClient|undefined} [props.client] client to connect to
+  * @param {import("~/client").InstallerClient|undefined} [props.client] client to connect to
   *   D-Installer service; if it is undefined, it instantiates a new one using the address
   *   registered in /run/d-installer/bus.address.
   * @param {React.ReactNode} [props.children] - content to display within the provider

--- a/web/src/context/software.jsx
+++ b/web/src/context/software.jsx
@@ -20,7 +20,7 @@
  */
 
 import React, { useEffect } from "react";
-import { useCancellablePromise } from "@/utils";
+import { useCancellablePromise } from "~/utils";
 import { useInstallerClient } from "./installer";
 
 const SoftwareContext = React.createContext();

--- a/web/src/index.js
+++ b/web/src/index.js
@@ -25,19 +25,19 @@ import "core-js/stable";
 import "regenerator-runtime/runtime";
 
 import { HashRouter, Routes, Route } from "react-router-dom";
-import { InstallerClientProvider } from "@context/installer";
-import { SoftwareProvider } from "@context/software";
-import { createClient } from "@/client";
+import { InstallerClientProvider } from "~/context/installer";
+import { SoftwareProvider } from "~/context/software";
+import { createClient } from "~/client";
 
-import "@assets/fonts.css";
+import "~/assets/fonts.css";
 import "@patternfly/patternfly/patternfly-base.scss";
-import "@assets/styles/index.scss";
+import "~/assets/styles/index.scss";
 
-import App from "@/App";
-import Main from "@/Main";
-import { Overview } from "@components/overview";
-import { ProductSelectionPage } from "@components/software";
-import { ProposalPage as StoragePage } from "@components/storage";
+import App from "~/App";
+import Main from "~/Main";
+import { Overview } from "~/components/overview";
+import { ProductSelectionPage } from "~/components/software";
+import { ProposalPage as StoragePage } from "~/components/storage";
 
 ReactDOM.render(
   <StrictMode>

--- a/web/src/test-utils.js
+++ b/web/src/test-utils.js
@@ -29,8 +29,8 @@ import React from "react";
 import userEvent from "@testing-library/user-event";
 import { render } from "@testing-library/react";
 
-import { createClient } from "@client/index";
-import { InstallerClientProvider } from "@context/installer";
+import { createClient } from "~/client/index";
+import { InstallerClientProvider } from "~/context/installer";
 
 const InstallerProvider = ({ children }) => {
   const client = createClient();

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -9,14 +9,14 @@
     "jsx": "react",
     "allowSyntheticDefaultImports": true,
     "paths": {
-      "@/*": ["src/*"],
-      "@assets/*": ["src/assets/*"],
-      "@client": ["src/client/index.js"],
-      "@client/*": ["src/client/*"],
-      "@components/*": ["src/components/*"],
-      "@context/*": ["src/context/*"],
-      "@lib/*": ["src/lib/*"],
-      "~icons/*": ["node_modules/@material-symbols/svg-400/outlined/*"]
+      "~/*": ["src/*"],
+      "~/assets/*": ["src/assets/*"],
+      "~/client": ["src/client/index.js"],
+      "~/client/*": ["src/client/*"],
+      "~/components/*": ["src/components/*"],
+      "~/context/*": ["src/context/*"],
+      "~/lib/*": ["src/lib/*"],
+      "@icons/*": ["node_modules/@material-symbols/svg-400/outlined/*"]
     }
   },
   "include": [

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -10,12 +10,7 @@
     "allowSyntheticDefaultImports": true,
     "paths": {
       "~/*": ["src/*"],
-      "~/assets/*": ["src/assets/*"],
       "~/client": ["src/client/index.js"],
-      "~/client/*": ["src/client/*"],
-      "~/components/*": ["src/components/*"],
-      "~/context/*": ["src/context/*"],
-      "~/lib/*": ["src/lib/*"],
       "@icons/*": ["node_modules/@material-symbols/svg-400/outlined/*"]
     }
   },


### PR DESCRIPTION
Because "@" is used by npm for packages published under a [named scope](https://docs.npmjs.com/about-scopes). From their documentation:

  > The scope name is everything between the @ and the slash

Additionally, "~" use to kind of means "home" or "root", which suits well for an alias pointing to the "root" directory.

Consequently, it is easier to understand now whether an import comes from a dependency or the source code of the project.

---

Related to https://github.com/yast/d-installer/pull/325 and https://github.com/yast/d-installer/pull/325/commits/f33e3273833bd7b3dae17d4861126befb0dd5c35
