### PR TITLE
Make NetworkManager mandatory in Tumbleweed and Leap installations

### DIFF
--- a/service/etc/d-installer.yaml
+++ b/service/etc/d-installer.yaml
@@ -63,7 +63,8 @@ Tumbleweed:
     mandatory_patterns:
       - enhanced_base # only pattern that is shared among all roles on TW
     optional_patterns: null # no optional pattern shared
-    mandatory_packages: null
+    mandatory_packages:
+      - NetworkManager
     optional_packages: null
     base_product: openSUSE
 
@@ -305,7 +306,8 @@ Leap:
     mandatory_patterns:
       - enhanced_base # For now lets pick some minimal one
     optional_patterns: null # no optional pattern shared
-    mandatory_packages: null
+    mandatory_packages:
+      - NetworkManager
     optional_packages: null
     base_product: Leap
 


### PR DESCRIPTION
## Problem

D-Installer uses **NetworkManager** for configuring the network and it is not possible choose an specific backend. At the end of the installation the configuration is copied to the target system but as we do not add the **NetworkManager**  package as part of the proposal the installation could end without network if the package is not required by any pattern.


**note:** for making the installation minimal we are only installing required packages

## Solution

Add the **NetworkManager** package to the products (**Tumbleweed** and **Leap 15.4** so far) which does not require it by the defined patterns.

