### PR TITLE
Fix product change

### DIFF
--- a/service/lib/dinstaller/software/manager.rb
+++ b/service/lib/dinstaller/software/manager.rb
@@ -63,7 +63,6 @@ module DInstaller
 
       def initialize(config, logger)
         @config = config
-        @probed = false
         @logger = logger
         @languages = DEFAULT_LANGUAGES
         @products = @config.products
@@ -82,7 +81,6 @@ module DInstaller
 
         @config.pick_product(name)
         @product = name
-        @probed = false # reset probing when product changed
         repositories.delete_all
       end
 

--- a/service/lib/dinstaller/software/manager.rb
+++ b/service/lib/dinstaller/software/manager.rb
@@ -83,6 +83,7 @@ module DInstaller
         @config.pick_product(name)
         @product = name
         @probed = false # reset probing when product changed
+        repositories.delete_all
       end
 
       def probe

--- a/service/lib/dinstaller/software/manager.rb
+++ b/service/lib/dinstaller/software/manager.rb
@@ -115,7 +115,7 @@ module DInstaller
 
       # Updates the software proposal
       def propose
-        proposal.base_product = @product
+        proposal.base_product = selected_base_product
         proposal.languages = languages
         select_resolvables
         result = proposal.calculate
@@ -216,6 +216,10 @@ module DInstaller
 
       def installation_repositories
         @config.data["software"]["installation_repositories"]
+      end
+
+      def selected_base_product
+        @config.data["software"]["base_product"]
       end
 
       def add_base_repos

--- a/service/lib/dinstaller/software/repositories_manager.rb
+++ b/service/lib/dinstaller/software/repositories_manager.rb
@@ -77,6 +77,12 @@ module DInstaller
         end
         Yast::Pkg.SourceLoad
       end
+
+      # Deletes all the repositories
+      def delete_all
+        repositories.each(&:delete!)
+        repositories.clear
+      end
     end
   end
 end

--- a/service/test/dinstaller/software/manager_test.rb
+++ b/service/test/dinstaller/software/manager_test.rb
@@ -37,9 +37,10 @@ describe DInstaller::Software::Manager do
   let(:repositories) do
     instance_double(
       DInstaller::Software::RepositoriesManager,
-      add:    nil,
-      load:   nil,
-      empty?: true
+      add:        nil,
+      load:       nil,
+      delete_all: nil,
+      empty?:     true
     )
   end
   let(:proposal) do

--- a/service/test/dinstaller/software/manager_test.rb
+++ b/service/test/dinstaller/software/manager_test.rb
@@ -141,7 +141,7 @@ describe DInstaller::Software::Manager do
 
     it "creates a new proposal for the selected product" do
       expect(proposal).to receive(:languages=).with(["en_US"])
-      expect(proposal).to receive(:base_product=).with("Tumbleweed")
+      expect(proposal).to receive(:base_product=).with("openSUSE")
       expect(proposal).to receive(:calculate)
       subject.propose
     end

--- a/service/test/dinstaller/software/repositories_manager_test.rb
+++ b/service/test/dinstaller/software/repositories_manager_test.rb
@@ -73,6 +73,19 @@ describe DInstaller::Software::RepositoriesManager do
     end
   end
 
+  describe "#delete_all" do
+    before do
+      subject.repositories << repo
+      subject.repositories << disabled_repo
+    end
+
+    it "deletes all the repositories" do
+      expect(repo).to receive(:delete!)
+      expect(disabled_repo).to receive(:delete!)
+      subject.delete_all
+    end
+  end
+
   describe "#enabled" do
     before do
       subject.repositories << repo


### PR DESCRIPTION
Fix two issues related to #414:

* Select the proper product when the name are different from the `base_product` key.
* Remove the old repositories when the product changes.

I have not included the entry in the changes file because it is a bugfix for #414 and we have not released that version yet.