### PR TITLE
[service] Start the daemon in the systemd service

### DIFF
--- a/service/bin/d-installer
+++ b/service/bin/d-installer
@@ -111,8 +111,7 @@ elsif ["-k", "--kill"].include?(ARGV[0])
   dbus_server_manager.stop_server
 elsif ["-d", "--daemon"].include?(ARGV[0])
   # start the D-Bus server
-  pid = dbus_server_manager.find_or_start_server
-  puts pid
+  dbus_server_manager.find_or_start_server
 else
   dbus_server_manager.find_or_start_server
   name = ARGV[0]

--- a/service/bin/d-installer
+++ b/service/bin/d-installer
@@ -57,7 +57,7 @@ end
 def start_service(name)
   general_y2dir = File.expand_path("../lib/dinstaller/dbus/y2dir", __dir__)
   module_y2dir = File.expand_path("../lib/dinstaller/dbus/y2dir/#{name}", __dir__)
-  ENV["Y2DIR"] = [ENV["Y2DIR"], module_y2dir, general_y2dir].compact.join(":")
+  ENV["Y2DIR"] = [ENV.fetch("Y2DIR", nil), module_y2dir, general_y2dir].compact.join(":")
 
   service_runner = DInstaller::DBus::ServiceRunner.new(name, logger: logger_for(name))
   service_runner.run

--- a/service/lib/dinstaller/dbus/server_manager.rb
+++ b/service/lib/dinstaller/dbus/server_manager.rb
@@ -19,7 +19,6 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-require "cheetah"
 require "fileutils"
 
 module DInstaller
@@ -55,20 +54,20 @@ module DInstaller
       def start_server
         FileUtils.mkdir_p(run_directory)
 
-        output = Cheetah.run(
+        cmd = [
           "/usr/bin/dbus-daemon",
           "--config-file", config_file,
           "--address", address,
-          "--fork", "--systemd-activation",
-          "--print-pid",
-          stdout: :capture
-        )
+          "--systemd-activation",
+          "--print-pid"
+        ]
+        pid = Process.spawn(*cmd)
+        Process.detach(pid)
         File.write(address_file, address)
-        pid = output.strip
         File.write(pid_file, pid)
-        pid.to_i
-      rescue Cheetah::ExecutionFailed => e
-        puts "Could not start the DBus daemon: #{e.message}"
+        pid
+      rescue SystemCallError => e
+        warn "Could not start the DBus daemon: #{e.message}"
         nil
       end
 

--- a/service/share/systemd.service
+++ b/service/share/systemd.service
@@ -5,7 +5,7 @@ After=network-online.target
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/d-installer
+ExecStart=/usr/bin/d-installer --daemon
 User=root
 TimeoutStopSec=5
 

--- a/service/share/systemd.service
+++ b/service/share/systemd.service
@@ -6,6 +6,7 @@ After=network-online.target
 [Service]
 Type=simple
 ExecStart=/usr/bin/d-installer --daemon
+PIDFile=/run/d-installer/bus.pid
 User=root
 TimeoutStopSec=5
 

--- a/service/test/dinstaller/dbus/server_manager_test.rb
+++ b/service/test/dinstaller/dbus/server_manager_test.rb
@@ -31,7 +31,8 @@ describe DInstaller::DBus::ServerManager do
   let(:tmpdir) { Dir.mktmpdir }
 
   before do
-    allow(Cheetah).to receive(:run).and_return("9999")
+    allow(Process).to receive(:spawn).and_return(9999)
+    allow(Process).to receive(:detach)
   end
 
   after do
@@ -63,9 +64,10 @@ describe DInstaller::DBus::ServerManager do
 
   describe "#start_server" do
     it "starts the dbus-daemon and returns the PID" do
-      expect(Cheetah).to receive(:run)
+      expect(Process).to receive(:spawn)
         .with(/dbus-daemon/, "--config-file", /dbus.conf/, any_args)
-        .and_return("1000")
+        .and_return(1000)
+      expect(Process).to receive(:detach).with(1000)
       expect(subject.start_server).to eq(1000)
     end
 

--- a/web/src/client/dbus.js
+++ b/web/src/client/dbus.js
@@ -130,6 +130,29 @@ class DBusClient {
   }
 
   /**
+   * Gets a property for a given path and interface
+   *
+   * @param {string} path - D-Bus object path
+   * @param {string} iface - D-Bus interface name
+   * @param {string} name - D-Bus property name
+   * @return {Promise<any>}
+   */
+  async getProperty(path, iface, name) {
+    let property;
+
+    try {
+      const result = await this.client.call(
+        path, "org.freedesktop.DBus.Properties", "Get", [iface, "Errors"]
+      );
+      property = result[0];
+    } catch (error) {
+      console.warn(`Could not get the ${name} property in ${iface}`, error);
+    }
+
+    return (property === undefined) ? null : property.v;
+  }
+
+  /**
    * Register a callback to run when properties change for given D-Bus path
    *
    * @param {string} path - D-Bus path

--- a/web/src/client/mixins.js
+++ b/web/src/client/mixins.js
@@ -155,8 +155,16 @@ const WithValidation = (superclass, object_path) => class extends superclass {
    * @return {Promise<ValidationError[]>}
    */
   async getValidationErrors() {
-    const proxy = await this.client.proxy(VALIDATION_IFACE, object_path);
-    return proxy.Errors.map(createError);
+    let errors;
+
+    try {
+      const result = await this.client.call(object_path, "org.freedesktop.DBus.Properties", "Get", [VALIDATION_IFACE, "Errors"]);
+      errors = result[0];
+    } catch (error) {
+      console.error(`Could not get the errors for ${object_path}`, error);
+    }
+
+    return errors.v.map(createError);
   }
 
   /**

--- a/web/src/client/mixins.js
+++ b/web/src/client/mixins.js
@@ -158,13 +158,12 @@ const WithValidation = (superclass, object_path) => class extends superclass {
     let errors;
 
     try {
-      const result = await this.client.call(object_path, "org.freedesktop.DBus.Properties", "Get", [VALIDATION_IFACE, "Errors"]);
-      errors = result[0];
+      errors = await this.client.getProperty(object_path, VALIDATION_IFACE, "Errors");
     } catch (error) {
-      console.error(`Could not get the errors for ${object_path}`, error);
+      console.error(`Could not get validation errors for ${object_path}`, error);
     }
 
-    return errors.v.map(createError);
+    return errors.map(createError);
   }
 
   /**

--- a/web/src/components/overview/StorageSection.jsx
+++ b/web/src/components/overview/StorageSection.jsx
@@ -32,7 +32,7 @@ import { InstallerSkeleton, Section } from "~/components/core";
 import { ProposalSummary } from "~/components/storage";
 
 const initialState = {
-  busy: false,
+  busy: true,
   proposal: undefined,
   errors: []
 };


### PR DESCRIPTION
## Problem

* D-Installer components crash in the installation media because the services are not started properly.

## Solution

On the one hand, we are *spawning* a process with the `dbus-daemon`. The rest of the services are activated properly.

After implementing the previous fix, I detected that the UI cannot get the validation errors for the storage layer. It cannot create the proxy and the component is not updated anymore. To fix this problem, I changed the implementation of the `getValidationErrors()` method to handle potential errors and not rely on proxies (better performance).

## Testing

- *Tested manually*