### PR TITLE
[web] Add `cspell`:  a spell checker for code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
     - name: Build the application
       run: make
 
+    - name: Run check spell
+      run: npm run cspell
+
     - name: Check types
       run: npm run check-types
 

--- a/web/cspell.json
+++ b/web/cspell.json
@@ -1,0 +1,31 @@
+{
+  "version": "0.2",
+  "language": "en",
+  "allowCompoundWords": true,
+  "ignorePaths": [
+    "src/lib/cockpit.js",
+    "src/lib/cockpit-po-plugin.js"
+  ],
+  "ignoreWords": [
+    "addrs",
+    "apsens",
+    "btrfs",
+    "ccmp",
+    "dbus",
+    "dinstaller",
+    "ifaces",
+    "ipaddr",
+    "jdoe",
+    "lldp",
+    "luks",
+    "mgmt",
+    "partitioner",
+    "patternfly",
+    "rfkill",
+    "ssid",
+    "ssids",
+    "subvol",
+    "teleporter",
+    "tkip"
+  ]
+}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -38,6 +38,7 @@
         "chrome-remote-interface": "^0.32.1",
         "compression-webpack-plugin": "^10.0.0",
         "copy-webpack-plugin": "^11.0.0",
+        "cspell-cli": "github:streetsidesoftware/cspell-cli",
         "css-loader": "^6.5.0",
         "css-minimizer-webpack-plugin": "^4.2.2",
         "eslint": "^8.28.0",
