### PR TITLE
Update the systemd service file

### DIFF
--- a/service/share/systemd.service
+++ b/service/share/systemd.service
@@ -1,13 +1,11 @@
 [Unit]
 Description=D-Installer Service
-Requires=dbus.socket cockpit.socket
+Requires=cockpit.socket
 After=network-online.target
 
 [Service]
-Type=dbus
-BusName=org.opensuse.DInstaller
-ExecStart=/usr/bin/d-installer manager
-ExecStop=/usr/bin/d-installer -k
+Type=simple
+ExecStart=/usr/bin/d-installer
 User=root
 TimeoutStopSec=5
 


### PR DESCRIPTION
## Problem

- The service uses a private DBus, it does not connect to the system bus anymore
- Starting the service does not work properly

## Solution

- Use a standard service type and remove the DBus references

## Testing

- Tested manually, works fine
