### PR TITLE
D-Bus API for managing DASD devices - first version

### DIFF
--- a/doc/dbus_api.md
+++ b/doc/dbus_api.md
@@ -126,10 +126,13 @@ Service for managing storage devices.
   .DInstaller.Storage1
   .DInstaller.Storage1.Proposal.Calculator
   .DInstaller.Storage1.ISCSI.Initiator
+  .DInstaller.Storage1.DASD.Manager (Only available on s390 systems)
 /DInstaller/Storage1/Proposal
   .DInstaller.Storage1.Proposal
 /DInstaller/Storage1/iscsi_nodes/[0-9]+
   .DInstaller.Storage1.ISCSI.Node
+/DInstaller/Storage1/dasds/[0-9]+ (Only available on s390 systems)
+  .DInstaller.Storage1.DASD.device
 ~~~
 
 ### D-Bus Objects
@@ -145,6 +148,7 @@ Service for managing storage devices.
   .DInstaller.Storage1
   .DInstaller.Storage1.Proposal.Calculator
   .DInstaller.Storage1.ISCSI.Initiator
+  .DInstaller.Storage1.DASD.manager
 ~~~
 
 Main object exported by the service `org.opensuse.DInstaller.Service`. This object implements the `org.freedesktop.DBus.ObjectManager` interface and should be used by clients to discover other objects.