@@ -1927,6 +1928,387 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "node_modules/@cspell/cspell-bundled-dicts": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-6.27.0.tgz",
+      "integrity": "sha512-udRkEUz0QIAecCUECVac8IBCu7f5siCrxUZmsoZINgqLlSh0ppmn4/CiiA+sefj99rOq/vB4VEEQCnMShfl5qw==",
+      "dev": true,
+      "dependencies": {
+        "@cspell/dict-ada": "^4.0.1",
+        "@cspell/dict-aws": "^3.0.0",
+        "@cspell/dict-bash": "^4.1.1",
+        "@cspell/dict-companies": "^3.0.8",
+        "@cspell/dict-cpp": "^4.0.3",
+        "@cspell/dict-cryptocurrencies": "^3.0.1",
+        "@cspell/dict-csharp": "^4.0.2",
+        "@cspell/dict-css": "^4.0.5",
+        "@cspell/dict-dart": "^2.0.2",
+        "@cspell/dict-django": "^4.0.2",
+        "@cspell/dict-docker": "^1.1.6",
+        "@cspell/dict-dotnet": "^4.0.2",
+        "@cspell/dict-elixir": "^4.0.2",
+        "@cspell/dict-en_us": "^4.3.0",
+        "@cspell/dict-en-common-misspellings": "^1.0.2",
+        "@cspell/dict-en-gb": "1.1.33",
+        "@cspell/dict-filetypes": "^3.0.0",
+        "@cspell/dict-fonts": "^3.0.1",
+        "@cspell/dict-fullstack": "^3.1.4",
+        "@cspell/dict-gaming-terms": "^1.0.4",
+        "@cspell/dict-git": "^2.0.0",
+        "@cspell/dict-golang": "^5.0.2",
+        "@cspell/dict-haskell": "^4.0.1",
+        "@cspell/dict-html": "^4.0.3",
+        "@cspell/dict-html-symbol-entities": "^4.0.0",
+        "@cspell/dict-java": "^5.0.5",
+        "@cspell/dict-k8s": "^1.0.1",
+        "@cspell/dict-latex": "^3.1.0",
+        "@cspell/dict-lorem-ipsum": "^3.0.0",
+        "@cspell/dict-lua": "^4.0.1",
+        "@cspell/dict-node": "^4.0.2",
+        "@cspell/dict-npm": "^5.0.5",
+        "@cspell/dict-php": "^3.0.4",
+        "@cspell/dict-powershell": "^4.0.2",
+        "@cspell/dict-public-licenses": "^2.0.1",
+        "@cspell/dict-python": "^4.0.1",
+        "@cspell/dict-r": "^2.0.1",
+        "@cspell/dict-ruby": "^4.0.2",
+        "@cspell/dict-rust": "^4.0.1",
+        "@cspell/dict-scala": "^4.0.1",
+        "@cspell/dict-software-terms": "^3.1.5",
+        "@cspell/dict-sql": "^2.0.2",
+        "@cspell/dict-svelte": "^1.0.2",
+        "@cspell/dict-swift": "^2.0.1",
+        "@cspell/dict-typescript": "^3.1.1",
+        "@cspell/dict-vue": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@cspell/cspell-pipe": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-6.27.0.tgz",
+      "integrity": "sha512-lS3kIew5+ETExORdPcJkEA03ylrEL9CHaJ1xE7SSezU3mqoUgbVW5/f2+PCIWPu1mVvUpWef2X1ODddiPPp9NQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@cspell/cspell-service-bus": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-6.27.0.tgz",
+      "integrity": "sha512-GC3WseMeBE1xtIftBgfTOQxgAMHmLF5HhjHo2rVIfCKv3uyQXuNsGYmtqY7dm4GDrBx1vIYjOoT2xtEaSLoUPw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@cspell/cspell-types": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-6.27.0.tgz",
+      "integrity": "sha512-eHKpAhIUYIjssqF20IrihzNAPDTWJsFpBzg7UznX03Z4Y77JrGAgdRZ6h69uaIafQb7uotNYWnDazpVSkMpikQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@cspell/dict-ada": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-ada/-/dict-ada-4.0.1.tgz",
+      "integrity": "sha512-/E9o3nHrXOhYmQE43deKbxZcR3MIJAsa+66IzP9TXGHheKEx8b9dVMVVqydDDH8oom1H0U20NRPtu6KRVbT9xw==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-aws": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-aws/-/dict-aws-3.0.0.tgz",
+      "integrity": "sha512-O1W6nd5y3Z00AMXQMzfiYrIJ1sTd9fB1oLr+xf/UD7b3xeHeMeYE2OtcWbt9uyeHim4tk+vkSTcmYEBKJgS5bQ==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-bash": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-bash/-/dict-bash-4.1.1.tgz",
+      "integrity": "sha512-8czAa/Mh96wu2xr0RXQEGMTBUGkTvYn/Pb0o+gqOO1YW+poXGQc3gx0YPqILDryP/KCERrNvkWUJz3iGbvwC2A==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-companies": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-companies/-/dict-companies-3.0.8.tgz",
+      "integrity": "sha512-tQPpkxgog+7xGN3dA9p2Hd4O95+hFYfJuHeY9GgxNahBQyq3bv0REAc6xlqdtkIpfV2ga93B0l37mQr1p107Iw==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-cpp": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-cpp/-/dict-cpp-4.0.3.tgz",
+      "integrity": "sha512-gbXY9cUgRpb5mpw19VBy+YNUqNMlT5Dj70d8V1yIFbqPVHxccmxwdU4rlNaRyYrC41kDZwxmG7QQwcng6FdGcg==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-cryptocurrencies": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-cryptocurrencies/-/dict-cryptocurrencies-3.0.1.tgz",
+      "integrity": "sha512-Tdlr0Ahpp5yxtwM0ukC13V6+uYCI0p9fCRGMGZt36rWv8JQZHIuHfehNl7FB/Qc09NCF7p5ep0GXbL+sVTd/+w==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-csharp": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-csharp/-/dict-csharp-4.0.2.tgz",
+      "integrity": "sha512-1JMofhLK+4p4KairF75D3A924m5ERMgd1GvzhwK2geuYgd2ZKuGW72gvXpIV7aGf52E3Uu1kDXxxGAiZ5uVG7g==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-css": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-css/-/dict-css-4.0.5.tgz",
+      "integrity": "sha512-z5vw8nJSyKd6d3i5UmMNoVcAp0wxvs9OHWOmAeJKT9fO3tok02gK24VZhcJ0NJtiKdHQ2zRuzdfWl51wdAiY6A==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-dart": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-dart/-/dict-dart-2.0.2.tgz",
+      "integrity": "sha512-jigcODm7Z4IFZ4vParwwP3IT0fIgRq/9VoxkXfrxBMsLBGGM2QltHBj7pl+joX+c4cOHxfyZktGJK1B1wFtR4Q==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-django": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-django/-/dict-django-4.0.2.tgz",
+      "integrity": "sha512-L0Yw6+Yh2bE9/FAMG4gy9m752G4V8HEBjEAGeRIQ9qvxDLR9yD6dPOtgEFTjv7SWlKSrLb9wA/W3Q2GKCOusSg==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-docker": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-docker/-/dict-docker-1.1.6.tgz",
+      "integrity": "sha512-zCCiRTZ6EOQpBnSOm0/3rnKW1kCcAUDUA7SxJG3SuH6iZvKi3I8FEg8+O83WQUeXg0SyPNerD9F40JLnnJjJig==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-dotnet": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-dotnet/-/dict-dotnet-4.0.2.tgz",
+      "integrity": "sha512-Cu+Ob142tBQ2cYrpK/d3tjm/FvNXQXwdUShRIPKx03HbtUk9BoTdeFY5bX+Zz7GeV66OJCMrmpFANrtKpB8NTg==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-elixir": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-elixir/-/dict-elixir-4.0.2.tgz",
+      "integrity": "sha512-/YeHlpZ1pE9VAyxp3V0xyUPapNyC61WwFuw2RByeoMqqYaIfS3Hw+JxtimOsAKVhUvgUH58zyKl5K5Q6FqgCpw==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-en_us": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.3.0.tgz",
+      "integrity": "sha512-lQ4r8tBiylNjmYwrWz4xUgBtVC0CciKpddMUVosdusHonFE0KjlvkZK6PFtROBupmRLMBBMjxvtpbq8SdFBqCw==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-en-common-misspellings": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en-common-misspellings/-/dict-en-common-misspellings-1.0.2.tgz",
+      "integrity": "sha512-jg7ZQZpZH7+aAxNBlcAG4tGhYF6Ksy+QS5Df73Oo+XyckBjC9QS+PrRwLTeYoFIgXy5j3ICParK5r3MSSoL4gw==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-en-gb": {
+      "version": "1.1.33",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en-gb/-/dict-en-gb-1.1.33.tgz",
+      "integrity": "sha512-tKSSUf9BJEV+GJQAYGw5e+ouhEe2ZXE620S7BLKe3ZmpnjlNG9JqlnaBhkIMxKnNFkLY2BP/EARzw31AZnOv4g==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-filetypes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-filetypes/-/dict-filetypes-3.0.0.tgz",
+      "integrity": "sha512-Fiyp0z5uWaK0d2TfR9GMUGDKmUMAsOhGD5A0kHoqnNGswL2iw0KB0mFBONEquxU65fEnQv4R+jdM2d9oucujuA==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-fonts": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-fonts/-/dict-fonts-3.0.1.tgz",
+      "integrity": "sha512-o2zVFKT3KcIBo88xlWhG4yOD0XQDjP7guc7C30ZZcSN8YCwaNc1nGoxU3QRea8iKcwk3cXH0G53nrQur7g9DjQ==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-fullstack": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-fullstack/-/dict-fullstack-3.1.4.tgz",
+      "integrity": "sha512-OnCIn3GgAhdhsU6xMYes7/WXnbV6R/5k/zRAu/d+WZP4Ltf48z7oFfNFjHXH6b8ZwnMhpekLAnCeIfT5dcxRqw==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-gaming-terms": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-gaming-terms/-/dict-gaming-terms-1.0.4.tgz",
+      "integrity": "sha512-hbDduNXlk4AOY0wFxcDMWBPpm34rpqJBeqaySeoUH70eKxpxm+dvjpoRLJgyu0TmymEICCQSl6lAHTHSDiWKZg==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-git": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-git/-/dict-git-2.0.0.tgz",
+      "integrity": "sha512-n1AxyX5Kgxij/sZFkxFJlzn3K9y/sCcgVPg/vz4WNJ4K9YeTsUmyGLA2OQI7d10GJeiuAo2AP1iZf2A8j9aj2w==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-golang": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-golang/-/dict-golang-5.0.2.tgz",
+      "integrity": "sha512-TNOQzsiLv4I56w5188OnJW+2ttjekoBl8IyPpI25GeV3dky4d+TX5pujayvcKQ+SM8vV8u2lpQpvyr4YePhiQg==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-haskell": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-haskell/-/dict-haskell-4.0.1.tgz",
+      "integrity": "sha512-uRrl65mGrOmwT7NxspB4xKXFUenNC7IikmpRZW8Uzqbqcu7ZRCUfstuVH7T1rmjRgRkjcIjE4PC11luDou4wEQ==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-html": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-html/-/dict-html-4.0.3.tgz",
+      "integrity": "sha512-Gae8i8rrArT0UyG1I6DHDK62b7Be6QEcBSIeWOm4VIIW1CASkN9B0qFgSVnkmfvnu1Y3H7SSaaEynKjdj3cs8w==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-html-symbol-entities": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-html-symbol-entities/-/dict-html-symbol-entities-4.0.0.tgz",
+      "integrity": "sha512-HGRu+48ErJjoweR5IbcixxETRewrBb0uxQBd6xFGcxbEYCX8CnQFTAmKI5xNaIt2PKaZiJH3ijodGSqbKdsxhw==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-java": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-java/-/dict-java-5.0.5.tgz",
+      "integrity": "sha512-X19AoJgWIBwJBSWGFqSgHaBR/FEykBHTMjL6EqOnhIGEyE9nvuo32tsSHjXNJ230fQxQptEvRZoaldNLtKxsRg==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-k8s": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-k8s/-/dict-k8s-1.0.1.tgz",
+      "integrity": "sha512-gc5y4Nm3hVdMZNBZfU2M1AsAmObZsRWjCUk01NFPfGhFBXyVne41T7E62rpnzu5330FV/6b/TnFcPgRmak9lLw==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-latex": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-latex/-/dict-latex-3.1.0.tgz",
+      "integrity": "sha512-XD5S3FY0DrYiun2vm/KKOkeaD30LXp9v5EzVTVQvmxqQrQh0HvOT3TFD7lgKbyzZaG7E+l3wS94uwwm80cOmuw==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-lorem-ipsum": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-lorem-ipsum/-/dict-lorem-ipsum-3.0.0.tgz",
+      "integrity": "sha512-msEV24qEpzWZs2kcEicqYlhyBpR0amfDkJOs+iffC07si9ftqtQ+yP3lf1VFLpgqw3SQh1M1vtU7RD4sPrNlcQ==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-lua": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-lua/-/dict-lua-4.0.1.tgz",
+      "integrity": "sha512-j0MFmeCouSoC6EdZTbvGe1sJ9V+ruwKSeF+zRkNNNload7R72Co5kX1haW2xLHGdlq0kqSy1ODRZKdVl0e+7hg==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-node": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-node/-/dict-node-4.0.2.tgz",
+      "integrity": "sha512-FEQJ4TnMcXEFslqBQkXa5HposMoCGsiBv2ux4IZuIXgadXeHKHUHk60iarWpjhzNzQLyN2GD7NoRMd12bK3Llw==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-npm": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.0.5.tgz",
+      "integrity": "sha512-eirZm4XpJNEcbmLGIwI2qXdRRlCKwEsH9mT3qCUytmbj6S6yn63F+8bShMW/yQBedV7+GXq9Td+cJdqiVutOiA==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-php": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-php/-/dict-php-3.0.4.tgz",
+      "integrity": "sha512-QX6zE/ZfnT3O5lSwV8EPVh8Va39ds34gSNNR8I4GWiuDpKcTkZPFi4OLoP3Tlhbl/3G0Ha35OkSDLvZfu8mnkA==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-powershell": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-powershell/-/dict-powershell-4.0.2.tgz",
+      "integrity": "sha512-3Wk2Z0fxpewML0zq4a9W5IsPZ0YwvzA8c6ykFdwQ0xcBQc/xRfdb9Z5drYXf9bobck1+MacGrprSeQXrmeByNQ==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-public-licenses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-public-licenses/-/dict-public-licenses-2.0.1.tgz",
+      "integrity": "sha512-NZNwzkL5BqKddepDxvX/Qbji378Mso1TdnV4RFAN8hJoo6dSR0fv2TTI/Y0i/YWBmfmQGyTpEztBXtAw4qgjiA==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-python": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-python/-/dict-python-4.0.1.tgz",
+      "integrity": "sha512-1wtUgyaTqRiQY0/fryk0oW22lcxNUnZ5DwteTzfatMdbgR0OHXTlHbI8vYxpHLWalSoch7EpLsnaymG+fOrt8g==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-r": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-r/-/dict-r-2.0.1.tgz",
+      "integrity": "sha512-KCmKaeYMLm2Ip79mlYPc8p+B2uzwBp4KMkzeLd5E6jUlCL93Y5Nvq68wV5fRLDRTf7N1LvofkVFWfDcednFOgA==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-ruby": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-ruby/-/dict-ruby-4.0.2.tgz",
+      "integrity": "sha512-fCoQHvLhTAetzXCUZMpyoCUPFMiyLHuECIPOiuYW6TGnP2eGV9y4j2J8HAOVtkyxOKUoyK+zZgtrma64yTUMkg==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-rust": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-rust/-/dict-rust-4.0.1.tgz",
+      "integrity": "sha512-xJSSzHDK2z6lSVaOmMxl3PTOtfoffaxMo7fTcbZUF+SCJzfKbO6vnN9TCGX2sx1RHFDz66Js6goz6SAZQdOwaw==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-scala": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-scala/-/dict-scala-4.0.1.tgz",
+      "integrity": "sha512-UvdQpAugrCqRC+2wfqJ4FFKpJr+spLrrrAmqdWEgAyZNMz8ib9FkO+yoIQnNFeodzI9xVPN9Hror+MjXbb2soQ==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-software-terms": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-3.1.5.tgz",
+      "integrity": "sha512-wmkWHHkp2AN9EDWNBLB0VASB5OtsC3KnhoAHxCJzC6AB3xjYoBfKsvgI/o50gfbsCVQceHpqXjOEYSw/xxTKNw==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-sql": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-sql/-/dict-sql-2.0.2.tgz",
+      "integrity": "sha512-XxUoamMFU9OGcDHLY6+pTlQDsqq9wcY7Oc4C55hqmotxFeFaaqinoD1UIAm1yDngRP7fKK4mVPPFmJI6bmspHg==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-svelte": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-svelte/-/dict-svelte-1.0.2.tgz",
+      "integrity": "sha512-rPJmnn/GsDs0btNvrRBciOhngKV98yZ9SHmg8qI6HLS8hZKvcXc0LMsf9LLuMK1TmS2+WQFAan6qeqg6bBxL2Q==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-swift": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-swift/-/dict-swift-2.0.1.tgz",
+      "integrity": "sha512-gxrCMUOndOk7xZFmXNtkCEeroZRnS2VbeaIPiymGRHj5H+qfTAzAKxtv7jJbVA3YYvEzWcVE2oKDP4wcbhIERw==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-typescript": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-typescript/-/dict-typescript-3.1.1.tgz",
+      "integrity": "sha512-N9vNJZoOXmmrFPR4ir3rGvnqqwmQGgOYoL1+y6D4oIhyr7FhaYiyF/d7QT61RmjZQcATMa6PSL+ZisCeRLx9+A==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-vue": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-vue/-/dict-vue-3.0.0.tgz",
+      "integrity": "sha512-niiEMPWPV9IeRBRzZ0TBZmNnkK3olkOPYxC1Ny2AX4TGlYRajcW0WUtoSHmvvjZNfWLSg2L6ruiBeuPSbjnG6A==",
+      "dev": true
+    },
+    "node_modules/@cspell/dynamic-import": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-6.27.0.tgz",
+      "integrity": "sha512-PrBAH0+6OERWeY57PUH+9WmxYtUBnBjTYmm+3Zpg3SUd/ToD0cNf83OJCrcDF7KNQYE9rjCPUfVdsOe3aJlIHw==",
+      "dev": true,
+      "dependencies": {
+        "import-meta-resolve": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@cspell/strong-weak-map": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-6.27.0.tgz",
+      "integrity": "sha512-4hel0Dik7GTX8yVOjOXlumIOzYD8mWzDeyMEhEJb3qwDfsTPeeYo1EMTSgtS+oJXR6kQ09qBrF1lok44v6NOAQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.6"
+      }
     },
     "node_modules/@csstools/css-parser-algorithms": {
       "version": "2.0.1",
@@ -4808,6 +5190,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/array-timsort": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-timsort/-/array-timsort-1.0.3.tgz",
+      "integrity": "sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==",
+      "dev": true
+    },
     "node_modules/array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -5684,6 +6072,34 @@
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
       "dev": true
     },
