### PR TITLE
Write the Iguana mountlist

### DIFF
--- a/service/lib/dinstaller/storage/finisher.rb
+++ b/service/lib/dinstaller/storage/finisher.rb
@@ -1,0 +1,295 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2023] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "yast2/execute"
+require "yast2/systemd/service"
+require "bootloader/finish_client"
+require "y2storage/storage_manager"
+require "dinstaller/with_progress"
+require "dinstaller/helpers"
+require "abstract_method"
+
+module DInstaller
+  module Storage
+    # Auxiliary class to handle the last storage-related steps of the installation
+    class Finisher
+      include WithProgress
+      include Helpers
+
+      # Constructor
+      def initialize(logger, config, security)
+        @logger = logger
+        @config = config
+        @security = security
+      end
+
+      # Execute the final storage actions, reporting the progress
+      def run
+        steps = possible_steps.select(&:run?)
+        start_progress(steps.size)
+
+        on_target do
+          steps.each do |step|
+            progress.step(step.label) { step.run }
+          end
+        end
+      end
+
+    private
+
+      # @return [Logger]
+      attr_reader :logger
+
+      # @return [Config]
+      attr_reader :config
+
+      # @return [Security]
+      attr_reader :security
+
+      # All possible steps, that may or not need to be executed
+      def possible_steps
+        [
+          SecurityStep.new(logger, security),
+          BootloaderStep.new(logger),
+          TpmStep.new(logger, config),
+          IguanaStep.new(logger),
+          SnapshotsStep.new(logger),
+          CopyLogsStep.new(logger),
+          UnmountStep.new(logger)
+        ]
+      end
+
+      # Base class for the Finisher steps containing some shared logic
+      class Step
+        # Base constructor
+        def initialize(logger)
+          @logger = logger
+        end
+
+        # Whether this step must be executed
+        def run?
+          true
+        end
+
+        # @!method run
+        #   Executes the step
+        abstract_method :run
+
+        # @!method label
+        #   Sentence to describe the step in the progress report
+        #   @return [String]
+        abstract_method :label
+
+      private
+
+        # @return [Logger]
+        attr_reader :logger
+
+        def wfm_write(function)
+          Yast::WFM.CallFunction(function, ["Write"])
+        end
+
+        # Representation on the staging devicegraph of the root mount point
+        #
+        # @return [Y2Storage::MountPoint]
+        def root_mount_point
+          staging_graph.mount_points.find(&:root?)
+        end
+
+        # @return [Y2Storage::Devicegraph]
+        def staging_graph
+          Y2Storage::StorageManager.instance.staging
+        end
+      end
+
+      # Step to write the security settings
+      class SecurityStep < Step
+        # Constructor
+        def initialize(logger, security)
+          super(logger)
+          @security = security
+        end
+
+        def label
+          "Writing Linux Security Modules configuration"
+        end
+
+        def run
+          @security.write
+        end
+      end
+
+      # Step to write the bootloader configuration
+      class BootloaderStep < Step
+        def label
+          "Installing bootloader"
+        end
+
+        def run
+          ::Bootloader::FinishClient.new.write
+        end
+      end
+
+      # Step to configure the file-system snapshots
+      class SnapshotsStep < Step
+        def label
+          "Configuring file systems snapshots"
+        end
+
+        def run
+          wfm_write("snapshots_finish")
+        end
+      end
+
+      # Step to copy the installation logs
+      class CopyLogsStep < Step
+        def label
+          "Copying logs"
+        end
+
+        def run
+          wfm_write("copy_logs_finish")
+        end
+      end
+
+      # Step to unmount the target file-systems
+      class UnmountStep < Step
+        def label
+          "Unmounting storage devices"
+        end
+
+        def run
+          wfm_write("umount_finish")
+        end
+      end
+
+      # Step to configure LUKS unlocking via TPMv2, if possible
+      class TpmStep < Step
+        # Constructor
+        def initialize(logger, config)
+          super(logger)
+          @config = config
+        end
+
+        def label
+          "Preparing the system to unlock the encryption using the TPM"
+        end
+
+        def run?
+          tpm_product? && tpm_proposal? && tpm_system?
+        end
+
+        def run
+          keyfile_path = File.join("root", ".root.keyfile")
+          Yast::Execute.on_target!(
+            "fdectl", "add-secondary-key", "--keyfile", keyfile_path,
+            stdin:    "#{luks.password}\n",
+            recorder: Yast::ReducedRecorder.new(skip: :stdin)
+          )
+
+          service = Yast2::Systemd::Service.find("fde-tpm-enroll.service")
+          logger.info "FDE: TPM enroll service: #{service}"
+          service&.enable
+        rescue Cheetah::ExecutionFailed
+          false
+        end
+
+      private
+
+        def tpm_proposal?
+          !!luks
+        end
+
+        # LUKS device from the devicegraph
+        #
+        # @return [Y2Storage::Luks, nil] nil if the root mount point is not encrypted
+        def luks
+          root_mount_point.ancestors.find do |dev|
+            dev.is?(:luks)
+          end
+        end
+
+        def tpm_system?
+          Y2Storage::Arch.new.efiboot? && tpm_present?
+        end
+
+        def tpm_present?
+          return @tpm_present unless @tpm_present.nil?
+
+          @tpm_present =
+            begin
+              Yast::Execute.on_target!("fdectl", "tpm-present")
+              logger.info "FDE: TPMv2 detected"
+              true
+            rescue Cheetah::ExecutionFailed
+              logger.info "FDE: TPMv2 not detected"
+              false
+            end
+        end
+
+        def tpm_product?
+          @config.data.fetch("security", {}).fetch("tpm_luks_open", false)
+        end
+      end
+
+      # Step to write the mountlist file for Iguana, if needed
+      class IguanaStep < Step
+        IGUANA_PATH = "/iguana"
+        private_constant :IGUANA_PATH
+        IGUANA_MOUNTLIST = File.join(IGUANA_PATH, "mountlist").freeze
+        private_constant :IGUANA_MOUNTLIST
+
+        def label
+          "Configuring Iguana"
+        end
+
+        def run?
+          File.directory?(IGUANA_PATH)
+        end
+
+        def run
+          File.open(IGUANA_MOUNTLIST, "w") do |list|
+            list.puts "#{root_device_name} /sysroot #{root_mount_options}"
+          end
+        end
+
+      private
+
+        def root_device_name
+          fs = root_mount_point&.filesystem
+          # This should never happen, we must have a root file-system
+          return "" unless fs
+
+          fs.respond_to?(:preferred_name) ? fs.preferred_name : fs.name
+        end
+
+        def root_mount_options
+          options = root_mount_point&.mount_options
+          # This should never happen, we must have a root mount point
+          return "" unless options
+
+          options.empty? ? "defaults" : options.join(",")
+        end
+      end
+    end
+  end
+end