@@ -170,6 +174,15 @@ This object is exported only if a proposal was already calculated (successful or
 ~~~
 
 Objects representing iSCSI nodes are dynamically exported when a successful iSCSI discovery is performed, see `.org.opensuse.DInstaller.Storage1.ISCSI.Initiator` interface.
+
+#### `/org/opensuse/DInstaller/Storage1/dasds/[0-9]+` Objects
+
+~~~
+/DInstaller/Storage1/dasds/[0-9]+
+  .DInstaller.Storage1.DASD.Device
+~~~
+
+Objects representing DASDs are dynamically exported when a successful probing is performed by the `DASD.manager` interface of the main storage object, see `.org.opensuse.DInstaller.Storage1.DASD.manager`.
 
 ### D-Bus Interfaces
 
@@ -337,7 +350,7 @@ Delete(in o  iscsi_node_path,
 ##### Properties
 
 ~~~
-IniciatorName readable,writable   s
+InitiatorName readable,writable   s
 ~~~
 
 ##### Details
@@ -351,7 +364,7 @@ Discover(in  s       address,
          out u       result)
 ~~~
 
-Performs nodes discovery. Discovered nodes are exported with the path `/org/opensuse/DInstaller/iscsi/node[0-9]+`.
+Performs nodes discovery. Discovered nodes are exported with the path `/org/opensuse/DInstaller/iscsi_nodes/[0-9]+`.
 
 Arguments:
 
@@ -411,7 +424,8 @@ Login(in  a{sv}   options,
       out u       result)
 ~~~
 
-Creates an iSCSI session. If the session is created, then a new iSCSI session object is exported with the path `/org/opensuse/DInstaller/Storage1/iscsi/session[0-9]+`.
+Creates an iSCSI session. If the session is created, the corresponding object at the path
+`/org/opensuse/DInstaller/Storage1/iscsi_nodes/[0-9]+` is updated.
 
 Arguments:
 
@@ -435,6 +449,127 @@ Arguments:
 
 * `out u result`: `0` on success and `1` on failure.
 
+#### `org.opensuse.DInstaller.Storage1.DASD.Manager` Interface
+
+Provides methods for configuring DASDs. It's only available if the D-Bus service is running on an
+s390x system.
+
+##### A Note About DIAG and YaST
+
+The `use_diag` flag of a given DASD controls whether it should use the DIAG access method.
+Traditionally YaST has managed that flag in a way that may be confusing to newcomers. Nevertheless,
+for the sake of consistency and easy transition (and also to reuse some YaST components without
+modifications) D-Installer observes that YaST approach. In a nutshell:
+
+- When the list of DASDs is read from the system (see method `Probe()`), the value of the `use_diag`
+  flag for enabled devices is checked from the system and exported with the proper value in the D-Bus
+  representation of the DASD. But for disabled DASDs, the value of the flag is always assumed to be
+  false.
+- When the value of the `use_diag` flag is changed for an enabled device using the D-Bus interface
+  (see method `SetDiag()`), the change is applied immediately to the system, disabling the device
+  and enabling it again with the new access method.
+- When the value of the flag is changed for a disabled device, the flag is updated in the D-Bus
+  representation of the DASD but not written to the system configuration. The change will only
+  have effect in the system if the device is enabled afterwards using the `Enable()` method. The
+  change is lost if `Probe()` is called again without having enabled the device.
+
+##### Methods
+
+~~~
+Probe()
+Enable(in  ao devices,
+       out u  result)
+Disable(in  ao devices,
+        out u  result)
+SetDiag(in  ao devices,
+        in  b  diag,
+        out u  result)
+~~~
+
+In addition, a `Format()` method is provided, but it's not documented here because it's going to
+change heavily in the short term.
+
+##### Details
+
+###### `Probe` Method
+
+Finds DASDs in the system. Found DASDs are exported with the path
+`/org/opensuse/DInstaller/Storage1/dasds/[0-9]+`.
+
+###### `Enable` Method
+
+~~~
+Enable(in  ao devices,
+       out u  result)
+~~~
+
+Enables the given list of DASDs. See documentation above to understand how the `use_diag` flag of
+the DASDs is affected by this method.
+
+Arguments:
+
+* `in ao devices`: paths of the D-Bus objects representing the DASDs to enable.
+* `out u result`: `0` if all DASDs are successfully enabled. `1` if any of the given paths is invalid (ie. it does not correspond to a known DASD), `2` in case of any other error.
+
+
+###### `Disable` Method
+
+~~~
+Disable(in  ao devices,
+        out u  result)
+~~~
+
+Disables the given list of DASDs.
+
+Arguments:
+
+* `in ao devices`: paths of the D-Bus objects representing the DASDs to disable.
+* `out u result`: `0` if all DASDs are successfully disabled. `1` if any of the given paths is invalid (ie. it does not correspond to a known DASD), `2` in case of any other error.
+
+###### `SetDiag` Method
+
+~~~
+SetDiag(in  ao devices,
+        in  b  diag,
+        out u  result)
+~~~
+
+Sets the `use_diag` attribute for the given DASDs to the given value. See documentation above to
+understand what setting the flag really means (since this follows the same convention than YaST).
+
+Arguments:
+
+* `in ao devices`: paths of the D-Bus objects representing the DASDs to configure.
+* `in b diag`: new value for the flag.
+* `out u result`: `0` if `use_diag` is correctly set for all the requested DASDs. `1` if any of the given paths is invalid (ie. it does not correspond to a known DASD), `2` in case of any other error.
+
+#### `org.opensuse.DInstaller.Storage1.DASD.Device` Interface
+
+This interface is implemented by objects exported at the `/org/opensuse/DInstaller/Storage1/dasds/[0-9]+`
+paths. It provides information about a DASD in the system.
+
+##### Properties
+
+~~~
+Id            readable s
+Enabled       readable b
+DeviceName    readable s
+Formatted     readable b
+Diag          readable b
+Type          readable s
+AccessType    readable s
+PartitionInfo readable s
+~~~
+
+* `Id`: The device channel id (eg. "0.0.0150")
+* `Enabled`: Whether the device is enabled.
+* `DeviceName`: Device name of the DASD in the linux system (eg. "/dev/dasda"). Empty string if the
+  device is not enabled.
+* `Formatted`: whether the device is formatted.
+* `Diag`: Whether the DIAG access method is used (or will be used when the device is enabled).
+* `Type`: The DASD type (eg. EKCD or FBA).
+* `AccessType`: Empty string if unknown. Either "rw" or "ro" otherwise.
+* `PartitionInfo`: Description of the partitions. Empty if the information is unknown.
 
 ## Users
 

--- a/doc/dbus_api.md
+++ b/doc/dbus_api.md
@@ -451,7 +451,7 @@ Arguments:
 
 #### `org.opensuse.DInstaller.Storage1.DASD.Manager` Interface
 
-Provides methods for configuring DASDs. It's only available if the D-Bus service is running on an
+Provides methods for configuring DASDs. It's only available if the D-Bus service is running on a
 s390x system.
 
 ##### A Note About DIAG and YaST
@@ -561,6 +561,10 @@ AccessType    readable s
 PartitionInfo readable s
 ~~~
 
+Bear in mind these properties are a quite direct translation of the attributes read and exposed by
+YaST. Some changes may be introduced in the future to make them easier to consume (eg. the current
+string `AccessType` could be replaced by a boolean `ReadOnly`).
+
 * `Id`: The device channel id (eg. "0.0.0150")
 * `Enabled`: Whether the device is enabled.
 * `DeviceName`: Device name of the DASD in the linux system (eg. "/dev/dasda"). Empty string if the
@@ -569,7 +573,8 @@ PartitionInfo readable s
 * `Diag`: Whether the DIAG access method is used (or will be used when the device is enabled).
 * `Type`: The DASD type (eg. EKCD or FBA).
 * `AccessType`: Empty string if unknown. Either "rw" or "ro" otherwise.
-* `PartitionInfo`: Description of the partitions. Empty if the information is unknown.
+* `PartitionInfo`: Partition names (and sometimes their type) separated by commas.
+  Eg. "_/dev/dasda1 (Linux native), /dev/dasda2 (Linux native)_". Empty if the information is unknown.
 
 ## Users
 

--- a/service/lib/dinstaller/dbus/clients/storage.rb
+++ b/service/lib/dinstaller/dbus/clients/storage.rb
@@ -33,7 +33,7 @@ module DInstaller
         include WithProgress
         include WithValidation
 
-        STORAGE_IFACE = "org.opensuse.DInstaller.Storage1.Proposal"
+        STORAGE_IFACE = "org.opensuse.DInstaller.Storage1"
         private_constant :STORAGE_IFACE
 
         PROPOSAL_CALCULATOR_IFACE = "org.opensuse.DInstaller.Storage1.Proposal.Calculator"
@@ -53,7 +53,7 @@ module DInstaller
         #
         # @param done [Proc] Block to execute once the probing is done
         def probe(&done)
-          dbus_object.Probe(&done)
+          dbus_object[STORAGE_IFACE].Probe(&done)
         end
 
         # Performs the packages installation

--- a/service/lib/dinstaller/dbus/interfaces/dasd.rb
+++ b/service/lib/dinstaller/dbus/interfaces/dasd.rb
@@ -141,7 +141,8 @@ module DInstaller
         def dasds_dbus_method(paths)
           dbus_dasds = dasds_tree.find_paths(paths)
           if dbus_dasds.size != paths.size
-            logger.error "Unknown path(s) at #{paths}"
+            missing = paths - dbus_dasds.map(&:path)
+            logger.error "Unknown path(s) #{missing} at requested list #{paths}"
             return 1
           end
 

--- a/service/lib/dinstaller/dbus/interfaces/dasd.rb
+++ b/service/lib/dinstaller/dbus/interfaces/dasd.rb
@@ -1,0 +1,178 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2023] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "dbus"
+require "dinstaller/storage/dasd/manager"
+require "dinstaller/dbus/storage/dasds_tree"
+
+module DInstaller
+  module DBus
+    module Interfaces
+      # Mixin to define the D-Bus interface to manage DASD devices
+      #
+      # @note This mixin is expected to be included in a class inherited from
+      # {DInstaller::DBus::BaseObject}
+      #
+      # @note This mixin is expected to be included only if the namespace Y2S390 (which
+      # traditionally lives in the yast2-s390 package) is available.
+      module Dasd
+        DASD_MANAGER_INTERFACE = "org.opensuse.DInstaller.Storage1.DASD.Manager"
+        private_constant :DASD_MANAGER_INTERFACE
+
+        def self.included(base)
+          # Require the optional dependencies only if the module is included
+          require "dinstaller/dbus/storage/dasds_tree"
+          require "dinstaller/storage/dasd/manager"
+
+          base.class_eval do
+            dbus_interface DASD_MANAGER_INTERFACE do
+              # Finds DASDs in the system and populates the D-Bus objects tree according
+              dbus_method(:Probe) do
+                busy_while { dasd_backend.probe }
+              end
+
+              # Enables the given list of DASDs.
+              # See documentation at DInstaller::Storage::DASD::Manager to understand how the
+              # use_diag flag is affected by this operation.
+              dbus_method(:Enable, "in devices:ao, out result:u") do |devs|
+                busy_while { dasd_enable(devs) }
+              end
+
+              # Disables the given list of DASDs
+              dbus_method(:Disable, "in devices:ao, out result:u") do |devs|
+                busy_while { dasd_disable(devs) }
+              end
+
+              # Sets the use_diag attribute for the given DASDs to the given value.
+              # See documentation at DInstaller::Storage::DASD::Manager to understand what that
+              # really means (since this follows the same strange convention than YaST).
+              dbus_method(:SetDiag, "in devices:ao, in diag:b, out result:u") do |devs, diag|
+                busy_while { dasd_set_diag(devs, diag) }
+              end
+
+              # Formats the DASDs in the given list
+              # TODO: we plan to change this so it returns the path of a new Process object. See
+              # https://gist.github.com/ancorgs/390b064373995595a1b1dfb08d00507a#gistcomment-4502266
+              dbus_method(:Format, "in devices:ao, out result:u") do |devs|
+                busy_while { dasd_format(devs) }
+              end
+            end
+          end
+        end
+
+        # Enables the DASDs devices indentified by the given D-Bus paths
+        #
+        # See {#dasds_dbus_method} for information about the possible return codes.
+        #
+        # Succeeds (returns 0) if all the devices where successfully enabled.
+        #
+        # @param paths [Array<String>]
+        # @return [Integer]
+        def dasd_enable(paths)
+          dasds_dbus_method(paths) { |dasds| dasd_backend.enable(dasds) }
+        end
+
+        # Disables the DASDs devices indentified by the given D-Bus paths
+        #
+        # See {#dasds_dbus_method} for information about the possible return codes.
+        #
+        # Succeeds (returns 0) if all the devices where successfully disabled.
+        #
+        # @param paths [Array<String>]
+        # @return [Integer]
+        def dasd_disable(paths)
+          dasds_dbus_method(paths) { |dasds| dasd_backend.disable(dasds) }
+        end
+
+        # Sets use_diag to the given value for the DASDs devices indentified by the given
+        # D-Bus paths
+        #
+        # See {#dasds_dbus_method} for information about the possible return codes.
+        #
+        # Succeeds (returns 0) if the desired value of use_diag is properly set for all the
+        # given devices.
+        #
+        # @param paths [Array<String>]
+        # @param diag [Boolean] value of the use_diag flag
+        # @return [Integer]
+        def dasd_set_diag(paths, diag)
+          dasds_dbus_method(paths) { |dasds| dasd_backend.set_diag(dasds, diag) }
+        end
+
+        # Format the DASDs devices indentified by the given D-Bus paths
+        #
+        # See {#dasds_dbus_method} for information about the possible return codes.
+        #
+        # Succeeds (returns 0) if all the devices where successfully formatted.
+        #
+        # @param paths [Array<String>]
+        # @return [Integer]
+        def dasd_format(paths)
+          dasds_dbus_method(paths) { |dasds| dasd_backend.format(dasds) }
+        end
+
+        # Finds the DASDs matching the given D-Bus paths and calls the given block on them
+        #
+        # It only tries to execute the given block if all the paths are found. Otherwise it
+        # returns 1 without trying to process any of the DASDs.
+        #
+        # If all the paths are on the D-Bus tree, it runs the block and returns 0 if it succeeds
+        # or 2 otherwise.
+        #
+        # @return [Integer]
+        def dasds_dbus_method(paths)
+          dbus_dasds = dasds_tree.find_paths(paths)
+          if dbus_dasds.size != paths.size
+            logger.error "Unknown path(s) at #{paths}"
+            return 1
+          end
+
+          return 0 if yield(dbus_dasds.map(&:dasd))
+
+          2
+        end
+
+        # Registers the callbacks necessary to ensure accuracy of the tree of DASD objects
+        def register_dasd_callbacks
+          dasd_backend.on_probe do |dasds|
+            dasds_tree.populate(dasds)
+          end
+
+          dasd_backend.on_refresh do |dasds|
+            dasds_tree.update(dasds)
+          end
+        end
+
+        # Tree with the devices representing the DASDs in the system
+        def dasds_tree
+          @dasds_tree ||= Storage::DasdsTree.new(@service, logger: logger)
+        end
+
+        # DASD manager
+        #
+        # @return [Storage::DASD::Manager]
+        def dasd_backend
+          @dasd_backend ||= DInstaller::Storage::DASD::Manager.new(logger: logger)
+        end
+      end
+    end
+  end
+end

--- a/service/lib/dinstaller/dbus/storage/dasd.rb
+++ b/service/lib/dinstaller/dbus/storage/dasd.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2023] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "dbus"
+require "dinstaller/dbus/base_object"
+
+module DInstaller
+  module DBus
+    module Storage
+      # Class representing a DASD in the D-Bus tree
+      class Dasd < BaseObject
+        # YaST representation of the DASD
+        #
+        # @return [Y2S390::Dasd]
+        attr_reader :dasd
+
+        # Constructor
+        #
+        # @param dasd [Y2S390::Dasd] See {#dasd}
+        # @param path [DBus::ObjectPath] Path in which the object is exported
+        # @param logger [Logger, nil]
+        def initialize(dasd, path, logger: nil)
+          super(path, logger: logger)
+          @dasd = dasd
+        end
+
+        # The device channel id
+        #
+        # @return [String]
+        def id
+          dasd.id
+        end
+
+        # Whether the device is enabled
+        #
+        # @return [Boolean]
+        def enabled
+          !dasd.offline?
+        end
+
+        # The associated device name
+        #
+        # @return [String] empty if the device is not enabled
+        def device_name
+          dasd.device_name || ""
+        end
+
+        # Whether the device is formatted
+        #
+        # @return [Boolean]
+        def formatted
+          dasd.formatted?
+        end
+
+        # Whether the DIAG access method is enabled
+        #
+        # YaST traditionally displays #use_diag, which is always false for disabled devices (see
+        # more info about the YaST behavior regarding DIAG at DInstaller::Storage::DASD::Manager).
+        # But displaying #diag_wanted is surely more useful. For enabled DASDs both values match
+        # and for disabled DASDs #diag_wanted is more informative.
+        #
+        # @return [Boolean]
+        def diag
+          dasd.diag_wanted
+        end
+
+        # The DASD type (EKCD, FBA)
+        #
+        # @return [String] empty if unknown
+        def type
+          dasd.type || ""
+        end
+
+        # Access type ('rw', 'ro')
+        #
+        # @return [String] empty if unknown
+        def access_type
+          dasd.access_type || ""
+        end
+
+        # Description of the partitions
+        #
+        # @return [String] empty if the information is unknown
+        def partition_info
+          dasd.partition_info || ""
+        end
+
+        # Sets the associated DASD object
+        #
+        # @note A properties changed signal is always emitted.
+        #
+        # @param value [Y2S390::Dasd]
+        def dasd=(value)
+          @dasd = value
+
+          properties = interfaces_and_properties[DASD_DEVICE_INTERFACE]
+          dbus_properties_changed(DASD_DEVICE_INTERFACE, properties, [])
+        end
+
+        # Interface name representing a DASD object
+        DASD_DEVICE_INTERFACE = "org.opensuse.DInstaller.Storage1.DASD.Device"
+        private_constant :DASD_DEVICE_INTERFACE
+
+        dbus_interface DASD_DEVICE_INTERFACE do
+          dbus_reader(:id, "s")
+          dbus_reader(:enabled, "b")
+          dbus_reader(:device_name, "s")
+          dbus_reader(:formatted, "b")
+          dbus_reader(:diag, "b")
+          dbus_reader(:type, "s")
+          dbus_reader(:access_type, "s")
+          dbus_reader(:partition_info, "s")
+        end
+      end
+    end
+  end
+end