+    "node_modules/clear-module": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/clear-module/-/clear-module-4.1.2.tgz",
+      "integrity": "sha512-LWAxzHqdHsAZlPlEyJ2Poz6AIs384mPeqLVCru2p0BrP9G/kVGuhNyZYClLO6cXlnuJjzC8xtsJIuMjKqLXoAw==",
+      "dev": true,
+      "dependencies": {
+        "parent-module": "^2.0.0",
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/clear-module/node_modules/parent-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-2.0.0.tgz",
+      "integrity": "sha512-uo0Z9JJeWzv8BG+tRcapBKNJ0dro9cLyczGzulS6EfeyAdeC9sbojtW6XwvYxJkEne9En+J2XEl4zyglVeIwFg==",
+      "dev": true,
+      "dependencies": {
+        "callsites": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/cli-cursor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
@@ -5871,6 +6287,28 @@
       "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
       "dev": true
     },
+    "node_modules/comment-json": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-4.2.3.tgz",
+      "integrity": "sha512-SsxdiOf064DWoZLH799Ata6u7iV658A11PlWtZATDlXPpKGJnbJZ5Z24ybixAi+LUUqJ/GKowAejtC5GFUG7Tw==",
+      "dev": true,
+      "dependencies": {
+        "array-timsort": "^1.0.3",
+        "core-util-is": "^1.0.3",
+        "esprima": "^4.0.1",
+        "has-own-prop": "^2.0.0",
+        "repeat-string": "^1.6.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/comment-json/node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true
+    },
     "node_modules/common-path-prefix": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-3.0.0.tgz",
@@ -5978,6 +6416,35 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
+    },
+    "node_modules/configstore": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
+      "integrity": "sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==",
+      "dev": true,
+      "dependencies": {
+        "dot-prop": "^5.2.0",
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^3.0.0",
+        "unique-string": "^2.0.0",
+        "write-file-atomic": "^3.0.0",
+        "xdg-basedir": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/configstore/node_modules/write-file-atomic": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+      "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+      "dev": true,
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "is-typedarray": "^1.0.0",
+        "signal-exit": "^3.0.2",
+        "typedarray-to-buffer": "^3.1.5"
+      }
     },
     "node_modules/connect-history-api-fallback": {
       "version": "2.0.0",
@@ -6173,6 +6640,327 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crypto-random-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
+      "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cspell": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/cspell/-/cspell-6.27.0.tgz",
+      "integrity": "sha512-BhDzXJIRFcpswOy32tgnoOw2OdSM91pQuUpRxfZvRxdM4HBxUrodDYJ5HbBz7D0vNBrXFidFX/157KNX4m1gmg==",
+      "dev": true,
+      "dependencies": {
+        "@cspell/cspell-pipe": "6.27.0",
+        "@cspell/dynamic-import": "6.27.0",
+        "chalk": "^4.1.2",
+        "commander": "^10.0.0",
+        "cspell-gitignore": "6.27.0",
+        "cspell-glob": "6.27.0",
+        "cspell-io": "6.27.0",
+        "cspell-lib": "6.27.0",
+        "fast-glob": "^3.2.12",
+        "fast-json-stable-stringify": "^2.1.0",
+        "file-entry-cache": "^6.0.1",
+        "get-stdin": "^8.0.0",
+        "imurmurhash": "^0.1.4",
+        "semver": "^7.3.8",
+        "strip-ansi": "^6.0.1",
+        "vscode-uri": "^3.0.7"
+      },
+      "bin": {
+        "cspell": "bin.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/streetsidesoftware/cspell?sponsor=1"
+      }
+    },
+    "node_modules/cspell-cli": {
+      "version": "6.27.0",
+      "resolved": "git+ssh://git@github.com/streetsidesoftware/cspell-cli.git#37dbd5d52b7fd05fb44b59af89e6b2b77e43b609",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cspell": "^6.27.0"
+      },
+      "bin": {
+        "cspell-cli": "index.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/cspell-dictionary": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-6.27.0.tgz",
+      "integrity": "sha512-u2HZ6Yl0tIBzflJ9Rt5i15kP1KN41XtyKfqCCntugX3gYtfbQ1t/HvAPcq4g7EDZV2tzqSKGcNvzuJgHJyxxFw==",
+      "dev": true,
+      "dependencies": {
+        "@cspell/cspell-pipe": "6.27.0",
+        "@cspell/cspell-types": "6.27.0",
+        "cspell-trie-lib": "6.27.0",
+        "fast-equals": "^4.0.3",
+        "gensequence": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/cspell-gitignore": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-6.27.0.tgz",
+      "integrity": "sha512-aXIuSMtm2pW8Z0y4SHBqvXwY4Hk3lz4b3PD50IU1gn2mjk8GioEYAnWlN/FANeOuMjOXiRfLaX0McvNErnZxdw==",
+      "dev": true,
+      "dependencies": {
+        "cspell-glob": "6.27.0",
+        "find-up": "^5.0.0"
+      },
+      "bin": {
+        "cspell-gitignore": "bin.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/cspell-glob": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-6.27.0.tgz",
+      "integrity": "sha512-YzS9SiNU5iFIdEMCeVOsGlCvffCM7M51io9ylkkY6138NLCnqWw/DSePzIAAsuLqh9nsJt8xiXrHPerKiPnN3g==",
+      "dev": true,
+      "dependencies": {
+        "micromatch": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/cspell-grammar": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-6.27.0.tgz",
+      "integrity": "sha512-03SH0+bWazhkzUUK+t6ywUZvWuDcqj4J171oIdA3fvdG7nBpTqyFc1/vU1mReZK7CDde16BUaqCkWgf+El+N1w==",
+      "dev": true,
+      "dependencies": {
+        "@cspell/cspell-pipe": "6.27.0",
+        "@cspell/cspell-types": "6.27.0"
+      },
+      "bin": {
+        "cspell-grammar": "bin.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/cspell-io": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-6.27.0.tgz",
+      "integrity": "sha512-WsvXjbbWwIQVembEtlNuC8cJrGtyUuk8GvZzL9bBpSofU2UXvFjaQ9bAZjIeHibGQrIIuOM0ra0CqOcLb5mShA==",
+      "dev": true,
+      "dependencies": {
+        "@cspell/cspell-service-bus": "6.27.0",
+        "node-fetch": "^2.6.9"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/cspell-lib": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-6.27.0.tgz",
+      "integrity": "sha512-wwi3VCFiWaVFrV/ycm4yNBjjPY3pyhWud4lVJs51p2IkKqJbmR7hZ+bSIyw6d9MVzPKRD67eMaNBYXFGDaNHGQ==",
+      "dev": true,
+      "dependencies": {
+        "@cspell/cspell-bundled-dicts": "6.27.0",
+        "@cspell/cspell-pipe": "6.27.0",
+        "@cspell/cspell-types": "6.27.0",
+        "@cspell/strong-weak-map": "6.27.0",
+        "clear-module": "^4.1.2",
+        "comment-json": "^4.2.3",
+        "configstore": "^5.0.1",
+        "cosmiconfig": "8.0.0",
+        "cspell-dictionary": "6.27.0",
+        "cspell-glob": "6.27.0",
+        "cspell-grammar": "6.27.0",
+        "cspell-io": "6.27.0",
+        "cspell-trie-lib": "6.27.0",
+        "fast-equals": "^4.0.3",
+        "find-up": "^5.0.0",
+        "gensequence": "^4.0.3",
+        "import-fresh": "^3.3.0",
+        "resolve-from": "^5.0.0",
+        "resolve-global": "^1.0.0",
+        "vscode-languageserver-textdocument": "^1.0.8",
+        "vscode-uri": "^3.0.7"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/cspell-lib/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "node_modules/cspell-lib/node_modules/cosmiconfig": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.0.0.tgz",
+      "integrity": "sha512-da1EafcpH6b/TD8vDRaWV7xFINlHlF6zKsGwS1TsuVJTZRkquaS5HTMq7uq6h31619QjbsYl21gVDOm32KM1vQ==",
+      "dev": true,
+      "dependencies": {
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/cspell-lib/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/cspell-trie-lib": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-6.27.0.tgz",
+      "integrity": "sha512-kelDXszZKzlWbk7hV3cTtWYd2Gs3MXqTNSL3udtN4Oow74ik+h1bWsOOmXKKjtKvRctx4omWC1JdriQXfhBMBA==",
+      "dev": true,
+      "dependencies": {
+        "@cspell/cspell-pipe": "6.27.0",
+        "@cspell/cspell-types": "6.27.0",
+        "gensequence": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/cspell/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cspell/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cspell/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/cspell/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/cspell/node_modules/commander": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.0.tgz",
+      "integrity": "sha512-zS5PnTI22FIRM6ylNW8G4Ap0IEOyk62fhLSD0+uHRT9McRCLGpkVNvao4bjimpK/GShynyQkFFxHhwMcETmduA==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/cspell/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cspell/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cspell/node_modules/semver": {
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cspell/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cspell/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/css-declaration-sorter": {
       "version": "6.3.1",
@@ -6855,6 +7643,18 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dot-prop": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+      "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
+      "dev": true,
+      "dependencies": {
+        "is-obj": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ecc-jsbn": {
@@ -8232,6 +9032,12 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
     },
+    "node_modules/fast-equals": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-4.0.3.tgz",
+      "integrity": "sha512-G3BSX9cfKttjr+2o1O22tYMLq0DPluZnYtq1rXumE1SpL/F/SLIfHx08WYQoWSIpeMYf8sRbJ8++71+v6Pnxfg==",
+      "dev": true
+    },
     "node_modules/fast-glob": {
       "version": "3.2.12",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
@@ -8533,20 +9339,6 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
-    "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/fstream": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
@@ -8628,6 +9420,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/gensequence": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gensequence/-/gensequence-4.0.3.tgz",
+      "integrity": "sha512-izr+MKqJKjexkvLiPGhW96elQX8TuUR/su/xzILxjqzU1RDz1n1ZbqwDUnNFaRcq0gFR3oQfNH2JOH4Je1x/QA==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -8667,6 +9468,18 @@
       "dev": true,
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-stdin": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz",
+      "integrity": "sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-stream": {
@@ -8775,6 +9588,18 @@
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "dev": true
+    },
+    "node_modules/global-dirs": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+      "integrity": "sha512-NknMLn7F2J7aflwFOlGdNIuCDpN3VGoSoB+aap3KABFWbHVn1TCgFC+np23J8W2BiZbjfEw3BFBycSMv1AFblg==",
+      "dev": true,
+      "dependencies": {
+        "ini": "^1.3.4"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/global-modules": {
       "version": "2.0.0",
@@ -8994,6 +9819,15 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/has-own-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-own-prop/-/has-own-prop-2.0.0.tgz",
+      "integrity": "sha512-Pq0h+hvsVm6dDEa8x82GnLSYHOzNDt7f0ddFa3FqcQlgzEiptPqL+XrOJNavjOzSYiYWIrgeVYYgGlLmnxwilQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/has-property-descriptors": {
@@ -9403,6 +10237,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/import-meta-resolve": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-2.2.1.tgz",
+      "integrity": "sha512-C6lLL7EJPY44kBvA80gq4uMsVFw5x3oSKfuMl1cuZ2RkI5+UJqQXgn+6hlUew0y4ig7Ypt4CObAAIzU53Nfpuw==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -9789,6 +10633,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-path-inside": {
@@ -12860,6 +13713,48 @@
       "integrity": "sha512-ye8AIYWQcP9MvoM1i0Z2jV0qed31Z8EWXYnyGNkiUAd+Fo8J+7uy90xTV8g/oAbhtjkY7iZbNTizQaXdKUuwpQ==",
       "dev": true
     },
+    "node_modules/node-fetch": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
+      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/node-forge": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
@@ -14704,6 +15599,15 @@
         "jsesc": "bin/jsesc"
       }
     },
+    "node_modules/repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/request": {
       "version": "2.88.2",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
@@ -14830,6 +15734,18 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
       "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve-global": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-global/-/resolve-global-1.0.0.tgz",
+      "integrity": "sha512-zFa12V4OLtT5XUX/Q4VLvTfBf+Ok0SPc1FNGM/z9ctUdiU618qwKpWnd0CHs3+RqROfyEg/DhuHbMWYqcgljEw==",
+      "dev": true,
+      "dependencies": {
+        "global-dirs": "^0.1.1"
+      },
       "engines": {
         "node": ">=8"
       }
@@ -16881,6 +17797,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "dev": true,
+      "dependencies": {
+        "is-typedarray": "^1.0.0"
+      }
+    },
     "node_modules/typedoc": {
       "version": "0.23.26",
       "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.26.tgz",
@@ -17013,6 +17938,18 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/unique-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
+      "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
+      "dev": true,
+      "dependencies": {
+        "crypto-random-string": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/universalify": {
@@ -17162,6 +18099,12 @@
         "extsprintf": "^1.2.0"
       }
     },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.8.tgz",
+      "integrity": "sha512-1bonkGqQs5/fxGT5UchTgjGVnfysL0O8v1AYMBjqTbWQTFn721zaPGDYFkOKtfDgFiSgXM3KwaG3FMGfW4Ed9Q==",
+      "dev": true
+    },
     "node_modules/vscode-oniguruma": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
@@ -17172,6 +18115,12 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
       "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
+      "dev": true
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.7.tgz",
+      "integrity": "sha512-eOpPHogvorZRobNqJGhapa0JdwaxpjVvyBp0QIUMRMSf8ZAlqOdEquKuRmw9Qwu0qXtJIWqFtMkmvJjUZmMjVA==",
       "dev": true
     },
     "node_modules/w3c-xmlserializer": {
@@ -17726,6 +18675,15 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xdg-basedir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
+      "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/xml-name-validator": {
@@ -19095,6 +20053,369 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true
+    },
+    "@cspell/cspell-bundled-dicts": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-6.27.0.tgz",
+      "integrity": "sha512-udRkEUz0QIAecCUECVac8IBCu7f5siCrxUZmsoZINgqLlSh0ppmn4/CiiA+sefj99rOq/vB4VEEQCnMShfl5qw==",
+      "dev": true,
+      "requires": {
+        "@cspell/dict-ada": "^4.0.1",
+        "@cspell/dict-aws": "^3.0.0",
+        "@cspell/dict-bash": "^4.1.1",
+        "@cspell/dict-companies": "^3.0.8",
+        "@cspell/dict-cpp": "^4.0.3",
+        "@cspell/dict-cryptocurrencies": "^3.0.1",
+        "@cspell/dict-csharp": "^4.0.2",
+        "@cspell/dict-css": "^4.0.5",
+        "@cspell/dict-dart": "^2.0.2",
+        "@cspell/dict-django": "^4.0.2",
+        "@cspell/dict-docker": "^1.1.6",
+        "@cspell/dict-dotnet": "^4.0.2",
+        "@cspell/dict-elixir": "^4.0.2",
+        "@cspell/dict-en_us": "^4.3.0",
+        "@cspell/dict-en-common-misspellings": "^1.0.2",
+        "@cspell/dict-en-gb": "1.1.33",
+        "@cspell/dict-filetypes": "^3.0.0",
+        "@cspell/dict-fonts": "^3.0.1",
+        "@cspell/dict-fullstack": "^3.1.4",
+        "@cspell/dict-gaming-terms": "^1.0.4",
+        "@cspell/dict-git": "^2.0.0",
+        "@cspell/dict-golang": "^5.0.2",
+        "@cspell/dict-haskell": "^4.0.1",
+        "@cspell/dict-html": "^4.0.3",
+        "@cspell/dict-html-symbol-entities": "^4.0.0",
+        "@cspell/dict-java": "^5.0.5",
+        "@cspell/dict-k8s": "^1.0.1",
+        "@cspell/dict-latex": "^3.1.0",
+        "@cspell/dict-lorem-ipsum": "^3.0.0",
+        "@cspell/dict-lua": "^4.0.1",
+        "@cspell/dict-node": "^4.0.2",
+        "@cspell/dict-npm": "^5.0.5",
+        "@cspell/dict-php": "^3.0.4",
+        "@cspell/dict-powershell": "^4.0.2",
+        "@cspell/dict-public-licenses": "^2.0.1",
+        "@cspell/dict-python": "^4.0.1",
+        "@cspell/dict-r": "^2.0.1",
+        "@cspell/dict-ruby": "^4.0.2",
+        "@cspell/dict-rust": "^4.0.1",
+        "@cspell/dict-scala": "^4.0.1",
+        "@cspell/dict-software-terms": "^3.1.5",
+        "@cspell/dict-sql": "^2.0.2",
+        "@cspell/dict-svelte": "^1.0.2",
+        "@cspell/dict-swift": "^2.0.1",
+        "@cspell/dict-typescript": "^3.1.1",
+        "@cspell/dict-vue": "^3.0.0"
+      }
+    },
+    "@cspell/cspell-pipe": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-6.27.0.tgz",
+      "integrity": "sha512-lS3kIew5+ETExORdPcJkEA03ylrEL9CHaJ1xE7SSezU3mqoUgbVW5/f2+PCIWPu1mVvUpWef2X1ODddiPPp9NQ==",
+      "dev": true
+    },
+    "@cspell/cspell-service-bus": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-6.27.0.tgz",
+      "integrity": "sha512-GC3WseMeBE1xtIftBgfTOQxgAMHmLF5HhjHo2rVIfCKv3uyQXuNsGYmtqY7dm4GDrBx1vIYjOoT2xtEaSLoUPw==",
+      "dev": true
+    },
+    "@cspell/cspell-types": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-6.27.0.tgz",
+      "integrity": "sha512-eHKpAhIUYIjssqF20IrihzNAPDTWJsFpBzg7UznX03Z4Y77JrGAgdRZ6h69uaIafQb7uotNYWnDazpVSkMpikQ==",
+      "dev": true
+    },
+    "@cspell/dict-ada": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-ada/-/dict-ada-4.0.1.tgz",
+      "integrity": "sha512-/E9o3nHrXOhYmQE43deKbxZcR3MIJAsa+66IzP9TXGHheKEx8b9dVMVVqydDDH8oom1H0U20NRPtu6KRVbT9xw==",
+      "dev": true
+    },
+    "@cspell/dict-aws": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-aws/-/dict-aws-3.0.0.tgz",
+      "integrity": "sha512-O1W6nd5y3Z00AMXQMzfiYrIJ1sTd9fB1oLr+xf/UD7b3xeHeMeYE2OtcWbt9uyeHim4tk+vkSTcmYEBKJgS5bQ==",
+      "dev": true
+    },
+    "@cspell/dict-bash": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-bash/-/dict-bash-4.1.1.tgz",
+      "integrity": "sha512-8czAa/Mh96wu2xr0RXQEGMTBUGkTvYn/Pb0o+gqOO1YW+poXGQc3gx0YPqILDryP/KCERrNvkWUJz3iGbvwC2A==",
+      "dev": true
+    },
+    "@cspell/dict-companies": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-companies/-/dict-companies-3.0.8.tgz",
+      "integrity": "sha512-tQPpkxgog+7xGN3dA9p2Hd4O95+hFYfJuHeY9GgxNahBQyq3bv0REAc6xlqdtkIpfV2ga93B0l37mQr1p107Iw==",
+      "dev": true
+    },
+    "@cspell/dict-cpp": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-cpp/-/dict-cpp-4.0.3.tgz",
+      "integrity": "sha512-gbXY9cUgRpb5mpw19VBy+YNUqNMlT5Dj70d8V1yIFbqPVHxccmxwdU4rlNaRyYrC41kDZwxmG7QQwcng6FdGcg==",
+      "dev": true
+    },
+    "@cspell/dict-cryptocurrencies": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-cryptocurrencies/-/dict-cryptocurrencies-3.0.1.tgz",
+      "integrity": "sha512-Tdlr0Ahpp5yxtwM0ukC13V6+uYCI0p9fCRGMGZt36rWv8JQZHIuHfehNl7FB/Qc09NCF7p5ep0GXbL+sVTd/+w==",
+      "dev": true
+    },
+    "@cspell/dict-csharp": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-csharp/-/dict-csharp-4.0.2.tgz",
+      "integrity": "sha512-1JMofhLK+4p4KairF75D3A924m5ERMgd1GvzhwK2geuYgd2ZKuGW72gvXpIV7aGf52E3Uu1kDXxxGAiZ5uVG7g==",
+      "dev": true
+    },
+    "@cspell/dict-css": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-css/-/dict-css-4.0.5.tgz",
+      "integrity": "sha512-z5vw8nJSyKd6d3i5UmMNoVcAp0wxvs9OHWOmAeJKT9fO3tok02gK24VZhcJ0NJtiKdHQ2zRuzdfWl51wdAiY6A==",
+      "dev": true
+    },
+    "@cspell/dict-dart": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-dart/-/dict-dart-2.0.2.tgz",
+      "integrity": "sha512-jigcODm7Z4IFZ4vParwwP3IT0fIgRq/9VoxkXfrxBMsLBGGM2QltHBj7pl+joX+c4cOHxfyZktGJK1B1wFtR4Q==",
+      "dev": true
+    },
+    "@cspell/dict-django": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-django/-/dict-django-4.0.2.tgz",
+      "integrity": "sha512-L0Yw6+Yh2bE9/FAMG4gy9m752G4V8HEBjEAGeRIQ9qvxDLR9yD6dPOtgEFTjv7SWlKSrLb9wA/W3Q2GKCOusSg==",
+      "dev": true
+    },
+    "@cspell/dict-docker": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-docker/-/dict-docker-1.1.6.tgz",
+      "integrity": "sha512-zCCiRTZ6EOQpBnSOm0/3rnKW1kCcAUDUA7SxJG3SuH6iZvKi3I8FEg8+O83WQUeXg0SyPNerD9F40JLnnJjJig==",
+      "dev": true
+    },
+    "@cspell/dict-dotnet": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-dotnet/-/dict-dotnet-4.0.2.tgz",
+      "integrity": "sha512-Cu+Ob142tBQ2cYrpK/d3tjm/FvNXQXwdUShRIPKx03HbtUk9BoTdeFY5bX+Zz7GeV66OJCMrmpFANrtKpB8NTg==",
+      "dev": true
+    },
+    "@cspell/dict-elixir": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-elixir/-/dict-elixir-4.0.2.tgz",
+      "integrity": "sha512-/YeHlpZ1pE9VAyxp3V0xyUPapNyC61WwFuw2RByeoMqqYaIfS3Hw+JxtimOsAKVhUvgUH58zyKl5K5Q6FqgCpw==",
+      "dev": true
+    },
+    "@cspell/dict-en_us": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.3.0.tgz",
+      "integrity": "sha512-lQ4r8tBiylNjmYwrWz4xUgBtVC0CciKpddMUVosdusHonFE0KjlvkZK6PFtROBupmRLMBBMjxvtpbq8SdFBqCw==",
+      "dev": true
+    },
+    "@cspell/dict-en-common-misspellings": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en-common-misspellings/-/dict-en-common-misspellings-1.0.2.tgz",
+      "integrity": "sha512-jg7ZQZpZH7+aAxNBlcAG4tGhYF6Ksy+QS5Df73Oo+XyckBjC9QS+PrRwLTeYoFIgXy5j3ICParK5r3MSSoL4gw==",
+      "dev": true
+    },
+    "@cspell/dict-en-gb": {
+      "version": "1.1.33",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en-gb/-/dict-en-gb-1.1.33.tgz",
+      "integrity": "sha512-tKSSUf9BJEV+GJQAYGw5e+ouhEe2ZXE620S7BLKe3ZmpnjlNG9JqlnaBhkIMxKnNFkLY2BP/EARzw31AZnOv4g==",
+      "dev": true
+    },
+    "@cspell/dict-filetypes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-filetypes/-/dict-filetypes-3.0.0.tgz",
+      "integrity": "sha512-Fiyp0z5uWaK0d2TfR9GMUGDKmUMAsOhGD5A0kHoqnNGswL2iw0KB0mFBONEquxU65fEnQv4R+jdM2d9oucujuA==",
+      "dev": true
+    },
+    "@cspell/dict-fonts": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-fonts/-/dict-fonts-3.0.1.tgz",
+      "integrity": "sha512-o2zVFKT3KcIBo88xlWhG4yOD0XQDjP7guc7C30ZZcSN8YCwaNc1nGoxU3QRea8iKcwk3cXH0G53nrQur7g9DjQ==",
+      "dev": true
+    },
+    "@cspell/dict-fullstack": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-fullstack/-/dict-fullstack-3.1.4.tgz",
+      "integrity": "sha512-OnCIn3GgAhdhsU6xMYes7/WXnbV6R/5k/zRAu/d+WZP4Ltf48z7oFfNFjHXH6b8ZwnMhpekLAnCeIfT5dcxRqw==",
+      "dev": true
+    },
+    "@cspell/dict-gaming-terms": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-gaming-terms/-/dict-gaming-terms-1.0.4.tgz",
+      "integrity": "sha512-hbDduNXlk4AOY0wFxcDMWBPpm34rpqJBeqaySeoUH70eKxpxm+dvjpoRLJgyu0TmymEICCQSl6lAHTHSDiWKZg==",
+      "dev": true
+    },
+    "@cspell/dict-git": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-git/-/dict-git-2.0.0.tgz",
+      "integrity": "sha512-n1AxyX5Kgxij/sZFkxFJlzn3K9y/sCcgVPg/vz4WNJ4K9YeTsUmyGLA2OQI7d10GJeiuAo2AP1iZf2A8j9aj2w==",
+      "dev": true
+    },
+    "@cspell/dict-golang": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-golang/-/dict-golang-5.0.2.tgz",
+      "integrity": "sha512-TNOQzsiLv4I56w5188OnJW+2ttjekoBl8IyPpI25GeV3dky4d+TX5pujayvcKQ+SM8vV8u2lpQpvyr4YePhiQg==",
+      "dev": true
+    },
+    "@cspell/dict-haskell": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-haskell/-/dict-haskell-4.0.1.tgz",
+      "integrity": "sha512-uRrl65mGrOmwT7NxspB4xKXFUenNC7IikmpRZW8Uzqbqcu7ZRCUfstuVH7T1rmjRgRkjcIjE4PC11luDou4wEQ==",
+      "dev": true
+    },
+    "@cspell/dict-html": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-html/-/dict-html-4.0.3.tgz",
+      "integrity": "sha512-Gae8i8rrArT0UyG1I6DHDK62b7Be6QEcBSIeWOm4VIIW1CASkN9B0qFgSVnkmfvnu1Y3H7SSaaEynKjdj3cs8w==",
+      "dev": true
+    },
+    "@cspell/dict-html-symbol-entities": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-html-symbol-entities/-/dict-html-symbol-entities-4.0.0.tgz",
+      "integrity": "sha512-HGRu+48ErJjoweR5IbcixxETRewrBb0uxQBd6xFGcxbEYCX8CnQFTAmKI5xNaIt2PKaZiJH3ijodGSqbKdsxhw==",
+      "dev": true
+    },
+    "@cspell/dict-java": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-java/-/dict-java-5.0.5.tgz",
+      "integrity": "sha512-X19AoJgWIBwJBSWGFqSgHaBR/FEykBHTMjL6EqOnhIGEyE9nvuo32tsSHjXNJ230fQxQptEvRZoaldNLtKxsRg==",
+      "dev": true
+    },
+    "@cspell/dict-k8s": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-k8s/-/dict-k8s-1.0.1.tgz",
+      "integrity": "sha512-gc5y4Nm3hVdMZNBZfU2M1AsAmObZsRWjCUk01NFPfGhFBXyVne41T7E62rpnzu5330FV/6b/TnFcPgRmak9lLw==",
+      "dev": true
+    },
+    "@cspell/dict-latex": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-latex/-/dict-latex-3.1.0.tgz",
+      "integrity": "sha512-XD5S3FY0DrYiun2vm/KKOkeaD30LXp9v5EzVTVQvmxqQrQh0HvOT3TFD7lgKbyzZaG7E+l3wS94uwwm80cOmuw==",
+      "dev": true
+    },
+    "@cspell/dict-lorem-ipsum": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-lorem-ipsum/-/dict-lorem-ipsum-3.0.0.tgz",
+      "integrity": "sha512-msEV24qEpzWZs2kcEicqYlhyBpR0amfDkJOs+iffC07si9ftqtQ+yP3lf1VFLpgqw3SQh1M1vtU7RD4sPrNlcQ==",
+      "dev": true
+    },
+    "@cspell/dict-lua": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-lua/-/dict-lua-4.0.1.tgz",
+      "integrity": "sha512-j0MFmeCouSoC6EdZTbvGe1sJ9V+ruwKSeF+zRkNNNload7R72Co5kX1haW2xLHGdlq0kqSy1ODRZKdVl0e+7hg==",
+      "dev": true
+    },
+    "@cspell/dict-node": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-node/-/dict-node-4.0.2.tgz",
+      "integrity": "sha512-FEQJ4TnMcXEFslqBQkXa5HposMoCGsiBv2ux4IZuIXgadXeHKHUHk60iarWpjhzNzQLyN2GD7NoRMd12bK3Llw==",
+      "dev": true
+    },
+    "@cspell/dict-npm": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.0.5.tgz",
+      "integrity": "sha512-eirZm4XpJNEcbmLGIwI2qXdRRlCKwEsH9mT3qCUytmbj6S6yn63F+8bShMW/yQBedV7+GXq9Td+cJdqiVutOiA==",
+      "dev": true
+    },
+    "@cspell/dict-php": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-php/-/dict-php-3.0.4.tgz",
+      "integrity": "sha512-QX6zE/ZfnT3O5lSwV8EPVh8Va39ds34gSNNR8I4GWiuDpKcTkZPFi4OLoP3Tlhbl/3G0Ha35OkSDLvZfu8mnkA==",
+      "dev": true
+    },
+    "@cspell/dict-powershell": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-powershell/-/dict-powershell-4.0.2.tgz",
+      "integrity": "sha512-3Wk2Z0fxpewML0zq4a9W5IsPZ0YwvzA8c6ykFdwQ0xcBQc/xRfdb9Z5drYXf9bobck1+MacGrprSeQXrmeByNQ==",
+      "dev": true
+    },
+    "@cspell/dict-public-licenses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-public-licenses/-/dict-public-licenses-2.0.1.tgz",
+      "integrity": "sha512-NZNwzkL5BqKddepDxvX/Qbji378Mso1TdnV4RFAN8hJoo6dSR0fv2TTI/Y0i/YWBmfmQGyTpEztBXtAw4qgjiA==",
+      "dev": true
+    },
+    "@cspell/dict-python": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-python/-/dict-python-4.0.1.tgz",
+      "integrity": "sha512-1wtUgyaTqRiQY0/fryk0oW22lcxNUnZ5DwteTzfatMdbgR0OHXTlHbI8vYxpHLWalSoch7EpLsnaymG+fOrt8g==",
+      "dev": true
+    },
+    "@cspell/dict-r": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-r/-/dict-r-2.0.1.tgz",
+      "integrity": "sha512-KCmKaeYMLm2Ip79mlYPc8p+B2uzwBp4KMkzeLd5E6jUlCL93Y5Nvq68wV5fRLDRTf7N1LvofkVFWfDcednFOgA==",
+      "dev": true
+    },
+    "@cspell/dict-ruby": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-ruby/-/dict-ruby-4.0.2.tgz",
+      "integrity": "sha512-fCoQHvLhTAetzXCUZMpyoCUPFMiyLHuECIPOiuYW6TGnP2eGV9y4j2J8HAOVtkyxOKUoyK+zZgtrma64yTUMkg==",
+      "dev": true
+    },
+    "@cspell/dict-rust": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-rust/-/dict-rust-4.0.1.tgz",
+      "integrity": "sha512-xJSSzHDK2z6lSVaOmMxl3PTOtfoffaxMo7fTcbZUF+SCJzfKbO6vnN9TCGX2sx1RHFDz66Js6goz6SAZQdOwaw==",
+      "dev": true
+    },
+    "@cspell/dict-scala": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-scala/-/dict-scala-4.0.1.tgz",
+      "integrity": "sha512-UvdQpAugrCqRC+2wfqJ4FFKpJr+spLrrrAmqdWEgAyZNMz8ib9FkO+yoIQnNFeodzI9xVPN9Hror+MjXbb2soQ==",
+      "dev": true
+    },
+    "@cspell/dict-software-terms": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-3.1.5.tgz",
+      "integrity": "sha512-wmkWHHkp2AN9EDWNBLB0VASB5OtsC3KnhoAHxCJzC6AB3xjYoBfKsvgI/o50gfbsCVQceHpqXjOEYSw/xxTKNw==",
+      "dev": true
+    },
+    "@cspell/dict-sql": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-sql/-/dict-sql-2.0.2.tgz",
+      "integrity": "sha512-XxUoamMFU9OGcDHLY6+pTlQDsqq9wcY7Oc4C55hqmotxFeFaaqinoD1UIAm1yDngRP7fKK4mVPPFmJI6bmspHg==",
+      "dev": true
+    },
+    "@cspell/dict-svelte": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-svelte/-/dict-svelte-1.0.2.tgz",
+      "integrity": "sha512-rPJmnn/GsDs0btNvrRBciOhngKV98yZ9SHmg8qI6HLS8hZKvcXc0LMsf9LLuMK1TmS2+WQFAan6qeqg6bBxL2Q==",
+      "dev": true
+    },
+    "@cspell/dict-swift": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-swift/-/dict-swift-2.0.1.tgz",
+      "integrity": "sha512-gxrCMUOndOk7xZFmXNtkCEeroZRnS2VbeaIPiymGRHj5H+qfTAzAKxtv7jJbVA3YYvEzWcVE2oKDP4wcbhIERw==",
+      "dev": true
+    },
+    "@cspell/dict-typescript": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-typescript/-/dict-typescript-3.1.1.tgz",
+      "integrity": "sha512-N9vNJZoOXmmrFPR4ir3rGvnqqwmQGgOYoL1+y6D4oIhyr7FhaYiyF/d7QT61RmjZQcATMa6PSL+ZisCeRLx9+A==",
+      "dev": true
+    },
+    "@cspell/dict-vue": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-vue/-/dict-vue-3.0.0.tgz",
+      "integrity": "sha512-niiEMPWPV9IeRBRzZ0TBZmNnkK3olkOPYxC1Ny2AX4TGlYRajcW0WUtoSHmvvjZNfWLSg2L6ruiBeuPSbjnG6A==",
+      "dev": true
+    },
+    "@cspell/dynamic-import": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-6.27.0.tgz",
+      "integrity": "sha512-PrBAH0+6OERWeY57PUH+9WmxYtUBnBjTYmm+3Zpg3SUd/ToD0cNf83OJCrcDF7KNQYE9rjCPUfVdsOe3aJlIHw==",
+      "dev": true,
+      "requires": {
+        "import-meta-resolve": "^2.2.1"
+      }
+    },
+    "@cspell/strong-weak-map": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-6.27.0.tgz",
+      "integrity": "sha512-4hel0Dik7GTX8yVOjOXlumIOzYD8mWzDeyMEhEJb3qwDfsTPeeYo1EMTSgtS+oJXR6kQ09qBrF1lok44v6NOAQ==",
       "dev": true
     },
     "@csstools/css-parser-algorithms": {
@@ -21264,6 +22585,12 @@
         "is-string": "^1.0.7"
       }
     },