--- a/service/lib/dinstaller/storage/manager.rb
+++ b/service/lib/dinstaller/storage/manager.rb
@@ -20,20 +20,17 @@
 # find current contact information at www.suse.com.
 
 require "yast"
-require "yast2/execute"
-require "yast2/systemd/service"
 require "bootloader/proposal_client"
-require "bootloader/finish_client"
 require "y2storage/storage_manager"
 require "dinstaller/storage/proposal"
 require "dinstaller/storage/proposal_settings"
 require "dinstaller/storage/callbacks"
 require "dinstaller/storage/iscsi/manager"
+require "dinstaller/storage/finisher"
 require "dinstaller/with_progress"
 require "dinstaller/security"
 require "dinstaller/dbus/clients/questions"
 require "dinstaller/dbus/clients/software"
-require "dinstaller/helpers"
 
 Yast.import "PackagesProposal"
 
@@ -42,7 +39,6 @@ module DInstaller
     # Manager to handle storage configuration
     class Manager
       include WithProgress
-      include Helpers
 
       def initialize(config, logger)
         @config = config
@@ -78,31 +74,9 @@ module DInstaller
         end
       end
 
-      # Unmounts the target file system
+      # Performs the final steps on the target file system(s)
       def finish
-        steps = tpm_key? ? 6 : 5
-        start_progress(steps)
-
-        on_target do
-          progress.step("Writing Linux Security Modules configuration") { security.write }
-          progress.step("Installing bootloader") do
-            ::Bootloader::FinishClient.new.write
-          end
-          if tpm_key?
-            progress.step("Preparing the system to unlock the encryption using the TPM") do
-              prepare_tpm_key
-            end
-          end
-          progress.step("Configuring file systems snapshots") do
-            Yast::WFM.CallFunction("snapshots_finish", ["Write"])
-          end
-          progress.step("Copying logs") do
-            Yast::WFM.CallFunction("copy_logs_finish", ["Write"])
-          end
-          progress.step("Unmounting storage devices") do
-            Yast::WFM.CallFunction("umount_finish", ["Write"])
-          end
-        end
+        Finisher.new(logger, config, security).run
       end
 
       # Storage proposal manager
@@ -191,51 +165,6 @@ module DInstaller
       # @return [DInstaller::DBus::Clients::Software]
       def software
         @software ||= DBus::Clients::Software.new
-      end
-
-      def tpm_key?
-        tpm_product? && tpm_proposal? && tpm_system?
-      end
-
-      def tpm_proposal?
-        proposal.calculated_settings.encrypt?
-      end
-
-      def tpm_system?
-        Y2Storage::Arch.new.efiboot? && tpm_present?
-      end
-
-      def tpm_present?
-        return @tpm_present unless @tpm_present.nil?
-
-        @tpm_present =
-          begin
-            Yast::Execute.on_target!("fdectl", "tpm-present")
-            logger.info "FDE: TPMv2 detected"
-            true
-          rescue Cheetah::ExecutionFailed
-            logger.info "FDE: TPMv2 not detected"
-            false
-          end
-      end
-
-      def tpm_product?
-        config.data.fetch("security", {}).fetch("tpm_luks_open", false)
-      end
-
-      def prepare_tpm_key
-        keyfile_path = File.join("root", ".root.keyfile")
-        Yast::Execute.on_target!(
-          "fdectl", "add-secondary-key", "--keyfile", keyfile_path,
-          stdin:    "#{proposal.calculated_settings.encryption_password}\n",
-          recorder: Yast::ReducedRecorder.new(skip: :stdin)
-        )
-
-        service = Yast2::Systemd::Service.find("fde-tpm-enroll.service")
-        logger.info "FDE: TPM enroll service: #{service}"
-        service&.enable
-      rescue Cheetah::ExecutionFailed
-        false
       end
     end
   end