--- a/service/lib/dinstaller/dbus/storage/dasds_tree.rb
+++ b/service/lib/dinstaller/dbus/storage/dasds_tree.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2023] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "dinstaller/dbus/with_path_generator"
+require "dinstaller/dbus/storage/dasd"
+
+module DInstaller
+  module DBus
+    module Storage
+      # Class representing the tree of DASDs exported on D-Bus
+      class DasdsTree
+        include WithPathGenerator
+
+        # Root of the tree
+        ROOT_PATH = "/org/opensuse/DInstaller/Storage1/dasds"
+        path_generator ROOT_PATH
+
+        # Constructor
+        #
+        # @param service [::DBus::Service]
+        # @param logger [Logger, nil]
+        def initialize(service, logger: nil)
+          @service = service
+          @logger = logger
+        end
+
+        # Fills the D-Bus tree with the given DASDs
+        #
+        # Any previous DASD if unexported and the new ones are exported
+        #
+        # @param dasds [Array<DBus::Storage::Dasd>]
+        def populate(dasds)
+          delete_missing(dasds)
+          update(dasds)
+        end
+
+        # Updates the information of the given DASDs in the D-Bus tree
+        #
+        # @param dasds [Array<DBus::Storage::Dasd>]
+        def update(dasds)
+          dasds.each { |dasd| publish(dasd) }
+        end
+
+        # Finds in the tree the DASDs objects corresponding to the given paths
+        #
+        # Paths not corresponding to any DASD are simply ignored.
+        #
+        # @param paths [Array<String>]
+        # @return [Array<DBus::Storage::Dasd>]
+        def find_paths(paths)
+          dbus_dasds.find_all { |d| paths.include?(d.path) }
+        end
+
+      private
+
+        # @return [::DBus::Service]
+        attr_reader :service
+
+        # @return [Logger]
+        attr_reader :logger
+
+        # All exported DASDs
+        #
+        # @return [Array<DBus::Storage::Dasd>]
+        def dbus_dasds
+          root = service.get_node(ROOT_PATH, create: false)
+          return [] unless root
+
+          root.descendant_objects
+        end
+
+        # @see #populate
+        def delete_missing(dasds)
+          missing_dbus_dasds(dasds).each do |dbus_dasd|
+            service.unexport(dbus_dasd)
+          end
+        end
+
+        # @see #delete_missing
+        def missing_dbus_dasds(dasds)
+          wanted_ids = dasds.map(&:id)
+          dbus_dasds.reject { |d| wanted_ids.include?(d.id) }
+        end
+
+        # Exports or updates the information of a given DASD object
+        #
+        # @return [DBus::Storage::Dasd>]
+        def publish(dasd)
+          dbus_dasd = dbus_dasds.find { |d| d.id == dasd.id }
+
+          if dbus_dasd
+            dbus_dasd.dasd = dasd
+          else
+            dbus_dasd = DBus::Storage::Dasd.new(dasd, next_path, logger: logger)
+            service.export(dbus_dasd)
+          end
+        end
+      end
+    end
+  end
+end

--- a/service/lib/dinstaller/dbus/storage/manager.rb
+++ b/service/lib/dinstaller/dbus/storage/manager.rb
@@ -20,16 +20,20 @@
 # find current contact information at www.suse.com.
 
 require "dbus"
+require "yast"
 require "dinstaller/dbus/base_object"
 require "dinstaller/dbus/with_service_status"
 require "dinstaller/dbus/interfaces/progress"
 require "dinstaller/dbus/interfaces/service_status"
 require "dinstaller/dbus/interfaces/validation"
+require "dinstaller/dbus/interfaces/dasd"
 require "dinstaller/dbus/storage/proposal"
 require "dinstaller/dbus/storage/proposal_settings_converter"
 require "dinstaller/dbus/storage/volume_converter"
 require "dinstaller/dbus/storage/with_iscsi_auth"
 require "dinstaller/dbus/storage/iscsi_nodes_tree"
+
+Yast.import "Arch"
 
 module DInstaller
   module DBus