+    "array-timsort": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-timsort/-/array-timsort-1.0.3.tgz",
+      "integrity": "sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==",
+      "dev": true
+    },
     "array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -21923,6 +23250,27 @@
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
       "dev": true
     },
+    "clear-module": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/clear-module/-/clear-module-4.1.2.tgz",
+      "integrity": "sha512-LWAxzHqdHsAZlPlEyJ2Poz6AIs384mPeqLVCru2p0BrP9G/kVGuhNyZYClLO6cXlnuJjzC8xtsJIuMjKqLXoAw==",
+      "dev": true,
+      "requires": {
+        "parent-module": "^2.0.0",
+        "resolve-from": "^5.0.0"
+      },
+      "dependencies": {
+        "parent-module": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-2.0.0.tgz",
+          "integrity": "sha512-uo0Z9JJeWzv8BG+tRcapBKNJ0dro9cLyczGzulS6EfeyAdeC9sbojtW6XwvYxJkEne9En+J2XEl4zyglVeIwFg==",
+          "dev": true,
+          "requires": {
+            "callsites": "^3.1.0"
+          }
+        }
+      }
+    },
     "cli-cursor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
@@ -22075,6 +23423,27 @@
       "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
       "dev": true
     },
+    "comment-json": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-4.2.3.tgz",
+      "integrity": "sha512-SsxdiOf064DWoZLH799Ata6u7iV658A11PlWtZATDlXPpKGJnbJZ5Z24ybixAi+LUUqJ/GKowAejtC5GFUG7Tw==",
+      "dev": true,
+      "requires": {
+        "array-timsort": "^1.0.3",
+        "core-util-is": "^1.0.3",
+        "esprima": "^4.0.1",
+        "has-own-prop": "^2.0.0",
+        "repeat-string": "^1.6.1"
+      },
+      "dependencies": {
+        "core-util-is": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+          "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+          "dev": true
+        }
+      }
+    },
     "common-path-prefix": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-3.0.0.tgz",
