### PR TITLE
[web] Sidebar/Hamburger menu improvements

### DIFF
--- a/web/package/cockpit-d-installer.changes
+++ b/web/package/cockpit-d-installer.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Feb 20 22:52:48 UTC 2023 - David Diaz <dgonzalez@suse.com>
+
+- Sidebar improvements (gh#yast/d-installer#436)
+  * Use proper control for open and close actions
+  * Improve styling and labels
+  * Add missing aria attributes
+
+-------------------------------------------------------------------
 Thu Feb 16 12:56:24 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
 
 - Integrate cockpit terminal application (gh#yast/d-installer#426)

--- a/web/src/assets/styles/blocks.scss
+++ b/web/src/assets/styles/blocks.scss
@@ -64,6 +64,10 @@ section > .content {
   box-shadow: 0 0 20px 10px var(--color-primary-darkest);
 }
 
+.sidebar header {
+  --focus-color: var(--color-primary-darkest);
+}
+
 .sidebar footer {
   border-top: 1px solid var(--color-gray);
 }

--- a/web/src/assets/styles/layout.scss
+++ b/web/src/assets/styles/layout.scss
@@ -28,12 +28,13 @@
 }
 
 .wrapper > header {
-  --color-button-plain-link: white;
-  --color-button-plain-link-hover: #fcfcfc;
-
   grid-area: header;
   background: var(--color-background-primary);
   color: var(--color-text-secondary);
+
+  svg {
+    color: white;
+  }
 }
 
 .wrapper > main {

--- a/web/src/assets/styles/utilities.scss
+++ b/web/src/assets/styles/utilities.scss
@@ -99,6 +99,11 @@
   box-shadow: 0 -3px 10px 0 var(--color-gray-darker);
 }
 
+.plain-control {
+  background: none;
+  border: none;
+}
+
 .tallest {
   /** block-size fallbacks **/
   height: 95dvh;

--- a/web/src/components/core/Sidebar.jsx
+++ b/web/src/components/core/Sidebar.jsx
@@ -19,7 +19,7 @@
  * find current contact information at www.suse.com.
  */
 
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Icon, PageActions } from "~/components/layout";
 import { About, ChangeProductButton, LogsButton, ShowLogButton, ShowTerminalButton } from "~/components/core";
 import { TargetIpsPopup } from "~/components/network";
@@ -29,9 +29,14 @@ import { TargetIpsPopup } from "~/components/network";
  */
 export default function Sidebar() {
   const [isOpen, setIsOpen] = useState(false);
+  const closeButtonRef = useRef(null);
 
   const open = () => setIsOpen(true);
   const close = () => setIsOpen(false);
+
+  useEffect(() => {
+    if (isOpen) closeButtonRef.current.focus();
+  }, [isOpen]);
 
   return (
     <>
@@ -57,6 +62,7 @@ export default function Sidebar() {
 
           <button
             onClick={close}
+            ref={closeButtonRef}
             aria-label="Close D-Installer options"
           >
             <Icon name="menu_open" data-variant="flip-X" onClick={close} />

--- a/web/src/components/core/Sidebar.jsx
+++ b/web/src/components/core/Sidebar.jsx
@@ -43,6 +43,7 @@ export default function Sidebar() {
       <PageActions>
         <button
           onClick={open}
+          className="plain-control"
           aria-label="Open D-Installer options"
           aria-controls="navigation-and-options"
           aria-expanded={isOpen}
@@ -63,6 +64,7 @@ export default function Sidebar() {
           <button
             onClick={close}
             ref={closeButtonRef}
+            className="plain-control"
             aria-label="Close D-Installer options"
           >
             <Icon name="menu_open" data-variant="flip-X" onClick={close} />

--- a/web/src/components/core/Sidebar.jsx
+++ b/web/src/components/core/Sidebar.jsx
@@ -44,7 +44,7 @@ export default function Sidebar() {
         <button
           onClick={open}
           className="plain-control"
-          aria-label="Open D-Installer options"
+          aria-label="Show navigation and other options"
           aria-controls="navigation-and-options"
           aria-expanded={isOpen}
         >
@@ -53,10 +53,10 @@ export default function Sidebar() {
       </PageActions>
 
       <nav
-        aria-label="D-Installer options"
-        data-state={isOpen ? "visible" : "hidden"}
         id="navigation-and-options"
         className="wrapper sidebar"
+        aria-label="Navigation and other options"
+        data-state={isOpen ? "visible" : "hidden"}
       >
         <header className="split justify-between">
           <h1>Options</h1>
@@ -65,7 +65,7 @@ export default function Sidebar() {
             onClick={close}
             ref={closeButtonRef}
             className="plain-control"
-            aria-label="Close D-Installer options"
+            aria-label="Hide navigation and other options"
           >
             <Icon name="menu_open" data-variant="flip-X" onClick={close} />
           </button>

--- a/web/src/components/core/Sidebar.jsx
+++ b/web/src/components/core/Sidebar.jsx
@@ -30,20 +30,18 @@ import { TargetIpsPopup } from "~/components/network";
 export default function Sidebar() {
   const [isOpen, setIsOpen] = useState(false);
 
-  const open = (e) => {
-    // Avoid the link navigating to the initial route
-    e.preventDefault();
-
-    setIsOpen(true);
-  };
+  const open = () => setIsOpen(true);
   const close = () => setIsOpen(false);
 
   return (
     <>
       <PageActions>
-        <a href="#" onClick={open} aria-label="Open D-Installer options">
+        <button
+          onClick={open}
+          aria-label="Open D-Installer options"
+        >
           <Icon name="menu" onClick={open} />
-        </a>
+        </button>
       </PageActions>
 
       <nav
@@ -54,9 +52,12 @@ export default function Sidebar() {
         <header className="split justify-between">
           <h1>Options</h1>
 
-          <a href="#" onClick={close} aria-label="Close D-Installer options">
+          <button
+            onClick={close}
+            aria-label="Close D-Installer options"
+          >
             <Icon name="menu_open" data-variant="flip-X" onClick={close} />
-          </a>
+          </button>
         </header>
 
         <div className="flex-stack">

--- a/web/src/components/core/Sidebar.jsx
+++ b/web/src/components/core/Sidebar.jsx
@@ -39,6 +39,8 @@ export default function Sidebar() {
         <button
           onClick={open}
           aria-label="Open D-Installer options"
+          aria-controls="navigation-and-options"
+          aria-expanded={isOpen}
         >
           <Icon name="menu" onClick={open} />
         </button>
@@ -47,6 +49,7 @@ export default function Sidebar() {
       <nav
         aria-label="D-Installer options"
         data-state={isOpen ? "visible" : "hidden"}
+        id="navigation-and-options"
         className="wrapper sidebar"
       >
         <header className="split justify-between">

--- a/web/src/components/core/Sidebar.test.jsx
+++ b/web/src/components/core/Sidebar.test.jsx
@@ -61,6 +61,17 @@ it("renders a link for hidding the sidebar", async () => {
   expect(nav).toHaveAttribute("data-state", "hidden");
 });
 
+it("moves the focus to the close action after opening it", async () => {
+  const { user } = plainRender(<Sidebar />);
+
+  const openLink = await screen.findByLabelText(/Show/i);
+  const closeLink = await screen.findByLabelText(/Hide/i);
+
+  expect(closeLink).not.toHaveFocus();
+  await user.click(openLink);
+  expect(closeLink).toHaveFocus();
+});
+
 describe("Sidebar content", () => {
   it("contains the component for changing the selected product", async () => {
     plainRender(<Sidebar />);

--- a/web/src/components/core/Sidebar.test.jsx
+++ b/web/src/components/core/Sidebar.test.jsx
@@ -39,7 +39,7 @@ it("renders the sidebar initially hidden", async () => {
 it("renders a link for displaying the sidebar", async () => {
   const { user } = plainRender(<Sidebar />);
 
-  const link = await screen.findByLabelText(/Open/i);
+  const link = await screen.findByLabelText(/Show/i);
   const nav = await screen.findByRole("navigation", { name: /options/i });
 
   expect(nav).toHaveAttribute("data-state", "hidden");
@@ -50,8 +50,8 @@ it("renders a link for displaying the sidebar", async () => {
 it("renders a link for hidding the sidebar", async () => {
   const { user } = plainRender(<Sidebar />);
 
-  const openLink = await screen.findByLabelText(/Open/i);
-  const closeLink = await screen.findByLabelText(/Close/i);
+  const openLink = await screen.findByLabelText(/Show/i);
+  const closeLink = await screen.findByLabelText(/Hide/i);
 
   const nav = await screen.findByRole("navigation", { name: /options/i });
 

--- a/web/src/components/core/Sidebar.test.jsx
+++ b/web/src/components/core/Sidebar.test.jsx
@@ -20,7 +20,7 @@
  */
 
 import React from "react";
-import { screen, within, createEvent, fireEvent } from "@testing-library/react";
+import { screen, within } from "@testing-library/react";
 import { plainRender, mockComponent, mockLayout } from "~/test-utils";
 import { Sidebar } from "~/components/core";
 
@@ -45,18 +45,6 @@ it("renders a link for displaying the sidebar", async () => {
   expect(nav).toHaveAttribute("data-state", "hidden");
   await user.click(link);
   expect(nav).toHaveAttribute("data-state", "visible");
-});
-
-// Test that opening the sidebar does not navigate to the initial route
-// This is achive by preventing the default link click behavior
-// Read https://testing-library.com/docs/dom-testing-library/api-events#fireevent and
-// https://developer.mozilla.org/en-US/docs/Web/API/Event/defaultPrevented
-it("prevents the default event when the user click on the open link", async () => {
-  plainRender(<Sidebar />);
-  const link = await screen.findByLabelText(/Open/i);
-  const clickEvent = createEvent.click(link);
-  fireEvent(link, clickEvent);
-  expect(clickEvent.defaultPrevented).toBe(true);
 });
 
 it("renders a link for hidding the sidebar", async () => {


### PR DESCRIPTION
## Problem

The sidebar component is misusing a `a` control for displaying/hiding its content. This leads to unexpected behavior when closing it: _it navigates to the summary_ too because the `a href="#"` _tells_ the application to do that.


## Solution

To use a `button` control instead of using an `<a >` [preventing its default action :sweat_smile:](https://github.com/yast/d-installer/commit/71b799957595fdaa1e04d68d76244f9a1ecab635) 

---

Related to https://github.com/yast/d-installer/issues/395