@@ -57,6 +61,10 @@ module DInstaller
           register_progress_callbacks
           register_service_status_callbacks
           register_iscsi_callbacks
+          return unless Yast::Arch.s390
+
+          singleton_class.include DBus::Interfaces::Dasd
+          register_dasd_callbacks
         end
 
         STORAGE_INTERFACE = "org.opensuse.DInstaller.Storage1"

--- a/service/lib/dinstaller/storage/dasd.rb
+++ b/service/lib/dinstaller/storage/dasd.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2023] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+module DInstaller
+  module Storage
+    # Module for managing DASDs (Direct-Access Storage Devices)
+    module DASD
+    end
+  end
+end
+
+require "dinstaller/storage/dasd/enable_operation"
+require "dinstaller/storage/dasd/disable_operation"
+require "dinstaller/storage/dasd/diag_operation"
+require "dinstaller/storage/dasd/format_operation"
+require "dinstaller/storage/dasd/manager"

--- a/service/lib/dinstaller/storage/dasd/dasd_configure_cmd.rb
+++ b/service/lib/dinstaller/storage/dasd/dasd_configure_cmd.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2023] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast2/execute"
+
+module DInstaller
+  module Storage
+    module DASD
+      # Class used to invoke the dasd_configure command traditionally used during (open)SUSE
+      # installations to manage DASDs
+      class DasdConfigureCmd
+        def initialize(dasd)
+          @dasd = dasd
+        end
+
+        # Executes the command to set the device online
+        def enable
+          command = ["dasd_configure", dasd.id, "1", diag_argument]
+          # An exit code of 8 means the disk was indeed enabled but it's not formatted.
+          # We don't consider that to be a problem.
+          Yast::Execute.locally!(command, allowed_exitstatus: [0, 8])
+          true
+        rescue Cheetah::ExecutionFailed
+          false
+        end
+
+        # Executes the command to set the device offline
+        def disable
+          # If the device is in use, chzdev (which is called by dasd_configure) interactively
+          # asks whether to continue. We use an empty string at stdin as a mechanism to reply
+          # the default 'no'.
+          command = ["dasd_configure", dasd.id, "0"]
+          Yast::Execute.locally!(command, stdin: "")
+          true
+        rescue Cheetah::ExecutionFailed
+          false
+        end
+
+      private
+
+        # @return [Y2S390::Dasd]
+        attr_reader :dasd
+
+        # @see #enable
+        def diag_argument
+          dasd.diag_wanted ? "1" : "0"
+        end
+      end
+    end
+  end
+end

--- a/service/lib/dinstaller/storage/dasd/diag_operation.rb
+++ b/service/lib/dinstaller/storage/dasd/diag_operation.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2023] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast2/execute"
+require "dinstaller/storage/dasd/sequential_operation"
+require "dinstaller/storage/dasd/dasd_configure_cmd"
+
+module DInstaller
+  module Storage
+    module DASD
+      # Operation to set the use_diag flag for a group of DASDs
+      #
+      # Management of that flag in YaST is a bit weird, but we decided to emulate it to a big extent
+      # to keep the known behavior. Check DInstaller::Storage::DASD::Manager for more information.
+      class DiagOperation < SequentialOperation
+        # Constructor
+        def initialize(dasds, logger, value)
+          super(dasds, logger)
+          @value = value
+        end
+
+      private
+
+        # @return [Boolean] new wanted value for the use_diag flag
+        attr_reader :value
+
+        def process_dasd(dasd)
+          dasd.diag_wanted = value
+          return true if dasd.offline?
+
+          dasd_configure.disable && dasd_configure.enable
+        rescue Cheetah::ExecutionFailed
+          false
+        end
+
+        # Utility object used to re-enable de device after the flag change
+        #
+        # @return [DasdConfigureCmd]
+        def dasd_configure
+          @dasd_configure ||= DasdConfigureCmd.new(dasd)
+        end
+      end
+    end
+  end
+end

--- a/service/lib/dinstaller/storage/dasd/diag_operation.rb
+++ b/service/lib/dinstaller/storage/dasd/diag_operation.rb
@@ -45,17 +45,12 @@ module DInstaller
         def process_dasd(dasd)
           dasd.diag_wanted = value
           return true if dasd.offline?
+          return true if dasd.diag_wanted == dasd.use_diag
 
+          dasd_configure = DasdConfigureCmd.new(dasd)
           dasd_configure.disable && dasd_configure.enable
         rescue Cheetah::ExecutionFailed
           false
-        end
-
-        # Utility object used to re-enable de device after the flag change
-        #
-        # @return [DasdConfigureCmd]
-        def dasd_configure
-          @dasd_configure ||= DasdConfigureCmd.new(dasd)
         end
       end
     end

--- a/service/lib/dinstaller/storage/dasd/diag_operation.rb
+++ b/service/lib/dinstaller/storage/dasd/diag_operation.rb
@@ -39,7 +39,7 @@ module DInstaller
 
       private
 
-        # @return [Boolean] new wanted value for the use_diag flag
+        # @return [Boolean] newly wanted value for the use_diag flag
         attr_reader :value
 
         def process_dasd(dasd)

--- a/service/lib/dinstaller/storage/dasd/disable_operation.rb
+++ b/service/lib/dinstaller/storage/dasd/disable_operation.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2023] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "dinstaller/storage/dasd/sequential_operation"
+require "dinstaller/storage/dasd/dasd_configure_cmd"
+
+module DInstaller
+  module Storage
+    module DASD
+      # Operation to enable a set of DASDs
+      class DisableOperation < SequentialOperation
+      private
+
+        def process_dasd(dasd)
+          # See EnableOperation for considerations about using dasd_configure or chzdev
+          DasdConfigureCmd.new(dasd).disable
+        end
+      end
+    end
+  end
+end

--- a/service/lib/dinstaller/storage/dasd/enable_operation.rb
+++ b/service/lib/dinstaller/storage/dasd/enable_operation.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2023] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "dinstaller/storage/dasd/sequential_operation"
+require "dinstaller/storage/dasd/dasd_configure_cmd"
+
+module DInstaller
+  module Storage
+    module DASD
+      # Operation to enable a set of DASDs
+      class EnableOperation < SequentialOperation
+      private
+
+        def process_dasd(dasd)
+          # We considered to stop using dasd_configure in favor of directly calling "chzdev -e".
+          # That would allow us, for example, to enable all the devices with a single command.
+          # But dasd_configure does a couple of extra things we still find valuable:
+          #   - It checks whether the device really goes online, using a reasonable timeout
+          #   - It writes the CIO channel of the device to /boot/zipl/active_devices.txt (we are
+          #     not sure whether this is relevant in our case, bsc#1095033 seems to suggest it is).
+          DasdConfigureCmd.new(dasd).enable
+        end
+      end
+    end
+  end
+end

--- a/service/lib/dinstaller/storage/dasd/format_operation.rb
+++ b/service/lib/dinstaller/storage/dasd/format_operation.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2023] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "y2s390"
+require "y2s390/format_process"
+
+module DInstaller
+  module Storage
+    module DASD
+      # Operation to format the given set of DASDs
+      #
+      # TODO: we plan to change the approach to DASD formatting, so this class will change
+      # very soon.
+      class FormatOperation
+        # Constructor
+        #
+        # @param dasds [Array<Y2S390:Dasd>] devices to format
+        def initialize(dasds)
+          @process = Y2S390::FormatProcess.new(dasds)
+        end
+
+        # Formats all the given DASDs
+        #
+        # NOTE: this algorithm is pretty much copied from Y2S390::Dialogs::FormatDialog
+        #
+        # @return [Boolean] true if the operation succeeds for all the DASDs
+        def run
+          # NOTE: Does a device need to be reactivated after formating it?
+          #       The code at DasdActions::Activate seems to imply that
+          #       But the code at DasdActions::Format contains a comment stating otherwise
+          return false unless start?
+
+          process.initialize_summary
+          while process.running?
+            process.update_summary
+            # TODO: trigger a callback to notify the process status information
+            sleep(0.2)
+          end
+          # TODO: maybe trigger a callback to notify the final status?
+
+          process.status.to_i.zero?
+        end
+
+      private
+
+        # Object to manage the process
+        #
+        # @return [Y2S390::FormatProcess]
+        attr_reader :process
+
+        # Starts the formatting process
+        #
+        # @return [Boolean] true if the process was succesfully started
+        def start?
+          process.start
+          sleep(0.2)
+          process.running?
+        end
+      end
+    end
+  end
+end