--- a/service/package/rubygem-d-installer.changes
+++ b/service/package/rubygem-d-installer.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu Mar  2 08:48:36 UTC 2023 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Write /iguana/mountlist if running on Iguana.
+
+-------------------------------------------------------------------
 Wed Feb 15 16:09:16 UTC 2023 - José Iván López González <jlopez@suse.com>
 
 - Add D-Bus API for iSCSI.

--- a/service/test/fixtures/staging-plain-partitions.yaml
+++ b/service/test/fixtures/staging-plain-partitions.yaml
@@ -1,0 +1,65 @@
+---
+- disk:
+    name: "/dev/sda"
+    size: 50 GiB
+    partition_table: gpt
+    partitions:
+    - partition:
+        size: 2 MiB
+        name: "/dev/sda1"
+        id: bios_boot
+    - partition:
+        size: 40 GiB
+        name: "/dev/sda2"
+        id: linux
+        file_system: btrfs
+        mount_point: "/"
+        btrfs:
+          subvolumes:
+          - subvolume:
+              path: boot/grub2/i386-pc
+          - subvolume:
+              path: boot/grub2/x86_64-efi
+          - subvolume:
+              path: home
+          - subvolume:
+              path: opt
+          - subvolume:
+              path: tmp
+          - subvolume:
+              path: usr/local
+          - subvolume:
+              path: var/cache
+          - subvolume:
+              path: var/crash
+          - subvolume:
+              path: var/lib/libvirt/images
+              nocow: true
+          - subvolume:
+              path: var/lib/machines
+          - subvolume:
+              path: var/lib/mailman
+          - subvolume:
+              path: var/lib/mariadb
+              nocow: true
+          - subvolume:
+              path: var/lib/mysql
+              nocow: true
+          - subvolume:
+              path: var/lib/named
+          - subvolume:
+              path: var/lib/pgsql
+              nocow: true
+          - subvolume:
+              path: var/log
+          - subvolume:
+              path: var/opt
+          - subvolume:
+              path: var/spool
+          - subvolume:
+              path: var/tmp
+    - partition:
+        name: "/dev/sda3"
+        id: linux
+        file_system: xfs
+        mount_point: "/srv"

--- a/service/test/fixtures/staging-ro-luks-partitions.yaml
+++ b/service/test/fixtures/staging-ro-luks-partitions.yaml
@@ -1,0 +1,48 @@
+---
+- disk:
+    name: /dev/vda
+    size: 20 GiB
+    partition_table: gpt
+    partitions:
+    - partition:
+        size: 0.5 GiB
+        name: /dev/vda1
+        id: esp
+        file_system: vfat
+        mount_point: /boot/efi
+        fstab_options:
+        - utf8
+    - partition:
+        name: /dev/vda2
+        id: linux
+        file_system: btrfs
+        mount_point: "/"
+        fstab_options:
+        - ro
+        btrfs:
+          default_subvolume: "@"
+          subvolumes:
+          - subvolume:
+              path: "@"
+          - subvolume:
+              path: "@/boot/grub2/i386-pc"
+          - subvolume:
+              path: "@/boot/grub2/x86_64-efi"
+          - subvolume:
+              path: "@/boot/writable"
+          - subvolume:
+              path: "@/home"
+          - subvolume:
+              path: "@/opt"
+          - subvolume:
+              path: "@/root"
+          - subvolume:
+              path: "@/srv"
+          - subvolume:
+              path: "@/usr/local"
+          - subvolume:
+              path: "@/var"
+              nocow: true
+        encryption:
+          type: luks
+          name: /dev/mapper/cr_root


### PR DESCRIPTION
## Problem

If D-Installer is executed from Iguana, it must create a file for Iguana to know what the resulting root file system is.

The file must be called at `/iguana/mountlist` and contain three columns:

* the device (`/dev/sdX`, `/dev/disk/by-uuid/...`, `uuid=`...)
* the mount point (`/sysroot`)
* the mount options

## Solution

Implement the behavior described above, only if the directory `/iguana` is already there.

This pull request also mitigates a related problem: D-Installer already does many things related to storage at the end of the installation. Likely, all that logic should be moved to YaST (for sure, the FDE part should be there and not in D-Installer itself[1]). But for the time being this pull request extracts that logic to a separate and properly object-oriented `DInstaller::Storage::Finisher`.

[1] https://trello.com/c/5x8G7xj8/89-d-installer-better-support-for-tpm-unlocking-of-fde

## Testing

- Added a new unit test
- Extensively tested manually, including FDE, to ensure no regressions were introduced with `DInstaller::Storage::Finisher`.
