### PR TITLE
[web] Section component improvements

### DIFF
--- a/web/src/assets/styles/blocks.scss
+++ b/web/src/assets/styles/blocks.scss
@@ -17,7 +17,15 @@ section > svg {
 section > h2 {
   grid-area: title;
 
-  a {
+  button {
+    border: none;
+    background: none;
+    color: inherit;
+    font: inherit;
+    padding: 0;
+  }
+
+  a, button {
     text-decoration: underline;
     text-decoration-thickness: 0.1em;
     text-underline-offset: 0.2em;

--- a/web/src/components/core/Section.jsx
+++ b/web/src/components/core/Section.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2022] SUSE LLC
+ * Copyright (c) [2022-2023] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -23,29 +23,69 @@
 
 import React from "react";
 import { Link } from "react-router-dom";
-import {
-  Button,
-  Text,
-  TextContent,
-  TextVariants,
-  Tooltip
-} from "@patternfly/react-core";
-
+import { Text, TextVariants } from "@patternfly/react-core";
 import { Icon } from '~/components/layout';
 import { ValidationErrors } from "~/components/core";
 
 /**
- * Helper method for rendering section icon
+ * Internal component for rendering the section icon
  *
- * @param {string} name
- * @param {number} [size=32]
+ * @param {object} props
+ * @param {string} [props.name] - the name of the icon
+ * @param {number} [props.size=32] - the icon size
  *
  * @return {React.ReactNode}
  */
-const renderIcon = (name, size = 32) => {
+const SectionIcon = ({ name, size = 32 }) => {
   if (!name) return null;
 
   return <Icon name={name} size={size} aria-hidden />;
+};
+
+/**
+ * Internal component for rendering the section title
+ *
+ *  NOTE: a section can do either, navigate to a page following given path or
+ *  open a dialog triggering the openDialog callback but not both. Thus, if path
+ *  is given onDialogCallback will be completely ignored. page or open a dialog,
+ *  but not both.
+ *
+ * @param {object} props
+ * @param {string} props.text - the title for the section
+ * @param {string} props.path - the path where the section links to. If present, props.openDialog is ignored
+ * @param {function} [props.openDialog] - callback to be triggered when user clicks on the title, used for opening a dialog.
+ *
+ * @return {React.ReactNode}
+ */
+const SectionTitle = ({ text, path, openDialog }) => {
+  let title = text;
+
+  if (path && path !== "") {
+    title = <Link to={path}>{text}</Link>;
+  } else if (typeof openDialog === "function") {
+    // NOTE: using a native button here on purpose
+    title = <button onClick={openDialog}>{text}</button>;
+  }
+
+  return (
+    <Text component={TextVariants.h2}>
+      {title}
+    </Text>
+  );
+};
+
+/**
+ * Internal component for wrapping and rendering the section content
+ *
+ * @param {JSX.Element} [props.children] - the content to be wrapped
+ * @return {React.ReactNode}
+ */
+const SectionContent = ({ children }) => {
+  return (
+    <div className="stack content">
+      {children}
+    </div>
+  );
 };
 
 /**
@@ -53,118 +93,58 @@ const renderIcon = (name, size = 32) => {
  * Displays an installation section
  * @component
  *
+ *  NOTE: a section can do either, navigate to a page following given path or
+ *  open a dialog triggering the openDialog callback but not both. Thus, if path
+ *  is given onDialogCallback will be completely ignored. page or open a dialog,
+ *  but not both.
+ *
  * @example <caption>Simple usage</caption>
- *   <Section title="Users" icon={UsersIcon}>
- *     <UserSectionContent />
+ *   <Section title="Users" icon="manage_accounts">
+ *     <UsersSummary />
  *   </Section>
  *
- * @example <caption>A section with a description</caption>
- *   <Section title="Users" icon={UsersIcon} description="Use this section for setting the user data">
- *     <UserSectionContent />
+ * @example <caption>A section that allows navigating to a page</caption>
+ *   <Section title="Users" icon="manage_accounts" path="/users">
+ *     <UsersSummary />
  *   </Section>
  *
- * @example <caption>A section without icon but settings action with tooltip</caption>
+ * @example <caption>A section that allows opening a settings dialog</caption>
  *   <Section
- *     key="language"
- *     title="Language"
- *     actionTooltip="Click here for tweaking language settings"
- *     onActionClick={() => setLanguageSettingsVisible(true)}
+ *     title="L10n"
+ *     icon="translate"
+ *     openDialog={() => setLanguageSettingsOpen(true)}
  *   >
- *     <LanguageSelector />
- *   </Section>
- *
- * @example <caption>A section with title separator and custom action icon</caption>
- *   <Section
- *     title="Target"
- *     icon={TargetIcon}
- *     actionIcon={TargetSettingIcon}
- *     onActionClick={() => setDisplayTargetSettings(true)}
- *     usingSeparator
- *   >
- *     <StorageTargetSelector />
+ *     <L10nSummary />
+ *     <L10nSettings />
  *   </Section>
  *
  * @param {object} props
- * @param {string} props.title - The title for the section
- * @param {string} props.path - The path where the section link to
- * @param {string} [props.description] - A tiny description for the section
- * @param {boolean} [props.hasSeparator] - whether or not a thin border should be shown between title and content
- * @param {boolean} [props.loading] - whether the section is loading the content
  * @param {string} [props.icon] - the name of the icon section, if any
- * @param {string} [props.actionIconName="settings"] - name for the icon for linking to section settings, when needed
- * @param {React.ReactNode} [props.actionTooltip] - text to be shown as a tooltip when user hovers action icon, if present
- * @param {React.MouseEventHandler} [props.onActionClick] - callback to be triggered when user clicks on action icon, if present
+ * @param {string} props.title - The title for the section
+ * @param {string} props.path - The path where the section links to. If present, props.openDialog is ignored
+ * @param {function} [props.openDialog] - callback to be triggered when user clicks on the title, used for opening a dialog.
+ * @param {boolean} [props.loading] - whether the section is busy loading its content or not
  * @param {import("~/client/mixins").ValidationError[]} [props.errors] - Validation errors to be shown before the title
  * @param {JSX.Element} [props.children] - the section content
  */
 export default function Section({
+  icon,
   title,
   path,
-  description,
-  hasSeparator,
-  icon,
+  openDialog,
   loading,
-  actionIconName = "settings",
-  actionTooltip,
-  onActionClick,
   errors,
   children,
 }) {
-  const renderAction = () => {
-    if (typeof onActionClick !== 'function') return null;
-
-    const Action = () => (
-      <Button
-        isInline
-        variant="link"
-        className="transform-on-hover"
-        onClick={onActionClick}
-        aria-label="Section settings"
-      >
-        {renderIcon(actionIconName, 16)}
-      </Button>
-    );
-
-    if (!actionTooltip) return <Action />;
-
-    return (
-      <Tooltip content={actionTooltip} position="right" distance={10} entryDelay={200} exitDelay={200}>
-        <Action />
-      </Tooltip>
-    );
-  };
-
-  const renderTitle = () => {
-    if (!path || path === "") return title;
-
-    return <Link to={path}>{title}</Link>;
-  };
-
-  let headerClassNames = "split";
-  if (hasSeparator) headerClassNames += " gradient-border-bottom";
-
-  const iconName = loading ? "loading" : icon;
-
   return (
     <section>
-      {renderIcon(iconName, 32)}
-
-      <Text component={TextVariants.h2} className={headerClassNames}>
-        {renderTitle()}
-        {renderAction()}
-      </Text>
-
-      <div className="stack content">
-        {description && description !== "" &&
-          <TextContent>
-            <Text component={TextVariants.small}>
-              {description}
-            </Text>
-          </TextContent>}
+      <SectionIcon name={loading ? "loading" : icon} />
+      <SectionTitle text={title} path={path} openDialog={openDialog} />
+      <SectionContent>
         {errors?.length > 0 &&
           <ValidationErrors errors={errors} title={`${title} errors`} />}
         {children}
-      </div>
+      </SectionContent>
     </section>
   );
 }

--- a/web/src/components/core/Section.jsx
+++ b/web/src/components/core/Section.jsx
@@ -45,11 +45,6 @@ const SectionIcon = ({ name, size = 32 }) => {
 /**
  * Internal component for rendering the section title
  *
- *  NOTE: a section can do either, navigate to a page following given path or
- *  open a dialog triggering the openDialog callback but not both. Thus, if path
- *  is given onDialogCallback will be completely ignored. page or open a dialog,
- *  but not both.
- *
  * @param {object} props
  * @param {string} props.text - the title for the section
  * @param {string} props.path - the path where the section links to. If present, props.openDialog is ignored
@@ -94,10 +89,9 @@ const SectionContent = ({ children }) => {
  * Displays an installation section
  * @component
  *
- *  NOTE: a section can do either, navigate to a page following given path or
- *  open a dialog triggering the openDialog callback but not both. Thus, if path
- *  is given onDialogCallback will be completely ignored. page or open a dialog,
- *  but not both.
+ *  NOTE: a section can do either, navigate to the given path or open a dialog
+ *  triggering the openDialog callback but not both. Thus, if path is given
+ *  openDialog callback will be completely ignored.
  *
  * @example <caption>Simple usage</caption>
  *   <Section title="Users" icon="manage_accounts">

--- a/web/src/components/core/Section.jsx
+++ b/web/src/components/core/Section.jsx
@@ -34,7 +34,7 @@ import { ValidationErrors } from "~/components/core";
  * @param {string} [props.name] - the name of the icon
  * @param {number} [props.size=32] - the icon size
  *
- * @return {React.ReactNode}
+ * @return {React.ReactElement}
  */
 const SectionIcon = ({ name, size = 32 }) => {
   if (!name) return null;
@@ -53,12 +53,12 @@ const SectionIcon = ({ name, size = 32 }) => {
  * @param {object} props
  * @param {string} props.text - the title for the section
  * @param {string} props.path - the path where the section links to. If present, props.openDialog is ignored
- * @param {function} [props.openDialog] - callback to be triggered when user clicks on the title, used for opening a dialog.
+ * @param {React.MouseEventHandler|undefined} [props.openDialog] - callback to be triggered when user clicks on the title, used for opening a dialog.
  *
- * @return {React.ReactNode}
+ * @return {JSX.Element}
  */
 const SectionTitle = ({ text, path, openDialog }) => {
-  let title = text;
+  let title = <>{text}</>;
 
   if (path && path !== "") {
     title = <Link to={path}>{text}</Link>;
@@ -77,8 +77,9 @@ const SectionTitle = ({ text, path, openDialog }) => {
 /**
  * Internal component for wrapping and rendering the section content
  *
- * @param {JSX.Element} [props.children] - the content to be wrapped
- * @return {React.ReactNode}
+ * @param {object} props
+ * @param {React.ReactElement|React.ReactElement[]} props.children - the content to be wrapped
+ * @return {JSX.Element}
  */
 const SectionContent = ({ children }) => {
   return (
@@ -122,10 +123,11 @@ const SectionContent = ({ children }) => {
  * @param {string} [props.icon] - the name of the icon section, if any
  * @param {string} props.title - The title for the section
  * @param {string} props.path - The path where the section links to. If present, props.openDialog is ignored
- * @param {function} [props.openDialog] - callback to be triggered when user clicks on the title, used for opening a dialog.
+ * @param {React.MouseEventHandler|undefined} [props.openDialog] - callback to be triggered
+ *  when user clicks on the title, used for opening a dialog.
  * @param {boolean} [props.loading] - whether the section is busy loading its content or not
  * @param {import("~/client/mixins").ValidationError[]} [props.errors] - Validation errors to be shown before the title
- * @param {JSX.Element} [props.children] - the section content
+ * @param {React.ReactElement} props.children - the section content
  */
 export default function Section({
   icon,

--- a/web/src/components/core/Section.test.jsx
+++ b/web/src/components/core/Section.test.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2022] SUSE LLC
+ * Copyright (c) [2022-2023] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -19,68 +19,98 @@
  * find current contact information at www.suse.com.
  */
 
-import React, { useState } from "react";
-import { screen } from "@testing-library/react";
-import { installerRender } from "~/test-utils";
+import React from "react";
+import { screen, within } from "@testing-library/react";
+import { plainRender } from "~/test-utils";
 import { Section } from "~/components/core";
+
+jest.mock('react-router-dom', () => ({
+  Link: ({ to, children }) => <a href={to}>{children}</a>
+}));
 
 describe("Section", () => {
   it("renders given title", () => {
-    installerRender(<Section title="Awesome settings" />);
+    plainRender(<Section title="settings" />);
 
-    screen.getByRole("heading", { name: "Awesome settings" });
-  });
-
-  it("renders given description", () => {
-    installerRender(
-      <Section title="Awesome settings" description="Intended to perform awesome tweaks" />
-    );
-
-    screen.getByText("Intended to perform awesome tweaks");
+    screen.getByRole("heading", { name: "settings" });
   });
 
   it("renders given errors", () => {
-    installerRender(
+    plainRender(
       <Section title="Awesome settings" errors={[{ message: "Something went wrong" }]} />
     );
 
     screen.getByText("Something went wrong");
   });
 
-  describe("when onActionClick callback is given", () => {
-    it("renders a link for section settings", () => {
-      installerRender(
-        <Section title="Awesome settings" onActionClick={() => null} />
-      );
+  it("renders given content", () => {
+    plainRender(
+      <Section title="Settings">
+        A settings summary
+      </Section>
+    );
 
-      screen.getByLabelText("Section settings");
+    screen.getByText("A settings summary");
+  });
+
+  it("renders an icon when set as loading", () => {
+    // TODO: add a mechanism to check that it's the expected icon. data-something attribute?
+    const { container } = plainRender(<Section title="Settings" loading />);
+    container.querySelector("svg");
+  });
+
+  it("renders an icon when a valid icon name is given", () => {
+    // TODO: add a mechanism to check that it's the expected icon. data-something attribute?
+    const { container } = plainRender(<Section title="Settings" icon="settings" />);
+    container.querySelector("svg");
+  });
+
+  it("does not render an icon when either, not loading or not icon name was given", () => {
+    // TODO: add a mechanism to check that it's the expected icon. data-something attribute?
+    const { container } = plainRender(<Section title="Settings" />);
+    const icon = container.querySelector("svg");
+    expect(icon).toBeNull();
+  });
+
+  describe("when path is given", () => {
+    it("renders a link for navigating to it", async () => {
+      plainRender(<Section title="Settings" path="/settings" />);
+      const heading = screen.getByRole("heading", { name: "Settings" });
+      const link = within(heading).getByRole("link", { name: "Settings" });
+      // NOTE: ReactRouter#Link is mocked at the top of file.
+      expect(link).toHaveAttribute("href", "/settings");
+    });
+  });
+
+  describe("when openDialog callback is given", () => {
+    describe("and path is not present", () => {
+      it("triggers it when the user click on the section title", async () => {
+        const openDialog = jest.fn();
+        const { user } = plainRender(
+          <Section title="Settings" openDialog={openDialog} />
+        );
+        const button = screen.getByRole("button", { name: "Settings" });
+        await user.click(button)
+        expect(openDialog).toHaveBeenCalled();
+      });
     });
 
-    it("triggers the action when user clicks on it", async () => {
-      const AwesomeSection = () => {
-        const [showInput, setShowInput] = useState(false);
-        return (
-          <Section title="Awesome settings" onActionClick={() => setShowInput(true)}>
-            { showInput &&
-              <>
-                <label htmlFor="awesome-input">Awesome input</label>
-                <input id="awesome-input" type="text" />
-              </> }
-          </Section>
+    describe("but path is present too", () => {
+      // Silence "Error: Not Implemented: navigation..." from jsdom when clicking a link
+      // https://github.com/jsdom/jsdom/issues/2112
+      const eventListener = (e) => e.preventDefault();
+      beforeEach(() => window.addEventListener("click", eventListener));
+      afterEach(() => window.removeEventListener("click", eventListener, true));
+
+      it("does not triggers it when the user click on the section title", async () => {
+        const openDialog = jest.fn();
+        const { user } = plainRender(
+          <Section path="/settings" title="Settings" openDialog={openDialog} />
         );
-      };
-
-      const { user } = installerRender(<AwesomeSection />);
-
-      let inputText = screen.queryByRole("textbox", { name: "Awesome input" });
-      expect(inputText).not.toBeInTheDocument();
-
-      const actionLink = screen.getByLabelText("Section settings");
-
-      await user.click(actionLink);
-
-      inputText = screen.queryByRole("textbox", { name: "Awesome input" });
-      expect(inputText).toBeInTheDocument();
+        const link = screen.getByRole("link", { name: "Settings" });
+        await user.click(link)
+        expect(openDialog).not.toHaveBeenCalled();
+      });
     });
   });
 });

--- a/web/src/components/core/Section.test.jsx
+++ b/web/src/components/core/Section.test.jsx
@@ -90,7 +90,7 @@ describe("Section", () => {
           <Section title="Settings" openDialog={openDialog} />
         );
         const button = screen.getByRole("button", { name: "Settings" });
-        await user.click(button)
+        await user.click(button);
         expect(openDialog).toHaveBeenCalled();
       });
     });
@@ -108,7 +108,7 @@ describe("Section", () => {
           <Section path="/settings" title="Settings" openDialog={openDialog} />
         );
         const link = screen.getByRole("link", { name: "Settings" });
-        await user.click(link)
+        await user.click(link);
         expect(openDialog).not.toHaveBeenCalled();
       });
     });

--- a/web/src/components/storage/ProposalActionsSection.jsx
+++ b/web/src/components/storage/ProposalActionsSection.jsx
@@ -26,11 +26,7 @@ import { ProposalActions } from "~/components/storage";
 
 export default function ProposalActionsSection({ proposal, errors }) {
   return (
-    <Section
-      title="Result"
-      hasSeparator
-      errors={errors}
-    >
+    <Section title="Result" errors={errors}>
       <ProposalActions actions={proposal.result.actions} />
     </Section>
   );

--- a/web/src/components/storage/ProposalSettingsSection.jsx
+++ b/web/src/components/storage/ProposalSettingsSection.jsx
@@ -54,12 +54,10 @@ export default function ProposalSettingsSection({ proposal, calculateProposal })
     );
   };
 
+  const openSettings = () => setIsOpen(true);
+
   return (
-    <Section
-      title="Settings"
-      onActionClick={() => setIsOpen(true)}
-      hasSeparator
-    >
+    <Section title="Settings" openDialog={openSettings}>
       <Popup title="Settings" isOpen={isOpen}>
         <ProposalSettingsForm
           id="settings-form"

--- a/web/src/components/storage/ProposalSettingsSection.test.jsx
+++ b/web/src/components/storage/ProposalSettingsSection.test.jsx
@@ -52,13 +52,7 @@ it("renders the list of the volumes to create", () => {
   screen.getByText("/test2");
 });
 
-it("renders an icon for configuring the settings", () => {
-  installerRender(<ProposalSettingsSection proposal={proposal} />);
-
-  screen.getByRole("button", { name: "Section settings" });
-});
-
-it("does not show the popup by default", async () => {
+it("does not show the settings dialog by default", async () => {
   installerRender(<ProposalSettingsSection proposal={proposal} />);
 
   await waitFor(() => {
@@ -66,23 +60,29 @@ it("does not show the popup by default", async () => {
   });
 });
 
-it("shows the popup with the form when the icon is clicked", async () => {
-  const { user } = installerRender(<ProposalSettingsSection proposal={proposal} />);
-
-  const button = screen.getByRole("button", { name: "Section settings" });
-  await user.click(button);
-
-  await screen.findByRole("dialog");
-  screen.getByRole("form", { name: "Settings form" });
-});
-
-it("closes the popup without submitting the form when cancel is clicked", async () => {
+it("allows editing the settings when the user clicks on the section title", async () => {
   const calculateFn = jest.fn();
 
   const { user } = installerRender(<ProposalSettingsSection proposal={proposal} calculateProposal={calculateFn} />);
 
-  const button = screen.getByRole("button", { name: "Section settings" });
-  await user.click(button);
+  const action = screen.getByRole("button", { name: "Settings" });
+  await user.click(action);
+
+  const popup = await screen.findByRole("dialog");
+  const accept = within(popup).getByRole("button", { name: "Accept" });
+  await user.click(accept);
+
+  expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  expect(calculateFn).toHaveBeenCalled();
+});
+
+it("allows aborting the settings edition when cancel is clicked", async () => {
+  const calculateFn = jest.fn();
+
+  const { user } = installerRender(<ProposalSettingsSection proposal={proposal} calculateProposal={calculateFn} />);
+
+  const action = screen.getByRole("button", { name: "Settings" });
+  await user.click(action);
 
   const popup = await screen.findByRole("dialog");
   const cancel = within(popup).getByRole("button", { name: "Cancel" });
@@ -92,21 +92,6 @@ it("closes the popup without submitting the form when cancel is clicked", async 
   expect(calculateFn).not.toHaveBeenCalled();
 });
 
-it("closes the popup and submits the form when accept is clicked", async () => {
-  const calculateFn = jest.fn();
-
-  const { user } = installerRender(<ProposalSettingsSection proposal={proposal} calculateProposal={calculateFn} />);
-
-  const button = screen.getByRole("button", { name: "Section settings" });
-  await user.click(button);
-
-  const popup = await screen.findByRole("dialog");
-  const accept = within(popup).getByRole("button", { name: "Accept" });
-  await user.click(accept);
-
-  expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
-  expect(calculateFn).toHaveBeenCalled();
-});
 
 describe("when neither lvm nor encryption are selected", () => {
   beforeEach(() => {

--- a/web/src/components/storage/ProposalSettingsSection.test.jsx
+++ b/web/src/components/storage/ProposalSettingsSection.test.jsx
@@ -92,7 +92,6 @@ it("allows aborting the settings edition when cancel is clicked", async () => {
   expect(calculateFn).not.toHaveBeenCalled();
 });
 
-
 describe("when neither lvm nor encryption are selected", () => {
   beforeEach(() => {
     proposal.result.lvm = false;

--- a/web/src/components/storage/ProposalTargetSection.jsx
+++ b/web/src/components/storage/ProposalTargetSection.jsx
@@ -32,7 +32,7 @@ export default function ProposalTargetSection({ proposal, calculateProposal }) {
     calculateProposal({ candidateDevices });
   };
 
-  const onActionClick = () => setIsOpen(true);
+  const openDeviceSelector = () => setIsOpen(true);
 
   const { availableDevices = [] } = proposal;
 
@@ -52,7 +52,7 @@ export default function ProposalTargetSection({ proposal, calculateProposal }) {
   );
 
   return (
-    <Section title="Device" onActionClick={renderSelector ? onActionClick : null} hasSeparator>
+    <Section title="Device" openDialog={renderSelector ? openDeviceSelector : null}>
       <If condition={renderSelector} then={<Content />} else="No available devices" />
     </Section>
   );

--- a/web/src/components/storage/ProposalTargetSection.test.jsx
+++ b/web/src/components/storage/ProposalTargetSection.test.jsx
@@ -94,7 +94,6 @@ describe("when there are candidate devices available", () => {
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     expect(calculateFn).not.toHaveBeenCalled();
   });
-
 });
 
 describe("when there are no candidate devices available", () => {

--- a/web/src/components/storage/ProposalTargetSection.test.jsx
+++ b/web/src/components/storage/ProposalTargetSection.test.jsx
@@ -55,13 +55,7 @@ describe("when there are candidate devices available", () => {
     screen.getByText("Proposal summary");
   });
 
-  it("renders an icon for configuring the candidate devices", () => {
-    installerRender(<ProposalTargetSection proposal={proposal} />);
-
-    screen.getByRole("button", { name: "Section settings" });
-  });
-
-  it("does not show the popup by default", async () => {
+  it("does not show the device selector by default", async () => {
     installerRender(<ProposalTargetSection proposal={proposal} />);
 
     await waitFor(() => {
@@ -69,22 +63,28 @@ describe("when there are candidate devices available", () => {
     });
   });
 
-  it("shows the popup with the form when the icon is clicked", async () => {
-    const { user } = installerRender(<ProposalTargetSection proposal={proposal} />);
-
-    const button = screen.getByRole("button", { name: "Section settings" });
-    await user.click(button);
-
-    await screen.findByRole("dialog");
-    screen.getByRole("form", { name: "Target form" });
-  });
-
-  it("closes the popup without submitting the form when cancel is clicked", async () => {
+  it("allows changing the device selection", async () => {
     const calculateFn = jest.fn();
 
     const { user } = installerRender(<ProposalTargetSection proposal={proposal} calculateProposal={calculateFn} />);
 
-    const button = screen.getByRole("button", { name: "Section settings" });
+    const button = screen.getByRole("button", { name: "Device" });
+    await user.click(button);
+
+    const popup = await screen.findByRole("dialog");
+    const accept = within(popup).getByRole("button", { name: "Accept" });
+    await user.click(accept);
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(calculateFn).toHaveBeenCalled();
+  });
+
+  it("allows aborting the candidate selection", async () => {
+    const calculateFn = jest.fn();
+
+    const { user } = installerRender(<ProposalTargetSection proposal={proposal} calculateProposal={calculateFn} />);
+
+    const button = screen.getByRole("button", { name: "Device" });
     await user.click(button);
 
     const popup = await screen.findByRole("dialog");
@@ -95,21 +95,6 @@ describe("when there are candidate devices available", () => {
     expect(calculateFn).not.toHaveBeenCalled();
   });
 
-  it("closes the popup and submits the form when accept is clicked", async () => {
-    const calculateFn = jest.fn();
-
-    const { user } = installerRender(<ProposalTargetSection proposal={proposal} calculateProposal={calculateFn} />);
-
-    const button = screen.getByRole("button", { name: "Section settings" });
-    await user.click(button);
-
-    const popup = await screen.findByRole("dialog");
-    const accept = within(popup).getByRole("button", { name: "Accept" });
-    await user.click(accept);
-
-    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
-    expect(calculateFn).toHaveBeenCalled();
-  });
 });
 
 describe("when there are no candidate devices available", () => {
@@ -128,10 +113,10 @@ describe("when there are no candidate devices available", () => {
     screen.getByText("No available devices");
   });
 
-  it("does not render an icon for configuring the candidate devices", () => {
+  it("does not allow configuring the candidate devices", () => {
     installerRender(<ProposalTargetSection proposal={proposal} />);
 
-    const actionButton = screen.queryByRole("button", { name: "Section settings" });
+    const actionButton = screen.queryByRole("button", { name: "Device" });
     expect(actionButton).toBeNull();
   });
 });


### PR DESCRIPTION
## Problem

Prior to using the section header for navigating to a page, we introduced a temporary mechanism for placing an action close to the section title when adding the first storage features. The action was intended to open a dialog with section-related settings/options/forms.

This approach was not suited to our needs because we didn't want multiple "settings" icons on one page. Personally, I thought the user interface was overcrowded and confused without a clear justification.

## Solution

Now that we took a step ~~backward~~ forward to use just a plain old HTML link (can I coin the POHL acronym for that?) we realized that no matter if the section allows the user to navigate deeper or simply displays a dialog: following the same pattern of the heading being a link looks discoverable enough in both cases.

<sub>   ^^^ (thanks @joseivanlopez for being so nit-picking :stuck_out_tongue_winking_eye:)</sub>

Thus, this PR adapts our `Section` component for,

* Navigate to a _path_ or trigger an _openDialog_ function. Naturally, only one action can be done so _openDialog_ is ignored when both params are given.

  <sub>^^^ maybe we could use a single _action_ param and delegates the responsibility to call the _navigate_ function to the component _rendering_ the section. But let's play with the component for a while as it is now and postpone that decision a bit. In any case, we start needing our own _navigate_ helper function.</sub>

* Remove the complicated and no longer needed logic for displaying the settings icon and its tooltip.

* Drop the ability to render a separator. Originally, it served as a visual alignment aid for the mentioned icon and section title, but it has no longer been required. Furthermore, the separator is less helpful now that a section title can be underlined if it is actionable. However, the CSS class has been kept just in case a gradient separator is needed to divide a lengthy section. We can remove it in the future if we no longer need it.

* Remove the _description_ param because is not needed at this moment.

## Testing

- Unit tests adapted accordingly
- Tested manually

## Screenshots

|Before|After|
|:-:|:-:|
|![Screen Shot 2023-03-07 at 09 02 17-fullpage](https://user-images.githubusercontent.com/1691872/223374350-8f0f25b0-1bd1-418c-b2a3-5ffeffc81724.png) |![Screen Shot 2023-03-07 at 09 00 05-fullpage](https://user-images.githubusercontent.com/1691872/223374396-ceac1106-782a-41d0-a554-6ab0954f5deb.png)|

<sub>Please, ignore the _Result_ section in the screenshots above. They are out of sync because a bit of hacking for taking the screenshots :stuck_out_tongue_closed_eyes: </sub>