--- a/service/lib/dinstaller/storage/dasd/manager.rb
+++ b/service/lib/dinstaller/storage/dasd/manager.rb
@@ -1,0 +1,177 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2023] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "y2s390"
+require "dinstaller/storage/dasd/enable_operation"
+require "dinstaller/storage/dasd/disable_operation"
+require "dinstaller/storage/dasd/diag_operation"
+require "dinstaller/storage/dasd/format_operation"
+
+module DInstaller
+  module Storage
+    module DASD
+      # Manager for configuring DASDs (Direct-Access Storage Devices)
+      #
+      # NOTE: this mimics to a big extent the YaST behavior regarding the management of the
+      # use_diag flag for a given DASD. YaST behavior have the following particularities:
+      #
+      #   - When the value of the DIAG flag is changed for an enabled device, the change is applied
+      #     immediately, disabling the device and enabling it again with the new value.
+      #   - When the value of DIAG is changed for a disabled device, the new wanted value is stored
+      #     by YaST in memory but not written to the system configuration. The change will only
+      #     have effect if the device is enabled afterwards during the same YaST execution (lost
+      #     if YaST quits without ever enabling the device).
+      #   - In the UI, DIAG is always displayed as 'no' for disabled devices. For enabled devices
+      #     the correct/current value is displayed.
+      class Manager
+        # All known DASDs
+        #
+        # @return [Y2S390::DasdsCollection]
+        attr_reader :devices
+
+        # Constructor
+        #
+        # @param logger [Logger, nil]
+        def initialize(logger: nil)
+          @logger = logger || ::Logger.new($stdout)
+          @devices = Y2S390::DasdsCollection.new([])
+
+          @on_probe_callbacks = []
+          @on_refresh_callbacks = []
+        end
+
+        # Reads the list of DASDs from the system
+        #
+        # Probe callbacks are called at the end, see {#on_probe}.
+        def probe
+          logger.info "Probing DASDs"
+          @devices = reader.list(force_probing: true)
+          # Initialize the attribute just in case the reader doesn't do it (see bsc#1209162)
+          @devices.each { |d| d.diag_wanted = d.use_diag }
+          logger.info("Probed DASDs #{@devices.inspect}")
+
+          @on_probe_callbacks.each do |callback|
+            callback.call(@devices)
+          end
+        end
+
+        # Registers a callback to be called when the DASDs are probed
+        #
+        # @param block [Proc]
+        def on_probe(&block)
+          @on_probe_callbacks << block
+        end
+
+        # Registers a callback to be called when some DASDS are modified
+        #
+        # @param block [Proc]
+        def on_refresh(&block)
+          @on_refresh_callbacks << block
+        end
+
+        # Enables the given list of DASDs
+        #
+        # Refresh callbacks are called at the end, see {#on_refresh}.
+        #
+        # NOTE: see note about use_diag at this class description.
+        #
+        # @param devices [Array<Y2S390::Dasd>]
+        # @return [Boolean] true if all the given devices were enabled
+        def enable(devices)
+          refresh_after(devices) { EnableOperation.new(devices, logger).run }
+        end
+
+        # Disables the given list of DASDs
+        #
+        # Refresh callbacks are called at the end, see {#on_refresh}.
+        #
+        # @param devices [Array<Y2S390::Dasd>]
+        # @return [Boolean] true if all the given devices were disabled
+        def disable(devices)
+          refresh_after(devices) { DisableOperation.new(devices, logger).run }
+        end
+
+        # Sets the value of the use_diag flag for the given list of DASDs
+        #
+        # Refresh callbacks are called at the end, see {#on_refresh}.
+        #
+        # NOTE: see note about management of the use_diag flag at this class description.
+        #
+        # @param devices [Array<Y2S390::Dasd>]
+        # @param diag [Boolean] value of the flag
+        # @return [Boolean] true if the flag is successfully set for all the given devices
+        def set_diag(devices, diag)
+          refresh_after(devices) { DiagOperation.new(devices, logger, diag).run }
+        end
+
+        # Formats the given list of DASDs
+        #
+        # Refresh callbacks are called at the end, see {#on_refresh}.
+        #
+        # TODO: we plan to change the approach to DASD formatting. See discussion at
+        # https://gist.github.com/ancorgs/390b064373995595a1b1dfb08d00507a
+        # So this method is subject to change in the short term.
+        #
+        # @param devices [Array<Y2S390::Dasd>]
+        # @return [Boolean] true if all the given devices were successfully formatted
+        def format(devices)
+          refresh_after(devices) { FormatOperation.new(devices).run }
+        end
+
+      private
+
+        # @return [Logger]
+        attr_reader :logger
+
+        # @return [Y2S390::DasdsReader]
+        def reader
+          @reader ||= Y2S390::DasdsReader.new
+        end
+
+        # Updates the attributes of the given DASDs with the current information read from the
+        # system
+        #
+        # Refresh callbacks are called at the end, see {#on_refresh}.
+        #
+        # @param dasds [Array<Y2S390::Dasd>] devices to update
+        def refresh(dasds)
+          logger.info "Refreshing DASDs"
+          dasds.each { |dev| reader.update_info(dev, extended: true) }
+          logger.info "Refreshed DASDs #{dasds.inspect}"
+
+          @on_refresh_callbacks.each do |callback|
+            callback.call(dasds)
+          end
+        end
+
+        # Calls the given block and performs a refresh of the affected DASDs afterwards
+        #
+        # @note Returns the result of the block.
+        # @param devices [Array<Y2S390::Dasd>]
+        # @param block [Proc]
+        def refresh_after(devices, &block)
+          block.call.tap { refresh(devices) }
+        end
+      end
+    end
+  end
+end

--- a/service/lib/dinstaller/storage/dasd/sequential_operation.rb
+++ b/service/lib/dinstaller/storage/dasd/sequential_operation.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2023] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "abstract_method"
+
+module DInstaller
+  module Storage
+    module DASD
+      # Base class for operations that are performed one by one over a set of DASDs
+      class SequentialOperation
+        # Constructor
+        #
+        # @param dasds [Array<Y2S390:Dasd>] see {#dasds}
+        # @param logger [Logger] see {#logger}
+        def initialize(dasds, logger)
+          @dasds = dasds
+          @logger = logger
+        end
+
+        # Executes the action on all the DASDs
+        #
+        # @return [Boolean] true if the operation succeeds for all the DASDs
+        def run
+          results = {}
+          dasds.each { |dasd| results[dasd.id] = process_dasd(dasd) }
+          logger.info "DASD operation (#{self.class.name}) results: #{results}"
+          results.values.all?
+        end
+
+      private
+
+        # @return [Array<Y2S390::Dasd>]
+        attr_reader :dasds
+
+        # @return [Logger]
+        attr_reader :logger
+
+        # @!method process_dasd(dasd)
+        #   Executes the action on a given DASD
+        #
+        #   @param dasd [Y2S390::Dasd]
+        #   @return [Boolean] whether the operation on the DASD succeeds
+        abstract_method :process_dasd
+      end
+    end
+  end
+end

--- a/service/test/dinstaller/dbus/clients/storage_test.rb
+++ b/service/test/dinstaller/dbus/clients/storage_test.rb
@@ -61,10 +61,10 @@ describe DInstaller::DBus::Clients::Storage do
   subject { described_class.new }
 
   describe "#probe" do
-    let(:dbus_object) { double(::DBus::ProxyObject, Probe: nil) }
+    let(:storage_iface) { double(::DBus::ProxyObjectInterface, Probe: nil) }
 
     it "calls the D-Bus Probe method" do
-      expect(dbus_object).to receive(:Probe)
+      expect(storage_iface).to receive(:Probe)
 
       subject.probe
     end