@@ -22163,6 +23532,34 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
+    },
+    "configstore": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
+      "integrity": "sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==",
+      "dev": true,
+      "requires": {
+        "dot-prop": "^5.2.0",
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^3.0.0",
+        "unique-string": "^2.0.0",
+        "write-file-atomic": "^3.0.0",
+        "xdg-basedir": "^4.0.0"
+      },
+      "dependencies": {
+        "write-file-atomic": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+          "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+          "dev": true,
+          "requires": {
+            "imurmurhash": "^0.1.4",
+            "is-typedarray": "^1.0.0",
+            "signal-exit": "^3.0.2",
+            "typedarray-to-buffer": "^3.1.5"
+          }
+        }
+      }
     },
     "connect-history-api-fallback": {
       "version": "2.0.0",
@@ -22298,6 +23695,246 @@
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
+      }
+    },
+    "crypto-random-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
+      "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
+      "dev": true
+    },
+    "cspell": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/cspell/-/cspell-6.27.0.tgz",
+      "integrity": "sha512-BhDzXJIRFcpswOy32tgnoOw2OdSM91pQuUpRxfZvRxdM4HBxUrodDYJ5HbBz7D0vNBrXFidFX/157KNX4m1gmg==",
+      "dev": true,
+      "requires": {
+        "@cspell/cspell-pipe": "6.27.0",
+        "@cspell/dynamic-import": "6.27.0",
+        "chalk": "^4.1.2",
+        "commander": "^10.0.0",
+        "cspell-gitignore": "6.27.0",
+        "cspell-glob": "6.27.0",
+        "cspell-io": "6.27.0",
+        "cspell-lib": "6.27.0",
+        "fast-glob": "^3.2.12",
+        "fast-json-stable-stringify": "^2.1.0",
+        "file-entry-cache": "^6.0.1",
+        "get-stdin": "^8.0.0",
+        "imurmurhash": "^0.1.4",
+        "semver": "^7.3.8",
+        "strip-ansi": "^6.0.1",
+        "vscode-uri": "^3.0.7"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "commander": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.0.tgz",
+          "integrity": "sha512-zS5PnTI22FIRM6ylNW8G4Ap0IEOyk62fhLSD0+uHRT9McRCLGpkVNvao4bjimpK/GShynyQkFFxHhwMcETmduA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
+    },
+    "cspell-cli": {
+      "version": "git+ssh://git@github.com/streetsidesoftware/cspell-cli.git#37dbd5d52b7fd05fb44b59af89e6b2b77e43b609",
+      "dev": true,
+      "from": "cspell-cli@github:streetsidesoftware/cspell-cli",
+      "requires": {
+        "cspell": "^6.27.0"
+      }
+    },
+    "cspell-dictionary": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-6.27.0.tgz",
+      "integrity": "sha512-u2HZ6Yl0tIBzflJ9Rt5i15kP1KN41XtyKfqCCntugX3gYtfbQ1t/HvAPcq4g7EDZV2tzqSKGcNvzuJgHJyxxFw==",
+      "dev": true,
+      "requires": {
+        "@cspell/cspell-pipe": "6.27.0",
+        "@cspell/cspell-types": "6.27.0",
+        "cspell-trie-lib": "6.27.0",
+        "fast-equals": "^4.0.3",
+        "gensequence": "^4.0.3"
+      }
+    },
+    "cspell-gitignore": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-6.27.0.tgz",
+      "integrity": "sha512-aXIuSMtm2pW8Z0y4SHBqvXwY4Hk3lz4b3PD50IU1gn2mjk8GioEYAnWlN/FANeOuMjOXiRfLaX0McvNErnZxdw==",
+      "dev": true,
+      "requires": {
+        "cspell-glob": "6.27.0",
+        "find-up": "^5.0.0"
+      }
+    },
+    "cspell-glob": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-6.27.0.tgz",
+      "integrity": "sha512-YzS9SiNU5iFIdEMCeVOsGlCvffCM7M51io9ylkkY6138NLCnqWw/DSePzIAAsuLqh9nsJt8xiXrHPerKiPnN3g==",
+      "dev": true,
+      "requires": {
+        "micromatch": "^4.0.5"
+      }
+    },
+    "cspell-grammar": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-6.27.0.tgz",
+      "integrity": "sha512-03SH0+bWazhkzUUK+t6ywUZvWuDcqj4J171oIdA3fvdG7nBpTqyFc1/vU1mReZK7CDde16BUaqCkWgf+El+N1w==",
+      "dev": true,
+      "requires": {
+        "@cspell/cspell-pipe": "6.27.0",
+        "@cspell/cspell-types": "6.27.0"
+      }
+    },
+    "cspell-io": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-6.27.0.tgz",
+      "integrity": "sha512-WsvXjbbWwIQVembEtlNuC8cJrGtyUuk8GvZzL9bBpSofU2UXvFjaQ9bAZjIeHibGQrIIuOM0ra0CqOcLb5mShA==",
+      "dev": true,
+      "requires": {
+        "@cspell/cspell-service-bus": "6.27.0",
+        "node-fetch": "^2.6.9"
+      }
+    },
+    "cspell-lib": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-6.27.0.tgz",
+      "integrity": "sha512-wwi3VCFiWaVFrV/ycm4yNBjjPY3pyhWud4lVJs51p2IkKqJbmR7hZ+bSIyw6d9MVzPKRD67eMaNBYXFGDaNHGQ==",
+      "dev": true,
+      "requires": {
+        "@cspell/cspell-bundled-dicts": "6.27.0",
+        "@cspell/cspell-pipe": "6.27.0",
+        "@cspell/cspell-types": "6.27.0",
+        "@cspell/strong-weak-map": "6.27.0",
+        "clear-module": "^4.1.2",
+        "comment-json": "^4.2.3",
+        "configstore": "^5.0.1",
+        "cosmiconfig": "8.0.0",
+        "cspell-dictionary": "6.27.0",
+        "cspell-glob": "6.27.0",
+        "cspell-grammar": "6.27.0",
+        "cspell-io": "6.27.0",
+        "cspell-trie-lib": "6.27.0",
+        "fast-equals": "^4.0.3",
+        "find-up": "^5.0.0",
+        "gensequence": "^4.0.3",
+        "import-fresh": "^3.3.0",
+        "resolve-from": "^5.0.0",
+        "resolve-global": "^1.0.0",
+        "vscode-languageserver-textdocument": "^1.0.8",
+        "vscode-uri": "^3.0.7"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "dev": true
+        },
+        "cosmiconfig": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.0.0.tgz",
+          "integrity": "sha512-da1EafcpH6b/TD8vDRaWV7xFINlHlF6zKsGwS1TsuVJTZRkquaS5HTMq7uq6h31619QjbsYl21gVDOm32KM1vQ==",
+          "dev": true,
+          "requires": {
+            "import-fresh": "^3.2.1",
+            "js-yaml": "^4.1.0",
+            "parse-json": "^5.0.0",
+            "path-type": "^4.0.0"
+          }
+        },
+        "js-yaml": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+          "dev": true,
+          "requires": {
+            "argparse": "^2.0.1"
+          }
+        }
+      }
+    },
+    "cspell-trie-lib": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-6.27.0.tgz",
+      "integrity": "sha512-kelDXszZKzlWbk7hV3cTtWYd2Gs3MXqTNSL3udtN4Oow74ik+h1bWsOOmXKKjtKvRctx4omWC1JdriQXfhBMBA==",
+      "dev": true,
+      "requires": {
+        "@cspell/cspell-pipe": "6.27.0",
+        "@cspell/cspell-types": "6.27.0",
+        "gensequence": "^4.0.3"
       }
     },
     "css-declaration-sorter": {
@@ -22785,6 +24422,15 @@
         "dom-serializer": "^1.0.1",
         "domelementtype": "^2.2.0",
         "domhandler": "^4.2.0"
+      }
+    },
+    "dot-prop": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+      "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
+      "dev": true,
+      "requires": {
+        "is-obj": "^2.0.0"
       }
     },
     "ecc-jsbn": {
@@ -23790,6 +25436,12 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
     },
