### PR TITLE
Fix alp_defaults pattern name

### DIFF
--- a/service/etc/d-installer.yaml
+++ b/service/etc/d-installer.yaml
@@ -158,7 +158,7 @@ ALP:
       - alp_base_zypper
       - alp_cockpit
       - alp-container_runtime
-      - alt_defaults
+      - alp_defaults
     optional_patterns: null # no optional pattern shared
     mandatory_packages:
       - device-mapper # Apparently needed if devices at /dev/mapper are used at boot (eg. FDE)


### PR DESCRIPTION
Fix `alp_defaults` pattern name.