@@ -72,7 +72,7 @@ describe DInstaller::DBus::Clients::Storage do
     context "when a block is given" do
       it "passes the block to the Probe method (async)" do
         callback = proc {}
-        expect(dbus_object).to receive(:Probe) do |&block|
+        expect(storage_iface).to receive(:Probe) do |&block|
           expect(block).to be(callback)
         end
 

--- a/service/test/dinstaller/dbus/storage/dasd_test.rb
+++ b/service/test/dinstaller/dbus/storage/dasd_test.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2023] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../../test_helper"
+require "dinstaller/dbus/storage/dasd"
+
+describe DInstaller::DBus::Storage::Dasd do
+  subject { described_class.new(y2s390_dasd1, path, logger: logger) }
+
+  let(:y2s390_dasd1) { instance_double("Y2S390::Dasd") }
+  let(:y2s390_dasd2) do
+    instance_double(
+      "Y2S390::Dasd", id: "0.0.002", offline?: true, device_name: nil, formatted?: false,
+      diag_wanted: false, type: nil, access_type: nil, partition_info: ""
+    )
+  end
+  let(:path) { "/org/opensuse/DInstaller/Storage1/dasds/1" }
+  let(:logger) { Logger.new($stdout, level: :warn) }
+
+  before do
+    allow(subject).to receive(:dbus_properties_changed)
+  end
+
+  describe "#dasd=" do
+    it "sets the iSCSI node value" do
+      allow(subject).to receive(:dbus_properties_changed)
+
+      expect(subject.dasd).to_not eq y2s390_dasd2
+      subject.dasd = y2s390_dasd2
+      expect(subject.dasd).to eq y2s390_dasd2
+    end
+
+    it "emits properties changed signal" do
+      expect(subject).to receive(:dbus_properties_changed)
+
+      subject.dasd = y2s390_dasd2
+    end
+  end
+end