+    "fast-equals": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-4.0.3.tgz",
+      "integrity": "sha512-G3BSX9cfKttjr+2o1O22tYMLq0DPluZnYtq1rXumE1SpL/F/SLIfHx08WYQoWSIpeMYf8sRbJ8++71+v6Pnxfg==",
+      "dev": true
+    },
     "fast-glob": {
       "version": "3.2.12",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
@@ -24027,13 +25679,6 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
-    "fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "optional": true
-    },
     "fstream": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
@@ -24096,6 +25741,12 @@
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
       "dev": true
     },
+    "gensequence": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gensequence/-/gensequence-4.0.3.tgz",
+      "integrity": "sha512-izr+MKqJKjexkvLiPGhW96elQX8TuUR/su/xzILxjqzU1RDz1n1ZbqwDUnNFaRcq0gFR3oQfNH2JOH4Je1x/QA==",
+      "dev": true
+    },
     "gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -24123,6 +25774,12 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
       "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "dev": true
+    },
+    "get-stdin": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz",
+      "integrity": "sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==",
       "dev": true
     },
     "get-stream": {
@@ -24209,6 +25866,15 @@
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "dev": true
+    },
+    "global-dirs": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+      "integrity": "sha512-NknMLn7F2J7aflwFOlGdNIuCDpN3VGoSoB+aap3KABFWbHVn1TCgFC+np23J8W2BiZbjfEw3BFBycSMv1AFblg==",
+      "dev": true,
+      "requires": {
+        "ini": "^1.3.4"
+      }
     },
     "global-modules": {
       "version": "2.0.0",
@@ -24382,6 +26048,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true
+    },
+    "has-own-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-own-prop/-/has-own-prop-2.0.0.tgz",
+      "integrity": "sha512-Pq0h+hvsVm6dDEa8x82GnLSYHOzNDt7f0ddFa3FqcQlgzEiptPqL+XrOJNavjOzSYiYWIrgeVYYgGlLmnxwilQ==",
       "dev": true
     },
     "has-property-descriptors": {
@@ -24689,6 +26361,12 @@
         "resolve-cwd": "^3.0.0"
       }
     },
