### PR TITLE
[web] Use react-teleporter from upstream

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -16,7 +16,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.3.0",
-        "react-teleporter": "github:yast/react-teleporter#support-function-as-source",
+        "react-teleporter": "^3.1.0",
         "regenerator-runtime": "^0.13.9"
       },
       "devDependencies": {
@@ -15296,9 +15296,9 @@
       }
     },
     "node_modules/react-teleporter": {
-      "version": "3.0.2",
-      "resolved": "git+ssh://git@github.com/yast/react-teleporter.git#df72c5725762342194031479c74a03447bd514e1",
-      "license": "MIT",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/react-teleporter/-/react-teleporter-3.1.0.tgz",
+      "integrity": "sha512-GqHwE3vNiTK/0OA1+GdE1EUW7bzS+fOkfBKI/mgbXuR3w650tDycFqZvmRceJuF3asOfglBx5TUdBWCBXB4spA==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/gregberge"
@@ -30044,8 +30044,9 @@
       }
     },
     "react-teleporter": {
-      "version": "git+ssh://git@github.com/yast/react-teleporter.git#df72c5725762342194031479c74a03447bd514e1",
-      "from": "react-teleporter@github:yast/react-teleporter#support-function-as-source",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/react-teleporter/-/react-teleporter-3.1.0.tgz",
+      "integrity": "sha512-GqHwE3vNiTK/0OA1+GdE1EUW7bzS+fOkfBKI/mgbXuR3w650tDycFqZvmRceJuF3asOfglBx5TUdBWCBXB4spA==",
       "requires": {}
     },
     "read": {

--- a/web/package.json
+++ b/web/package.json
@@ -99,7 +99,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.3.0",
-    "react-teleporter": "github:yast/react-teleporter#support-function-as-source",
+    "react-teleporter": "^3.1.0",
     "regenerator-runtime": "^0.13.9"
   }
 }


### PR DESCRIPTION
Now that our contributions[1][2] were merged in the upstream `main` branch and the library supports children as function, it makes sense to switch back to use the library from upstream instead of our fork.

[1] https://github.com/gregberge/react-teleporter/pull/49
[2] https://github.com/gregberge/react-teleporter/pull/48

---

Related to https://github.com/yast/d-installer/pull/457