--- a/service/test/dinstaller/dbus/storage/dasds_tree_test.rb
+++ b/service/test/dinstaller/dbus/storage/dasds_tree_test.rb
@@ -1,0 +1,225 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2023] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../../test_helper"
+require "dinstaller/dbus/storage/dasds_tree"
+require "dinstaller/dbus/storage/dasd"
+require "dbus"
+
+describe DInstaller::DBus::Storage::DasdsTree do
+  subject { described_class.new(service, logger: logger) }
+
+  let(:service) { instance_double(::DBus::Service) }
+  let(:root_node) { instance_double(::DBus::Node) }
+  let(:logger) { Logger.new($stdout, level: :warn) }
+
+  before do
+    allow(service).to receive(:get_node).with(described_class::ROOT_PATH, anything)
+      .and_return(root_node)
+
+    allow(root_node).to receive(:descendant_objects).and_return(dbus_nodes)
+  end
+
+  describe "#find_paths" do
+    let(:dbus_nodes) { [dbus_dasd1, dbus_dasd2] }
+
+    let(:dbus_dasd1) do
+      instance_double(::DBus::Object, path: "/org/opensuse/DInstaller/Storage1/dasds/1")
+    end
+
+    let(:dbus_dasd2) do
+      instance_double(::DBus::Object, path: "/org/opensuse/DInstaller/Storage1/dasds/2")
+    end
+
+    context "when all the given paths are already exported on D-Bus" do
+      let(:paths) do
+        ["/org/opensuse/DInstaller/Storage1/dasds/1"]
+      end
+
+      it "returns the corresponding D-BUS DASDs" do
+        expect(subject.find_paths(paths)).to eq [dbus_dasd1]
+      end
+    end
+
+    context "when some of the given paths are already exported on D-Bus" do
+      let(:paths) do
+        ["/org/opensuse/DInstaller/Storage1/dasds/1", "/org/opensuse/DInstaller/Storage1/dasds/3"]
+      end
+
+      it "returns the subset of D-BUS DASDs that are exported" do
+        expect(subject.find_paths(paths)).to eq [dbus_dasd1]
+      end
+    end
+
+    context "when none of the given paths are already exported on D-Bus" do
+      let(:paths) do
+        ["/org/opensuse/DInstaller/Storage1/dasds/3"]
+      end
+
+      it "returns an empty array" do
+        expect(subject.find_paths(paths)).to eq []
+      end
+    end
+  end
+
+  describe "#populate" do
+    let(:dbus_nodes) { [dbus_dasd1, dbus_dasd2] }
+
+    let(:dbus_dasd1) do
+      instance_double(DInstaller::DBus::Storage::Dasd, dasd: dasd1, id: dasd1.id)
+    end
+
+    let(:dbus_dasd2) do
+      instance_double(DInstaller::DBus::Storage::Dasd, dasd: dasd2, id: dasd2.id)
+    end
+
+    let(:dasd1) do
+      instance_double(
+        "Y2S390::Dasd", id: "0.0.001", offline?: false, device_name: "/dev/dasda", type: "ECKD",
+        formatted?: false, use_diag: false, access_type: "rw", partition_info: "/dev/dasda1"
+      )
+    end
+
+    let(:dasd2) do
+      instance_double(
+        "Y2S390::Dasd", id: "0.0.002", offline?: true, device_name: nil, type: nil,
+        formatted?: false, use_diag: false, access_type: nil, partition_info: ""
+      )
+    end
+
+    before do
+      allow(service).to receive(:export)
+      allow(service).to receive(:unexport)
+    end
+
+    context "if a given DASD is not exported yet" do
+      let(:dasds) { [dasd3] }
+
+      let(:dasd3) do
+        instance_double(
+          "Y2S390::Dasd", id: "0.0.003", offline?: true, device_name: nil, type: nil,
+          formatted?: false, use_diag: false, access_type: nil, partition_info: ""
+        )
+      end
+
+      it "exports a new D-Bus DASD object" do
+        expect(service).to receive(:export) do |dbus_dasd|
+          expect(dbus_dasd.path).to match(/#{described_class::ROOT_PATH}\/[0-9]+/)
+        end
+
+        subject.populate(dasds)
+      end
+    end
+
+    context "if a given DASD is already exported" do
+      # This DASD has the same id than dasd1, so it represents the same device
+      let(:dasds) { [dasd3] }
+
+      let(:dasd3) do
+        instance_double(
+          "Y2S390::Dasd", id: "0.0.001", offline?: true, device_name: nil, type: nil,
+          formatted?: false, use_diag: false, access_type: nil, partition_info: ""
+        )
+      end
+
+      it "updates the D-Bus node" do
+        expect(dbus_dasd1).to receive(:dasd=).with(dasd3)
+
+        subject.populate(dasds)
+      end
+    end
+
+    context "if an exported D-Bus DASD is not included in the given list of devices" do
+      # dasd2 is part of the tree, but is not included in the list below
+      let(:dasds) { [dasd1] }
+
+      before do
+        allow(dbus_dasd1).to receive(:dasd=)
+      end
+
+      it "unexports the D-Bus DASD object" do
+        expect(service).to receive(:unexport).with(dbus_dasd2)
+
+        subject.populate(dasds)
+      end
+    end
+  end
+
+  describe "#update" do
+    let(:dbus_nodes) { [dbus_dasd1, dbus_dasd2] }
+
+    let(:dbus_dasd1) do
+      instance_double(DInstaller::DBus::Storage::Dasd, dasd: dasd1, id: dasd1.id)
+    end
+
+    let(:dbus_dasd2) do
+      instance_double(DInstaller::DBus::Storage::Dasd, dasd: dasd2, id: dasd2.id)
+    end
+
+    let(:dasd1) do
+      instance_double(
+        "Y2S390::Dasd", id: "0.0.001", offline?: false, device_name: "/dev/dasda", type: "ECKD",
+        formatted?: false, use_diag: false, access_type: "rw", partition_info: "/dev/dasda1"
+      )
+    end
+
+    let(:dasd2) do
+      instance_double(
+        "Y2S390::Dasd", id: "0.0.002", offline?: true, device_name: nil, type: nil,
+        formatted?: false, use_diag: false, access_type: nil, partition_info: ""
+      )
+    end
+
+    context "if a given DASD is already exported" do
+      # This DASD has the same id than dasd1, so it represents the same device
+      let(:dasds) { [dasd3] }
+
+      let(:dasd3) do
+        instance_double(
+          "Y2S390::Dasd", id: "0.0.001", offline?: true, device_name: nil, type: nil,
+          formatted?: false, use_diag: false, access_type: nil, partition_info: ""
+        )
+      end
+
+      it "updates the D-Bus node" do
+        expect(dbus_dasd1).to receive(:dasd=).with(dasd3)
+
+        subject.update(dasds)
+      end
+    end
+
+    context "if an exported D-Bus DASD is not included in the given list of devices" do
+      # dasd2 is part of the tree, but is not included in the list below
+      let(:dasds) { [dasd1] }
+      before { allow(dbus_dasd1).to receive(:dasd=) }
+
+      it "does not unexport the ommitted DASDs" do
+        expect(service).to_not receive(:unexport)
+        subject.update(dasds)
+      end
+
+      it "does not update the ommitted DASDs" do
+        expect(dbus_dasd2).to_not receive(:dasd=)
+        subject.update(dasds)
+      end
+    end
+  end
+end

--- a/service/test/dinstaller/dbus/storage/manager_test.rb
+++ b/service/test/dinstaller/dbus/storage/manager_test.rb
@@ -27,6 +27,7 @@ require "dinstaller/storage/proposal"
 require "dinstaller/storage/proposal_settings"
 require "dinstaller/storage/volume"
 require "dinstaller/storage/iscsi/manager"
+require "dinstaller/storage/dasd/manager"
 require "y2storage"
 require "dbus"
 
@@ -50,6 +51,10 @@ describe DInstaller::DBus::Storage::Manager do
   let(:settings) { nil }
 
   let(:iscsi) { instance_double(DInstaller::Storage::ISCSI::Manager, on_probe: nil) }
+
+  before do
+    allow(Yast::Arch).to receive(:s390).and_return false
+  end
 
   describe "#available_devices" do
     before do
@@ -419,6 +424,93 @@ describe DInstaller::DBus::Storage::Manager do
           expect(result).to eq(2)
         end
       end
+    end
+  end
+
+  context "in an s390 system" do
+    before do
+      allow(Yast::Arch).to receive(:s390).and_return true
+      allow(DInstaller::Storage::DASD::Manager).to receive(:new).and_return(dasd_backend)
+    end
+
+    let(:dasd_backend) do
+      instance_double(DInstaller::Storage::DASD::Manager,
+        on_probe:   nil,
+        on_refresh: nil)
+    end
+
+    describe "#dasd_enable" do
+      before do
+        allow(DInstaller::DBus::Storage::DasdsTree).to receive(:new).and_return(dasds_tree)
+        allow(dasds_tree).to receive(:find_paths).and_return [dbus_dasd1, dbus_dasd2]
+      end
+
+      let(:dasds_tree) { instance_double(DInstaller::DBus::Storage::DasdsTree) }
+
+      let(:dasd1) { instance_double("Y2S390::Dasd") }
+      let(:path1) { "/org/opensuse/DInstaller/Storage1/dasds/1" }
+      let(:dbus_dasd1) { DInstaller::DBus::Storage::Dasd.new(dasd1, path1) }
+
+      let(:dasd2) { instance_double("Y2S390::Dasd") }
+      let(:path2) { "/org/opensuse/DInstaller/Storage1/dasds/2" }
+      let(:dbus_dasd2) { DInstaller::DBus::Storage::Dasd.new(dasd2, path2) }
+
+      let(:path3) { "/org/opensuse/DInstaller/Storage1/dasds/3" }
+
+      context "when some of the paths do not correspond to an exported DASD" do
+        let(:paths) { [path1, path2, path3] }
+
+        it "does not try enable any DASD" do
+          expect(dasd_backend).to_not receive(:enable)
+          subject.dasd_enable(paths)
+        end
+
+        it "returns 1" do
+          result = subject.dasd_enable(paths)
+          expect(result).to eq(1)
+        end
+      end
+
+      context "when all the paths correspond to exported DASDs" do
+        let(:paths) { [path1, path2] }
+
+        it "tries to enable all the DASDs" do
+          expect(dasd_backend).to receive(:enable).with([dasd1, dasd2])
+          subject.dasd_enable(paths)
+        end
+
+        context "and the action successes" do
+          before do
+            allow(dasd_backend).to receive(:enable).with([dasd1, dasd2]).and_return true
+          end
+
+          it "returns 0" do
+            result = subject.dasd_enable(paths)
+            expect(result).to eq 0
+          end
+        end
+
+        context "and the action fails" do
+          before do
+            allow(dasd_backend).to receive(:enable).with([dasd1, dasd2]).and_return false
+          end
+
+          it "returns 2" do
+            result = subject.dasd_enable(paths)
+            expect(result).to eq 2
+          end
+        end
+      end
+    end
+  end
+
+  context "in a system that is not s390" do
+    before do
+      allow(Yast::Arch).to receive(:s390).and_return false
+    end
+
+    it "does not respond to #dasd_enable" do
+      expect { subject.dasd_enable }.to raise_error NoMethodError
     end
   end
 end

--- a/service/test/dinstaller/storage/dasd/manager_test.rb
+++ b/service/test/dinstaller/storage/dasd/manager_test.rb
@@ -1,0 +1,241 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2023] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../../test_helper"
+require "dinstaller/storage/dasd/manager"
+require "forwardable"
+
+# Define some very basic (almost empty) Y2S390 classes to support the tests,
+# since yast2-s390 is not available in all architectures so we cannot depend
+# on the real definitions of these classes to run the tests.
+module Y2S390
+  class DasdsReader; end # rubocop:disable Lint/EmptyClass
+  class FormatProcess; end # rubocop:disable Lint/EmptyClass
+
+  class DasdsCollection
+    extend Forwardable
+
+    def_delegators :@elements, :each, :each_with_index, :select, :find, :reject, :map,
+      :any?, :size, :empty?, :first
+
+    # Constructor
+    #
+    # @param elements [Array<Objects>]
+    def initialize(elements = [])
+      @elements = elements
+    end
+
+    def all
+      @elements.dup
+    end
+  end
+end
+
+describe DInstaller::Storage::DASD::Manager do
+  subject { described_class.new(logger: logger) }
+
+  let(:logger) { Logger.new($stdout, level: :warn) }
+  let(:reader) { double(Y2S390::DasdsReader) }
+  before { expect(Y2S390::DasdsReader).to receive(:new).and_return(reader) }
+
+  let(:dasds) { Y2S390::DasdsCollection.new([dasd1, dasd2, dasd3]) }
+  let(:dasd1) { double("Y2S390::Dasd", id: "0.0.001", use_diag: true, diag_wanted: true) }
+  let(:dasd2) { double("Y2S390::Dasd", id: "0.0.002", use_diag: false, diag_wanted: false) }
+  let(:dasd3) { double("Y2S390::Dasd", id: "0.0.003", use_diag: false, diag_wanted: false) }
+
+  describe "#probe" do
+    before do
+      allow(reader).to receive(:list).and_return dasds
+
+      allow(dasd1).to receive(:diag_wanted=)
+      allow(dasd2).to receive(:diag_wanted=)
+      allow(dasd3).to receive(:diag_wanted=)
+    end
+
+    it "reads the list of DASDs from the system" do
+      expect(reader).to receive(:list).with(force_probing: true).and_return dasds
+      subject.probe
+      expect(subject.devices).to eq dasds
+    end
+
+    it "ensures initial consistency of #use_diag and #diag_wanted" do
+      expect(dasd1).to receive(:diag_wanted=).with(dasd1.use_diag)
+      expect(dasd2).to receive(:diag_wanted=).with(dasd2.use_diag)
+      expect(dasd3).to receive(:diag_wanted=).with(dasd3.use_diag)
+      subject.probe
+    end
+
+    let(:callback) { proc {} }
+
+    it "runs the probe callbacks" do
+      subject.on_probe(&callback)
+      expect(callback).to receive(:call).with(dasds)
+      subject.probe
+    end
+  end
+
+  describe "#enable" do
+    let(:callback) { proc {} }
+    let(:cheetah_error) { Cheetah::ExecutionFailed.new([], "", nil, nil) }
+
+    before do
+      allow(reader).to receive(:update_info)
+    end
+
+    it "calls dasd_configure for each given DASD with the 'online' argument set to 1" do
+      expect(Yast::Execute).to receive(:locally!) do |cmd|
+        expect(cmd.join(" ")).to match(/dasd_configure #{dasd1.id} 1/)
+      end
+      expect(Yast::Execute).to receive(:locally!) do |cmd|
+        expect(cmd.join(" ")).to match(/dasd_configure #{dasd2.id} 1/)
+      end
+      expect(Yast::Execute).to receive(:locally!) do |cmd|
+        expect(cmd.join(" ")).to match(/dasd_configure #{dasd3.id} 1/)
+      end
+
+      subject.enable(dasds)
+    end
+
+    it "returns true if none of the dasd_configure invocations fails" do
+      expect(Yast::Execute).to receive(:locally!).exactly(dasds.size).times
+      expect(subject.enable(dasds)).to eq true
+    end
+
+    it "returns false if any of the dasd_configure invocations fails" do
+      expect(Yast::Execute).to receive(:locally!).with(array_including(dasd1.id), any_args)
+      expect(Yast::Execute).to receive(:locally!).with(array_including(dasd2.id), any_args)
+        .and_raise cheetah_error
+      expect(Yast::Execute).to receive(:locally!).with(array_including(dasd3.id), any_args)
+      expect(subject.enable(dasds)).to eq false
+    end
+
+    it "updates the information of the DASDs and runs the refresh callbacks" do
+      allow(Yast::Execute).to receive(:locally!)
+      subject.on_refresh(&callback)
+
+      expect(reader).to receive(:update_info).with(dasd1, extended: true)
+      expect(reader).to receive(:update_info).with(dasd2, extended: true)
+      expect(reader).to receive(:update_info).with(dasd3, extended: true)
+      expect(callback).to receive(:call).with(dasds)
+
+      subject.enable(dasds)
+    end
+  end
+
+  describe "#disable" do
+    let(:callback) { proc {} }
+    let(:cheetah_error) { Cheetah::ExecutionFailed.new([], "", nil, nil) }
+
+    before { allow(reader).to receive(:update_info) }
+
+    it "calls dasd_configure for each given DASD with the 'online' argument set to 0" do
+      expect(Yast::Execute).to receive(:locally!).with(["dasd_configure", dasd1.id, "0"], any_args)
+      expect(Yast::Execute).to receive(:locally!).with(["dasd_configure", dasd2.id, "0"], any_args)
+      expect(Yast::Execute).to receive(:locally!).with(["dasd_configure", dasd3.id, "0"], any_args)
+
+      subject.disable(dasds)
+    end
+
+    it "returns true if none of the dasd_configure invocations fails" do
+      expect(Yast::Execute).to receive(:locally!).exactly(dasds.size).times
+      expect(subject.disable(dasds)).to eq true
+    end
+
+    it "returns false if any of the dasd_configure invocations fails" do
+      expect(Yast::Execute).to receive(:locally!).with(array_including(dasd1.id), any_args)
+      expect(Yast::Execute).to receive(:locally!).with(array_including(dasd2.id), any_args)
+        .and_raise cheetah_error
+      expect(Yast::Execute).to receive(:locally!).with(array_including(dasd3.id), any_args)
+      expect(subject.disable(dasds)).to eq false
+    end
+
+    it "updates the information of the DASDs and runs the refresh callbacks" do
+      allow(Yast::Execute).to receive(:locally!)
+      subject.on_refresh(&callback)
+
+      expect(reader).to receive(:update_info).with(dasd1, extended: true)
+      expect(reader).to receive(:update_info).with(dasd2, extended: true)
+      expect(reader).to receive(:update_info).with(dasd3, extended: true)
+      expect(callback).to receive(:call).with(dasds)
+
+      subject.disable(dasds)
+    end
+  end
+
+  describe "#format" do
+    let(:callback) { proc {} }
+
+    let(:fmt_status) { 0 }
+    let(:fmt_process) do
+      double("FmtProcess", start: true, status: fmt_status,
+              initialize_summary: true, update_summary: true)
+    end
+
+    before do
+      allow(reader).to receive(:update_info)
+      allow(Y2S390::FormatProcess).to receive(:new).and_return fmt_process
+      allow(fmt_process).to receive(:running?).and_return(true, true, true, false)
+    end
+
+    it "starts a FormatProcess with the given dasds" do
+      expect(Y2S390::FormatProcess).to receive(:new).with(dasds)
+      expect(fmt_process).to receive(:start)
+      subject.format(dasds)
+    end
+
+    it "updates the information of the DASDs and runs the refresh callbacks" do
+      subject.on_refresh(&callback)
+
+      expect(reader).to receive(:update_info).with(dasd1, extended: true)
+      expect(reader).to receive(:update_info).with(dasd2, extended: true)
+      expect(reader).to receive(:update_info).with(dasd3, extended: true)
+      expect(callback).to receive(:call).with(dasds)
+
+      subject.format(dasds)
+    end
+
+    context "when the process is not running after 0.2 seconds of waiting" do
+      before do
+        allow(fmt_process).to receive(:running?).and_return(false)
+      end
+
+      it "returns false" do
+        expect(subject.format(dasds)).to eq false
+      end
+    end
+
+    context "if the process finishes with a status of 0" do
+      let(:fmt_status) { 0 }
+
+      it "returns true" do
+        expect(subject.format(dasds)).to eq true
+      end
+    end
+
+    context "if the process finishes with a non-zero status" do
+      let(:fmt_status) { 1 }
+
+      it "returns false" do
+        expect(subject.format(dasds)).to eq false
+      end
+    end
+  end
+end

--- a/service/test/test_helper.rb
+++ b/service/test/test_helper.rb
@@ -33,7 +33,7 @@ ENV["LC_ALL"] = "en_US.UTF-8"
 # Hack to avoid requiring some files
 # Initially introduced because yast2-s390 is only available for s390x systems
 # (but we want to run the DASD-related unit tests in all architectures).
-LIBS_TO_SKIP = ["y2s390"].freeze
+LIBS_TO_SKIP = ["y2s390", "y2s390/format_process"].freeze
 module Kernel
   alias_method :old_require, :require
 

--- a/service/test/test_helper.rb
+++ b/service/test/test_helper.rb
@@ -30,6 +30,18 @@ $LOAD_PATH.unshift(SRC_PATH)
 # (some tests check the output which is marked for translation)
 ENV["LC_ALL"] = "en_US.UTF-8"
 
+# Hack to avoid requiring some files
+# Initially introduced because yast2-s390 is only available for s390x systems
+# (but we want to run the DASD-related unit tests in all architectures).
+LIBS_TO_SKIP = ["y2s390"].freeze
+module Kernel
+  alias_method :old_require, :require
+
+  def require(path)
+    old_require(path) unless LIBS_TO_SKIP.include?(path)
+  end
+end
+
 if ENV["COVERAGE"]
   require "simplecov"
   SimpleCov.start do


### PR DESCRIPTION
 D-Bus API that allows to:

- Query all the available DASD devices with their corresponding information
- Set the DIAG value for a set of DASD devices
- Activate a set of DASD devices
- Deactivate a set of DASD devices
- Format a set of DASD devices (see below)

Only if D-Installer is running in an s390x system, the Storage1 object will implement the interface `.DInstaller.Storage1.DASD.manager` that is the entry point for all the mentioned operations. Documentation about that new interface and the corresponding ``.DInstaller.Storage1.DASD.device` is included in the pull request.

Although the format operation works, the current implementation is temporary and will be refined in a subsequent pull request. It's a slow operation (potentially several minutes), so [we decided](https://gist.github.com/ancorgs/390b064373995595a1b1dfb08d00507a?permalink_comment_id=4502266#gistcomment-4502266) to create the concept of "processes" or "jobs" and expose them in the D-Bus tree. But it makes no sense to block this pull request meanwhile.

### Testing

- All operations manually tested in a real s390 system.
- Unit tests included.