+    "import-meta-resolve": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-2.2.1.tgz",
+      "integrity": "sha512-C6lLL7EJPY44kBvA80gq4uMsVFw5x3oSKfuMl1cuZ2RkI5+UJqQXgn+6hlUew0y4ig7Ypt4CObAAIzU53Nfpuw==",
+      "dev": true
+    },
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -24966,6 +26644,12 @@
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
+    },
+    "is-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+      "dev": true
     },
     "is-path-inside": {
       "version": "3.0.3",
@@ -27274,6 +28958,39 @@
       "integrity": "sha512-ye8AIYWQcP9MvoM1i0Z2jV0qed31Z8EWXYnyGNkiUAd+Fo8J+7uy90xTV8g/oAbhtjkY7iZbNTizQaXdKUuwpQ==",
       "dev": true
     },
+    "node-fetch": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
+      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
+      "dev": true,
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+          "dev": true
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+          "dev": true
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+          "dev": true,
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        }
+      }
+    },
     "node-forge": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
@@ -28557,6 +30274,12 @@
         }
       }
     },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
+      "dev": true
+    },
     "request": {
       "version": "2.88.2",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
@@ -28660,6 +30383,15 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
       "dev": true
+    },
+    "resolve-global": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-global/-/resolve-global-1.0.0.tgz",
+      "integrity": "sha512-zFa12V4OLtT5XUX/Q4VLvTfBf+Ok0SPc1FNGM/z9ctUdiU618qwKpWnd0CHs3+RqROfyEg/DhuHbMWYqcgljEw==",
+      "dev": true,
+      "requires": {
+        "global-dirs": "^0.1.1"
+      }
     },
     "resolve.exports": {
       "version": "2.0.0",
@@ -30222,6 +31954,15 @@
         "is-typed-array": "^1.1.9"
       }
     },
