### PR TITLE
Added a button for displaying the YaST logs

### DIFF
--- a/web/package/cockpit-d-installer.changes
+++ b/web/package/cockpit-d-installer.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jan 24 09:32:13 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
+
+- Added a button for displaying the YaST logs
+  (related to gh#yast/d-installer#379)
+
+-------------------------------------------------------------------
 Fri Jan 20 09:03:22 UTC 2023 - David Diaz <dgonzalez@suse.com>
 
 - UI fixes (gh#yast/d-installer#401):

--- a/web/src/components/core/LogPopup.jsx
+++ b/web/src/components/core/LogPopup.jsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) [2023] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React, { useState } from "react";
+import { Popup } from "~/components/core";
+import { classNames } from "~/utils";
+
+import "./logpopup.scss";
+
+export default function LogPopup({ className, log, onCloseCallback, title }) {
+  const [isOpen, setIsOpen] = useState(true);
+
+  const close = () => {
+    setIsOpen(false);
+    if (onCloseCallback) onCloseCallback();
+  };
+
+  const lines = log.split("\n").map((line, index) => {
+    return <div className="d-installer-logline" key={`log-line-${index}`}>{line}</div>;
+  });
+
+  return (
+    <>
+      <Popup
+        isOpen={isOpen}
+        title={title}
+        variant="large"
+      >
+        <div className={classNames("d-installer-logpopup", className)}>
+          {lines}
+        </div>
+
+        <Popup.Actions>
+          <Popup.Confirm onClick={close} autoFocus>Close</Popup.Confirm>
+        </Popup.Actions>
+      </Popup>
+    </>
+  );
+}

--- a/web/src/components/core/ShowLogButton.jsx
+++ b/web/src/components/core/ShowLogButton.jsx
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) [2023] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React, { useState } from "react";
+import { useCancellablePromise } from "~/utils";
+import { LogPopup } from "~/components/core";
+import { Icon } from "~/components/layout";
+import { Alert, Button } from "@patternfly/react-core";
+import cockpit from "../../lib/cockpit";
+
+/**
+ * Button for displaying the YaST logs
+ *
+ * @component
+ *
+ * @param {object} props
+ */
+const ShowLogButton = (props) => {
+  const { cancellablePromise } = useCancellablePromise();
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [log, setLog] = useState(null);
+
+  const loadLog = () => {
+    setError(null);
+    setIsLoading(true);
+    cancellablePromise(cockpit.file(props.file).read())
+      .then((content) => {
+        console.log(props.file, " size: ", content.length);
+        if (props.onShowCallback) props.onShowCallback();
+        setLog(content);
+      })
+      .catch(setError)
+      .finally(() => setIsLoading(false));
+  };
+
+  const resetLog = () => setLog(null);
+
+  return (
+    <>
+      <Button
+        variant="link"
+        onClick={loadLog}
+        isLoading={isLoading}
+        isDisabled={isLoading}
+        icon={isLoading ? null : <Icon name="description" size="24" />}
+      >
+        Show Logs
+      </Button>
+
+      { error &&
+        <Alert
+          isInline
+          isPlain
+          variant="warning"
+          title="Cannot read the log file."
+        /> }
+
+      { log &&
+        <LogPopup
+          title={props.title}
+          log={log}
+          onCloseCallback={resetLog}
+        /> }
+    </>
+  );
+};
+
+export default ShowLogButton;

--- a/web/src/components/core/Sidebar.jsx
+++ b/web/src/components/core/Sidebar.jsx
@@ -21,7 +21,7 @@
 
 import React, { useState } from "react";
 import { Icon, PageActions } from "~/components/layout";
-import { About, ChangeProductButton, LogsButton } from "~/components/core";
+import { About, ChangeProductButton, LogsButton, ShowLogButton } from "~/components/core";
 import { TargetIpsPopup } from "~/components/network";
 
 /**
@@ -64,6 +64,7 @@ export default function Sidebar() {
           <About onClickCallback={close} />
           <TargetIpsPopup onClickCallback={close} />
           <LogsButton />
+          <ShowLogButton onShowCallback={close} file="/var/log/YaST2/y2log" title="YaST Logs" />
         </div>
 
         <footer className="split" data-state="reversed">

--- a/web/src/components/core/index.js
+++ b/web/src/components/core/index.js
@@ -30,6 +30,8 @@ export { default as InstallButton } from "./InstallButton";
 export { default as InstallerSkeleton } from "./InstallerSkeleton";
 export { default as KebabMenu } from "./KebabMenu";
 export { default as LogsButton } from "./LogsButton";
+export { default as LogPopup } from "./LogPopup";
+export { default as ShowLogButton } from "./ShowLogButton";
 export { default as PasswordAndConfirmationInput } from "./PasswordAndConfirmationInput";
 export { default as Popup } from "./Popup";
 export { default as ProgressReport } from "./ProgressReport";

--- a/web/src/components/core/logpopup.scss
+++ b/web/src/components/core/logpopup.scss
@@ -1,0 +1,12 @@
+div.d-installer-logpopup {
+  word-break: break-all;
+  white-space: pre-wrap;
+  font-family: var(--pf-global--FontFamily--monospace);
+  font-size: 80%;
+}
+
+div.d-installer-logline {
+  &:hover {
+    background-color: var(--color-gray-dark);
+  }
+}

--- a/web/src/components/layout/Icon.jsx
+++ b/web/src/components/layout/Icon.jsx
@@ -52,11 +52,13 @@ import Delete from "@icons/delete.svg?component";
 import Warning from "@icons/warning.svg?component";
 import Apps from "@icons/apps.svg?component";
 import Loading from "./three-dots-loader-icon.svg?component";
+import Description from "@icons/description.svg?component";
 
 const icons = {
   apps: Apps,
   check_circle: CheckCircle,
   delete: Delete,
+  description: Description,
   download: Download,
   downloading: Downloading,
   edit: Edit,


### PR DESCRIPTION
## Problem

- It should be possible to easily see the YaST logs from the UI to make debugging easier
- Related to gh#yast/d-installer#379

## Solution

- Added a new button which opens a popup with the `y2log` file
- So far a simple solution, no message colorizing or filtering. We can improve it later.

## Testing

- Tested manually

## TODO

- [ ] Unit tests

## Screenshots

| Options Menu  | Log Popup |
| ------------- | ------------- |
| ![log_view_button](https://user-images.githubusercontent.com/907998/214262839-8bcc69c2-c06d-42b9-bfff-4a8c75091cf1.png)  | ![log_view_popup](https://user-images.githubusercontent.com/907998/214262869-89ef5f69-5e50-47b5-bc62-7e3a0e9b28f4.png)  |



