### PR TITLE
[web] Use a specific manifest.json file for development

### DIFF
--- a/web/src/manifest.dev.json
+++ b/web/src/manifest.dev.json
@@ -8,5 +8,6 @@
         "index": {
             "label": "D-Installer"
         }
-    }
+    },
+    "content-security-policy": "connect-src 'self' https://localhost:9090 wss://localhost:9090 ws://localhost:8080"
 }

--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -29,7 +29,10 @@ const packageJson = JSON.parse(fs.readFileSync('package.json'));
 // Non-JS files which are copied verbatim to dist/
 const copy_files = [
   "./src/index.html",
-  "./src/manifest.json",
+  {
+    from: production ? "./src/manifest.json" : "./src/manifest.dev.json",
+    to: "manifest.json"
+  },
   // TODO: consider using something more complete like https://github.com/jantimon/favicons-webpack-plugin
   "./src/assets/favicon.svg",
 ];


### PR DESCRIPTION
## Problem

We've changed the [`content-security-policy`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy) in https://github.com/yast/d-installer/pull/419 via [manifest](https://cockpit-project.org/guide/latest/packages.html#package-manifest) file for allowing [HMR](https://webpack.js.org/concepts/hot-module-replacement/). However, that change must not reach a production environment.

## Solution

Added a `manifest.dev.json` and keep `manifest.json` as it was. Depending on the `NODE_ENV` value the resulting _div/manifest.json_ will contain the proper settings.

## Testing

Tested manually by running `npm run build` and `NODE_ENV=production npm run build` and checking the content of the _dist/manifest.json_