+    "typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "dev": true,
+      "requires": {
+        "is-typedarray": "^1.0.0"
+      }
+    },
     "typedoc": {
       "version": "0.23.26",
       "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.26.tgz",
@@ -30318,6 +32059,15 @@
       "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz",
       "integrity": "sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==",
       "dev": true
+    },
+    "unique-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
+      "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
+      "dev": true,
+      "requires": {
+        "crypto-random-string": "^2.0.0"
+      }
     },
     "universalify": {
       "version": "0.2.0",
@@ -30428,6 +32178,12 @@
         "extsprintf": "^1.2.0"
       }
     },
+    "vscode-languageserver-textdocument": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.8.tgz",
+      "integrity": "sha512-1bonkGqQs5/fxGT5UchTgjGVnfysL0O8v1AYMBjqTbWQTFn721zaPGDYFkOKtfDgFiSgXM3KwaG3FMGfW4Ed9Q==",
+      "dev": true
+    },
     "vscode-oniguruma": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
@@ -30438,6 +32194,12 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
       "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
+      "dev": true
+    },
+    "vscode-uri": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.7.tgz",
+      "integrity": "sha512-eOpPHogvorZRobNqJGhapa0JdwaxpjVvyBp0QIUMRMSf8ZAlqOdEquKuRmw9Qwu0qXtJIWqFtMkmvJjUZmMjVA==",
       "dev": true
     },
     "w3c-xmlserializer": {
@@ -30822,6 +32584,12 @@
       "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
       "dev": true,
       "requires": {}
+    },
+    "xdg-basedir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
+      "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
+      "dev": true
     },
     "xml-name-validator": {
       "version": "4.0.0",

--- a/web/package.json
+++ b/web/package.json
@@ -42,6 +42,7 @@
     "chrome-remote-interface": "^0.32.1",
     "compression-webpack-plugin": "^10.0.0",
     "copy-webpack-plugin": "^11.0.0",
+    "cspell-cli": "github:streetsidesoftware/cspell-cli",
     "css-loader": "^6.5.0",
     "css-minimizer-webpack-plugin": "^4.2.2",
     "eslint": "^8.28.0",

--- a/web/package.json
+++ b/web/package.json
@@ -12,6 +12,7 @@
     "server": "webpack server",
     "watch": "webpack --watch --progress",
     "build": "webpack",
+    "cspell": "cspell --no-progress --show-suggestions src",
     "eslint": "eslint --ext .js --ext .jsx src/",
     "eslint:fix": "eslint --fix --ext .js --ext .jsx src/",
     "stylelint": "stylelint 'src/**/*.{css,scss}'",

--- a/web/src/assets/fonts.scss
+++ b/web/src/assets/fonts.scss
@@ -3,7 +3,7 @@
  * http://www.latofonts.com/team) and published under the open-source Open Font License
  * https://scripts.sil.org/cms/scripts/page.php?site_id=nrsi&id=OFL
  *
- * Font files downloaded brom its web page https://www.latofonts.com/
+ * Font files downloaded from its web page https://www.latofonts.com/
  * Note: At the time of writing, Google Fonts only use the older version (1.0)
  */
 

--- a/web/src/assets/fonts.scss
+++ b/web/src/assets/fonts.scss
@@ -1,3 +1,5 @@
+// cspell:ignore Jonny Pinhorn Łukasz Dziedzic
+
 /**
  * Lato font, a sanserif family designed by Łukasz Dziedzic and others (see
  * http://www.latofonts.com/team) and published under the open-source Open Font License

--- a/web/src/client/language.test.js
+++ b/web/src/client/language.test.js
@@ -20,6 +20,7 @@
  */
 
 // @ts-check
+// cspell:ignore Cestina
 
 import DBusClient from "./dbus";
 import { LanguageClient } from "./language";

--- a/web/src/components/core/Fieldset.jsx
+++ b/web/src/components/core/Fieldset.jsx
@@ -25,7 +25,7 @@ import React from "react";
 
 /**
  * Convenient component for grouping form fields in "sections"
- * by using the native formfield element
+ * by using the native fieldset element
  *
  * @component
  *

--- a/web/src/components/core/ProgressReport.test.jsx
+++ b/web/src/components/core/ProgressReport.test.jsx
@@ -102,7 +102,7 @@ describe("ProgressReport", () => {
 
         await screen.findByText(/Waiting/i);
 
-        // NOTE: there can be more than one susbcriptions to the
+        // NOTE: there can be more than one subscriptions to the
         // manager#onChange. We're interested in the latest one here.
         const cb0 = callbacks.manager[callbacks.manager.length - 1];
         act(() => {

--- a/web/src/components/layout/Layout.jsx
+++ b/web/src/components/layout/Layout.jsx
@@ -144,7 +144,7 @@ const MainActions = FooterActions.Source;
  * Component for setting the additional content shown at the footer
  *
  * @example
- *   import { AdditionaInfo } from "dinstaller-layout";
+ *   import { AdditionalInfo } from "dinstaller-layout";
  *   import { About, HostIp } from "somewhere";
  *
  *   ...

--- a/web/src/components/network/WifiNetworksList.test.jsx
+++ b/web/src/components/network/WifiNetworksList.test.jsx
@@ -38,7 +38,7 @@ const myNetwork = {
 const otherNetwork = {
   ssid: "My Neighbor Network",
   security: ["WPA2"],
-  strengh: 35
+  strength: 35
 };
 
 const networksMock = [myNetwork, otherNetwork];

--- a/web/src/components/questions/LuksActivationQuestion.test.jsx
+++ b/web/src/components/questions/LuksActivationQuestion.test.jsx
@@ -118,7 +118,7 @@ describe("LuksActivationQuestion", () => {
       });
     });
 
-    describe("submiting the form by pressing 'enter'", () => {
+    describe("submitting the form by pressing 'enter'", () => {
       it("calls the callback after setting both, answer and password", async() => {
         const { user } = renderQuestion();
 


### PR DESCRIPTION
## Problem

While working in #443, I found _few_ typos in the code, a bunch of them sent by myself :sweat_smile:  Sadly, typos are easy to type but so hard to spot. And not only for me, read https://www.scienceabc.com/humans/why-is-it-so-difficult-to-spot-your-own-typos.html.

<p align="center">

<img src="https://user-images.githubusercontent.com/1691872/222589879-d3deb2dd-3a08-47c7-abf0-91794402e1e0.jpg" />

</p>



## Solution

Add a spell checker to help us to detect them. Specifically [cspell](https://github.com/streetsidesoftware/cspell).

## Notes

* Changes were made on top of `add-missing-sections` branch. If we're willing to include them in `master`, I can adapt them after mentioned branch got merged.
* There is an [eslint plugin](https://github.com/streetsidesoftware/cspell/tree/main/packages/cspell-eslint-plugin) that could help to spot typos while executing the linter or even right away in your editor if it's properly configured. However, I'm proposing to use just a _plain npm task_ for checking the CSS files too. There is not a stylelint plugin yet.
* In my opinion, this change does not deserve an entry in the changes file.

---

<sub>Image borrowed from the article.</sub>

