### PR TITLE
[web] Use react-teleporter from YaST fork

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -16,7 +16,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.3.0",
-        "react-teleporter": "^3.0.2",
+        "react-teleporter": "github:yast/react-teleporter#support-function-as-source",
         "regenerator-runtime": "^0.13.9"
       },
       "devDependencies": {
@@ -15297,8 +15297,8 @@
     },
     "node_modules/react-teleporter": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/react-teleporter/-/react-teleporter-3.0.2.tgz",
-      "integrity": "sha512-6kxP/r01akC0NO/oWgz6bFJQFsDD0CSqKB6c+F3f2locfBUrDK+I8fic17W6idVL/Hv3ab72N2c3DyrL2+y4kQ==",
+      "resolved": "git+ssh://git@github.com/yast/react-teleporter.git#df72c5725762342194031479c74a03447bd514e1",
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/gregberge"
@@ -30044,9 +30044,8 @@
       }
     },
     "react-teleporter": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/react-teleporter/-/react-teleporter-3.0.2.tgz",
-      "integrity": "sha512-6kxP/r01akC0NO/oWgz6bFJQFsDD0CSqKB6c+F3f2locfBUrDK+I8fic17W6idVL/Hv3ab72N2c3DyrL2+y4kQ==",
+      "version": "git+ssh://git@github.com/yast/react-teleporter.git#df72c5725762342194031479c74a03447bd514e1",
+      "from": "react-teleporter@github:yast/react-teleporter#support-function-as-source",
       "requires": {}
     },
     "read": {

--- a/web/package.json
+++ b/web/package.json
@@ -99,7 +99,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.3.0",
-    "react-teleporter": "^3.0.2",
+    "react-teleporter": "github:yast/react-teleporter#support-function-as-source",
     "regenerator-runtime": "^0.13.9"
   }
 }


### PR DESCRIPTION
At least temporary, until https://github.com/gregberge/react-teleporter/pull/49 or similar solution will be merged. 

Needed to address the use case exposed at https://github.com/gregberge/react-teleporter/pull/47, 

> **sidebar closing itself when the user clicks on any of the actions held by it**. Check out this [codesandbox project](https://codesandbox.io/p/sandbox/react-teleporter-bubbling-demo-x3wo4f) where it is illustrated that it does not work for teleported links (think in a contextual actions sections inside the sidebar).

The solution is to make the `Source` able to receive a function as `children`, which should make possible to implement the use case and even cover other use cases.

