### PR TITLE
Support modern `fde-tools`

### DIFF
--- a/service/etc/d-installer.yaml
+++ b/service/etc/d-installer.yaml
@@ -149,9 +149,9 @@ Tumbleweed:
 ALP:
   software:
     installation_repositories:
-      - url: https://download.opensuse.org/repositories/SUSE:/ALP:/ToTest/images/repo/ALP-0.1-x86_64-Media1/
+      - url: https://download.opensuse.org/repositories/SUSE:/ALP/standard/
         archs: x86_64
-      - url: https://download.opensuse.org/repositories/SUSE:/ALP:/ToTest/images/repo/ALP-0.1-aarch64-Media1/
+      - url: https://download.opensuse.org/repositories/SUSE:/ALP/standard/
         archs: aarch64
     mandatory_patterns:
       - alp_base


### PR DESCRIPTION
## Problem

D-Installer in its current version is not really that useful for those developers working on the fde-tools.

First of all, it installs a relatively old version of ALP.

On the other hand, it executes the `fdectl` from the installation media, not always the latest one available at the ALP repositories.

Moreover, it skips invocation to `fdectl` if LVM is used. That's because previous versions of `fdectl` didn't support the scenario. Modern versions do.

## Solution

1) Install ALP from the repositories that contain the latest and greatest version of all ALP packages, instead of the most stable ones at the ToTest repository. That should be useful for everybody working on ALP development, not only the developers of `fdectl`. It also provides a more accurate view on ALP's current state.

2) Remove several hacks and workarounds that were introduced in the invocation of `fdectl` (like enforcing a `--target` argument). Now the tool is more polished and doesn't need that anymore.

3) Run `fdectl` from the target installed system (via chroot), instead of the version provided in the installation media. In fact, the installation media doesn't need to include `fde-tools` anymore.

4) Execute `fdectl` even if LVM is used in the storage proposal. It works with current versions of `fde-tools`.

## Testing

Extensively tested manually with a virtual TPMv2 (libvirt).

The key enrollment performed during the first boot throws some errors to the systemd journal, but from the user point of view everything works as expected. The system boots without requesting a passphrase and, after the first boot, there are only two key slots in the LUKS2 device (one for passphrase and another for the TPM, I assume).
