### PR TITLE
build always against base ruby version only ( otherwise file conflict…

### DIFF
--- a/service/package/gem2rpm.yml
+++ b/service/package/gem2rpm.yml
@@ -1,6 +1,7 @@
 ---
 :sourceurl: "%{mod_full_name}.gem"
 :preamble: |-
+  # Override build.rpm, see also https://github.com/openSUSE/obs-build/blob/master/configs/
   %global rb_build_versions %{rb_default_ruby}
   BuildRequires:  dbus-1-common
   Requires:       dbus-1-common

--- a/service/package/gem2rpm.yml
+++ b/service/package/gem2rpm.yml
@@ -1,6 +1,7 @@
 ---
 :sourceurl: "%{mod_full_name}.gem"
 :preamble: |-
+  %global rb_build_versions %{rb_default_ruby}
   BuildRequires:  dbus-1-common
   Requires:       dbus-1-common
   Requires:       snapper


### PR DESCRIPTION
… happen due to dbus config)


## Problem

We get multiple reports that new d-installer live iso failed to connect to dbus. Reason is new ruby in TW and failed build due to file conflict when we build against both ruby versions ( conflict in dbus config ).


## Solution

Build always only against system ruby.

also hot fix deployment at https://build.opensuse.org/request/show/1067028 which I will merge when this PR will be merged to have again working live ISO.


## Testing

- testing that it builds in OBS

