### PR TITLE
yupdate - allow building the web frontend in the development mode

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -115,7 +115,18 @@ if File.exist?("/.packages.initrd") || `mount`.match?(/^[\w]+ on \/ type overlay
 
     puts "Installing the Web frontend..."
     Dir.chdir("web") do
-      sh "NODE_ENV=production make install"
+      node_env = ENV["NODE_ENV"] || "production"
+      sh "NODE_ENV=#{node_env.shellescape} make install"
+
+      # clean up the extra files when switching the development/production mode
+      if node_env == "production"
+        # remove the uncompressed and development files
+        FileUtils.rm_f(Dir.glob("/usr/share/cockpit/d-installer/index.{css,html,js}"))
+        FileUtils.rm_f(Dir.glob("/usr/share/cockpit/d-installer/*.map"))
+      else
+        # remove the compressed files
+        FileUtils.rm_f(Dir.glob("/usr/share/cockpit/d-installer/*.gz"))
+      end
     end
   end
 end


### PR DESCRIPTION
## Problem

The `yupdate` script builds the web frontend in the production mode. That has some disadvantages:
- The debugging files (`*.map`) are missing, you cannot get a reference to the original sources, this makes debugging more difficult
- The build takes longer time

## Solution

- Allow reading the `NODE_ENV` value from the current environment

## Testing

- Tested manually with `NODE_ENV=development yupdate ...`

