### PR TITLE
[web] Change cspell dependency source

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -42,7 +42,7 @@
         "chrome-remote-interface": "^0.32.1",
         "compression-webpack-plugin": "^10.0.0",
         "copy-webpack-plugin": "^11.0.0",
-        "cspell-cli": "github:streetsidesoftware/cspell-cli",
+        "cspell": "^6.29.3",
         "css-loader": "^6.5.0",
         "css-minimizer-webpack-plugin": "^4.2.2",
         "eslint": "^8.28.0",
@@ -1934,15 +1934,15 @@
       "dev": true
     },
     "node_modules/@cspell/cspell-bundled-dicts": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-6.27.0.tgz",
-      "integrity": "sha512-udRkEUz0QIAecCUECVac8IBCu7f5siCrxUZmsoZINgqLlSh0ppmn4/CiiA+sefj99rOq/vB4VEEQCnMShfl5qw==",
+      "version": "6.29.3",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-6.29.3.tgz",
+      "integrity": "sha512-M4KizYr/MgC1dkJ3Q1lgwh+VQLO60J0P/99GAVPExyT4pGufIekBLCuVypaMKveEgMlsL0LwaumQl+vOlWJnaQ==",
       "dev": true,
       "dependencies": {
         "@cspell/dict-ada": "^4.0.1",
         "@cspell/dict-aws": "^3.0.0",
         "@cspell/dict-bash": "^4.1.1",
-        "@cspell/dict-companies": "^3.0.8",
+        "@cspell/dict-companies": "^3.0.9",
         "@cspell/dict-cpp": "^4.0.3",
         "@cspell/dict-cryptocurrencies": "^3.0.1",
         "@cspell/dict-csharp": "^4.0.2",
@@ -1974,13 +1974,13 @@
         "@cspell/dict-php": "^3.0.4",
         "@cspell/dict-powershell": "^4.0.2",
         "@cspell/dict-public-licenses": "^2.0.1",
-        "@cspell/dict-python": "^4.0.1",
+        "@cspell/dict-python": "^4.0.2",
         "@cspell/dict-r": "^2.0.1",
         "@cspell/dict-ruby": "^4.0.2",
         "@cspell/dict-rust": "^4.0.1",
         "@cspell/dict-scala": "^4.0.1",
         "@cspell/dict-software-terms": "^3.1.5",
-        "@cspell/dict-sql": "^2.0.2",
+        "@cspell/dict-sql": "^2.1.0",
         "@cspell/dict-svelte": "^1.0.2",
         "@cspell/dict-swift": "^2.0.1",
         "@cspell/dict-typescript": "^3.1.1",
@@ -1991,27 +1991,27 @@
       }
     },
     "node_modules/@cspell/cspell-pipe": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-6.27.0.tgz",
-      "integrity": "sha512-lS3kIew5+ETExORdPcJkEA03ylrEL9CHaJ1xE7SSezU3mqoUgbVW5/f2+PCIWPu1mVvUpWef2X1ODddiPPp9NQ==",
+      "version": "6.29.3",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-6.29.3.tgz",
+      "integrity": "sha512-6cmFkkat0CP411mY9vtE72piMh5RDBKc6K7g3O3JCAK1T01qa1WUUEhwFDOekwP1gE0HgC7SRDSy2/NU8zVTvQ==",
       "dev": true,
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@cspell/cspell-service-bus": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-6.27.0.tgz",
-      "integrity": "sha512-GC3WseMeBE1xtIftBgfTOQxgAMHmLF5HhjHo2rVIfCKv3uyQXuNsGYmtqY7dm4GDrBx1vIYjOoT2xtEaSLoUPw==",
+      "version": "6.29.3",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-6.29.3.tgz",
+      "integrity": "sha512-rcxgmbTbUhiF872tw0S7xfv95V2z0kJZSyeXHH9ZRyLNdkk+JU306lWFF8q962+5uuYeGJK31fzJ6ckmnj3IhA==",
       "dev": true,
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@cspell/cspell-types": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-6.27.0.tgz",
-      "integrity": "sha512-eHKpAhIUYIjssqF20IrihzNAPDTWJsFpBzg7UznX03Z4Y77JrGAgdRZ6h69uaIafQb7uotNYWnDazpVSkMpikQ==",
+      "version": "6.29.3",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-6.29.3.tgz",
+      "integrity": "sha512-JSl+P+WiJSrMclq6CklHrsfRuNG170HO/mo3giM/R4Zf4dscgnZL8xcOgFz765KKvTL4WJqYI7hWqLkBff3V+A==",
       "dev": true,
       "engines": {
         "node": ">=14"
@@ -2036,9 +2036,9 @@
       "dev": true
     },
     "node_modules/@cspell/dict-companies": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-companies/-/dict-companies-3.0.8.tgz",
-      "integrity": "sha512-tQPpkxgog+7xGN3dA9p2Hd4O95+hFYfJuHeY9GgxNahBQyq3bv0REAc6xlqdtkIpfV2ga93B0l37mQr1p107Iw==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-companies/-/dict-companies-3.0.9.tgz",
+      "integrity": "sha512-wSkVIJjk33Sm3LhieNv9TsSvUSeP0R/h8xx06NqbMYF43w9J8hZiMHlbB3FzaSOHRpXT5eBIJBVTeFbceZdiqg==",
       "dev": true
     },
     "node_modules/@cspell/dict-cpp": {
@@ -2096,9 +2096,9 @@
       "dev": true
     },
     "node_modules/@cspell/dict-en_us": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.3.0.tgz",
-      "integrity": "sha512-lQ4r8tBiylNjmYwrWz4xUgBtVC0CciKpddMUVosdusHonFE0KjlvkZK6PFtROBupmRLMBBMjxvtpbq8SdFBqCw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.3.1.tgz",
+      "integrity": "sha512-akfx/Q+4J3rfawtGaqe1Yp+fNyCGJCKmTQT14LXxGLN7DEjGvOFzlYoS+DdD3aDwAJih79bEFGiG+Lqs0zOauA==",
       "dev": true
     },
     "node_modules/@cspell/dict-en-common-misspellings": {
@@ -2222,15 +2222,15 @@
       "dev": true
     },
     "node_modules/@cspell/dict-public-licenses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-public-licenses/-/dict-public-licenses-2.0.1.tgz",
-      "integrity": "sha512-NZNwzkL5BqKddepDxvX/Qbji378Mso1TdnV4RFAN8hJoo6dSR0fv2TTI/Y0i/YWBmfmQGyTpEztBXtAw4qgjiA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-public-licenses/-/dict-public-licenses-2.0.2.tgz",
+      "integrity": "sha512-baKkbs/WGEV2lCWZoL0KBPh3uiPcul5GSDwmXEBAsR5McEW52LF94/b7xWM0EmSAc/y8ODc5LnPYC7RDRLi6LQ==",
       "dev": true
     },
     "node_modules/@cspell/dict-python": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-python/-/dict-python-4.0.1.tgz",
-      "integrity": "sha512-1wtUgyaTqRiQY0/fryk0oW22lcxNUnZ5DwteTzfatMdbgR0OHXTlHbI8vYxpHLWalSoch7EpLsnaymG+fOrt8g==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-python/-/dict-python-4.0.2.tgz",
+      "integrity": "sha512-w1jSWDR1CkO23cZFbSYgnD/ZqknDZSVCI1AOE6sSszOJR8shmBkV3lMBYd+vpLsWhmkLLBcZTXDkiqFLXDGowQ==",
       "dev": true
     },
     "node_modules/@cspell/dict-r": {
@@ -2264,9 +2264,9 @@
       "dev": true
     },
     "node_modules/@cspell/dict-sql": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-sql/-/dict-sql-2.0.2.tgz",
-      "integrity": "sha512-XxUoamMFU9OGcDHLY6+pTlQDsqq9wcY7Oc4C55hqmotxFeFaaqinoD1UIAm1yDngRP7fKK4mVPPFmJI6bmspHg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-sql/-/dict-sql-2.1.0.tgz",
+      "integrity": "sha512-Bb+TNWUrTNNABO0bmfcYXiTlSt0RD6sB2MIY+rNlaMyIwug43jUjeYmkLz2tPkn3+2uvySeFEOMVYhMVfcuDKg==",
       "dev": true
     },
     "node_modules/@cspell/dict-svelte": {
@@ -2294,21 +2294,21 @@
       "dev": true
     },
     "node_modules/@cspell/dynamic-import": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-6.27.0.tgz",
-      "integrity": "sha512-PrBAH0+6OERWeY57PUH+9WmxYtUBnBjTYmm+3Zpg3SUd/ToD0cNf83OJCrcDF7KNQYE9rjCPUfVdsOe3aJlIHw==",
+      "version": "6.29.3",
+      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-6.29.3.tgz",
+      "integrity": "sha512-M5C8pdFT2Vc14krsiF2IHGVPhnfo2fncrG7PtbKS4tF/UNb2/qsJmK+XKym4TUtlv8re61/XA8OPD6TzK/q0kw==",
       "dev": true,
       "dependencies": {
-        "import-meta-resolve": "^2.2.1"
+        "import-meta-resolve": "^2.2.2"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@cspell/strong-weak-map": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-6.27.0.tgz",
-      "integrity": "sha512-4hel0Dik7GTX8yVOjOXlumIOzYD8mWzDeyMEhEJb3qwDfsTPeeYo1EMTSgtS+oJXR6kQ09qBrF1lok44v6NOAQ==",
+      "version": "6.29.3",
+      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-6.29.3.tgz",
+      "integrity": "sha512-+dc3pUsZY2lrtmosDJt4UlOGZDWyzCFnBJyMJ3uYADr+mBBaY4SILDPsTMOBrUHM3qrdft/TUKyLX4XxalAjPw==",
       "dev": true,
       "engines": {
         "node": ">=14.6"
@@ -6655,19 +6655,19 @@
       }
     },
     "node_modules/cspell": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/cspell/-/cspell-6.27.0.tgz",
-      "integrity": "sha512-BhDzXJIRFcpswOy32tgnoOw2OdSM91pQuUpRxfZvRxdM4HBxUrodDYJ5HbBz7D0vNBrXFidFX/157KNX4m1gmg==",
+      "version": "6.29.3",
+      "resolved": "https://registry.npmjs.org/cspell/-/cspell-6.29.3.tgz",
+      "integrity": "sha512-lhNpCEsze7/YzD4yMb4LnSbCg2Qt+qKOuW/pR47ysqylA6EeBIl8Ea+kBYpSs1GuUHNEu3WXDE23gevePkMkog==",
       "dev": true,
       "dependencies": {
-        "@cspell/cspell-pipe": "6.27.0",
-        "@cspell/dynamic-import": "6.27.0",
+        "@cspell/cspell-pipe": "6.29.3",
+        "@cspell/dynamic-import": "6.29.3",
         "chalk": "^4.1.2",
         "commander": "^10.0.0",
-        "cspell-gitignore": "6.27.0",
-        "cspell-glob": "6.27.0",
-        "cspell-io": "6.27.0",
-        "cspell-lib": "6.27.0",
+        "cspell-gitignore": "6.29.3",
+        "cspell-glob": "6.29.3",
+        "cspell-io": "6.29.3",
+        "cspell-lib": "6.29.3",
         "fast-glob": "^3.2.12",
         "fast-json-stable-stringify": "^2.1.0",
         "file-entry-cache": "^6.0.1",
@@ -6678,7 +6678,8 @@
         "vscode-uri": "^3.0.7"
       },
       "bin": {
-        "cspell": "bin.js"
+        "cspell": "bin.js",
+        "cspell-esm": "bin.mjs"
       },
       "engines": {
         "node": ">=14"
@@ -6687,57 +6688,42 @@
         "url": "https://github.com/streetsidesoftware/cspell?sponsor=1"
       }
     },
-    "node_modules/cspell-cli": {
-      "version": "6.27.0",
-      "resolved": "git+ssh://git@github.com/streetsidesoftware/cspell-cli.git#37dbd5d52b7fd05fb44b59af89e6b2b77e43b609",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cspell": "^6.27.0"
-      },
-      "bin": {
-        "cspell-cli": "index.js"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/cspell-dictionary": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-6.27.0.tgz",
-      "integrity": "sha512-u2HZ6Yl0tIBzflJ9Rt5i15kP1KN41XtyKfqCCntugX3gYtfbQ1t/HvAPcq4g7EDZV2tzqSKGcNvzuJgHJyxxFw==",
+      "version": "6.29.3",
+      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-6.29.3.tgz",
+      "integrity": "sha512-701ypYHQlmJxhVuFV2vivaw1TVCKQwFpukrbFIKGtj/SPxwQd9F/idHiSAHHfIfttmPUBYCBmbSOYlFXrK5jQg==",
       "dev": true,
       "dependencies": {
-        "@cspell/cspell-pipe": "6.27.0",
-        "@cspell/cspell-types": "6.27.0",
-        "cspell-trie-lib": "6.27.0",
+        "@cspell/cspell-pipe": "6.29.3",
+        "@cspell/cspell-types": "6.29.3",
+        "cspell-trie-lib": "6.29.3",
         "fast-equals": "^4.0.3",
-        "gensequence": "^4.0.3"
+        "gensequence": "^5.0.2"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/cspell-gitignore": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-6.27.0.tgz",
-      "integrity": "sha512-aXIuSMtm2pW8Z0y4SHBqvXwY4Hk3lz4b3PD50IU1gn2mjk8GioEYAnWlN/FANeOuMjOXiRfLaX0McvNErnZxdw==",
+      "version": "6.29.3",
+      "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-6.29.3.tgz",
+      "integrity": "sha512-pfKAsXY1LCcy+pNHjTOm5GhEDmbHsfJKBxwp5oYjaBxPDw2zOi2Zyw7qXJskT9B3SaU7FkwPt/kLmXwgUTjcKQ==",
       "dev": true,
       "dependencies": {
-        "cspell-glob": "6.27.0",
+        "cspell-glob": "6.29.3",
         "find-up": "^5.0.0"
       },
       "bin": {
-        "cspell-gitignore": "bin.js"
+        "cspell-gitignore": "bin.mjs"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/cspell-glob": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-6.27.0.tgz",
-      "integrity": "sha512-YzS9SiNU5iFIdEMCeVOsGlCvffCM7M51io9ylkkY6138NLCnqWw/DSePzIAAsuLqh9nsJt8xiXrHPerKiPnN3g==",
+      "version": "6.29.3",
+      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-6.29.3.tgz",
+      "integrity": "sha512-qDo5A2W4/UPut8Uji1ilNDuqOIEkv2zI062rTXWQ1PuVVpXLPuRSAJcx0/6bFPfZCu5ecVZFCZZidS35EV5eWg==",
       "dev": true,
       "dependencies": {
         "micromatch": "^4.0.5"
@@ -6747,28 +6733,28 @@
       }
     },
     "node_modules/cspell-grammar": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-6.27.0.tgz",
-      "integrity": "sha512-03SH0+bWazhkzUUK+t6ywUZvWuDcqj4J171oIdA3fvdG7nBpTqyFc1/vU1mReZK7CDde16BUaqCkWgf+El+N1w==",
+      "version": "6.29.3",
+      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-6.29.3.tgz",
+      "integrity": "sha512-ax5G7Z7Go1mO6fTbbL0w6XUcLUBuKFOFklRjXI3dNktfhfNp2/zsD82ypjfqJJdjyJF010N9xwELSWJqBtPc9w==",
       "dev": true,
       "dependencies": {
-        "@cspell/cspell-pipe": "6.27.0",
-        "@cspell/cspell-types": "6.27.0"
+        "@cspell/cspell-pipe": "6.29.3",
+        "@cspell/cspell-types": "6.29.3"
       },
       "bin": {
-        "cspell-grammar": "bin.js"
+        "cspell-grammar": "bin.mjs"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/cspell-io": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-6.27.0.tgz",
-      "integrity": "sha512-WsvXjbbWwIQVembEtlNuC8cJrGtyUuk8GvZzL9bBpSofU2UXvFjaQ9bAZjIeHibGQrIIuOM0ra0CqOcLb5mShA==",
+      "version": "6.29.3",
+      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-6.29.3.tgz",
+      "integrity": "sha512-8+k+LQ8kT6UfNo+RbRaT7iG3wM3lfo10lP3CroQ7QKycshn1LmdF7vn21XUvI3KY03fmTpv1oEDaAbNS/PueOw==",
       "dev": true,
       "dependencies": {
-        "@cspell/cspell-service-bus": "6.27.0",
+        "@cspell/cspell-service-bus": "6.29.3",
         "node-fetch": "^2.6.9"
       },
       "engines": {
@@ -6776,27 +6762,27 @@
       }
     },
     "node_modules/cspell-lib": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-6.27.0.tgz",
-      "integrity": "sha512-wwi3VCFiWaVFrV/ycm4yNBjjPY3pyhWud4lVJs51p2IkKqJbmR7hZ+bSIyw6d9MVzPKRD67eMaNBYXFGDaNHGQ==",
+      "version": "6.29.3",
+      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-6.29.3.tgz",
+      "integrity": "sha512-6LZMjfesW8lOG2aCy0knApY82SiM/McK8KX2uvMI+3VCALsrPdpyh6sgjxrPDm+AioRSW57CoOpRL+R4rZ/12Q==",
       "dev": true,
       "dependencies": {
-        "@cspell/cspell-bundled-dicts": "6.27.0",
-        "@cspell/cspell-pipe": "6.27.0",
-        "@cspell/cspell-types": "6.27.0",
-        "@cspell/strong-weak-map": "6.27.0",
+        "@cspell/cspell-bundled-dicts": "6.29.3",
+        "@cspell/cspell-pipe": "6.29.3",
+        "@cspell/cspell-types": "6.29.3",
+        "@cspell/strong-weak-map": "6.29.3",
         "clear-module": "^4.1.2",
         "comment-json": "^4.2.3",
         "configstore": "^5.0.1",
-        "cosmiconfig": "8.0.0",
-        "cspell-dictionary": "6.27.0",
-        "cspell-glob": "6.27.0",
-        "cspell-grammar": "6.27.0",
-        "cspell-io": "6.27.0",
-        "cspell-trie-lib": "6.27.0",
+        "cosmiconfig": "^8.1.0",
+        "cspell-dictionary": "6.29.3",
+        "cspell-glob": "6.29.3",
+        "cspell-grammar": "6.29.3",
+        "cspell-io": "6.29.3",
+        "cspell-trie-lib": "6.29.3",
         "fast-equals": "^4.0.3",
         "find-up": "^5.0.0",
-        "gensequence": "^4.0.3",
+        "gensequence": "^5.0.2",
         "import-fresh": "^3.3.0",
         "resolve-from": "^5.0.0",
         "resolve-global": "^1.0.0",
@@ -6814,9 +6800,9 @@
       "dev": true
     },
     "node_modules/cspell-lib/node_modules/cosmiconfig": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.0.0.tgz",
-      "integrity": "sha512-da1EafcpH6b/TD8vDRaWV7xFINlHlF6zKsGwS1TsuVJTZRkquaS5HTMq7uq6h31619QjbsYl21gVDOm32KM1vQ==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.1.0.tgz",
+      "integrity": "sha512-0tLZ9URlPGU7JsKq0DQOQ3FoRsYX8xDZ7xMiATQfaiGMz7EHowNkbU9u1coAOmnh9p/1ySpm0RB3JNWRXM5GCg==",
       "dev": true,
       "dependencies": {
         "import-fresh": "^3.2.1",
@@ -6826,6 +6812,9 @@
       },
       "engines": {
         "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
       }
     },
     "node_modules/cspell-lib/node_modules/js-yaml": {
@@ -6841,14 +6830,14 @@
       }
     },
     "node_modules/cspell-trie-lib": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-6.27.0.tgz",
-      "integrity": "sha512-kelDXszZKzlWbk7hV3cTtWYd2Gs3MXqTNSL3udtN4Oow74ik+h1bWsOOmXKKjtKvRctx4omWC1JdriQXfhBMBA==",
+      "version": "6.29.3",
+      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-6.29.3.tgz",
+      "integrity": "sha512-9jJp+Dt0ZEuSRAiL4ZFS3bp26xUUr8BhRmnj/ZS58RPSEE3QJXzIQsiAzj8LKgHHVySzCAwrIvnEFS8oDQN/vA==",
       "dev": true,
       "dependencies": {
-        "@cspell/cspell-pipe": "6.27.0",
-        "@cspell/cspell-types": "6.27.0",
-        "gensequence": "^4.0.3"
+        "@cspell/cspell-pipe": "6.29.3",
+        "@cspell/cspell-types": "6.29.3",
+        "gensequence": "^5.0.2"
       },
       "engines": {
         "node": ">=14"
@@ -9425,9 +9414,9 @@
       }
     },
     "node_modules/gensequence": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/gensequence/-/gensequence-4.0.3.tgz",
-      "integrity": "sha512-izr+MKqJKjexkvLiPGhW96elQX8TuUR/su/xzILxjqzU1RDz1n1ZbqwDUnNFaRcq0gFR3oQfNH2JOH4Je1x/QA==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/gensequence/-/gensequence-5.0.2.tgz",
+      "integrity": "sha512-JlKEZnFc6neaeSVlkzBGGgkIoIaSxMgvdamRoPN8r3ozm2r9dusqxeKqYQ7lhzmj2UhFQP8nkyfCaiLQxiLrDA==",
       "dev": true,
       "engines": {
         "node": ">=14"
@@ -10242,9 +10231,9 @@
       }
     },
     "node_modules/import-meta-resolve": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-2.2.1.tgz",
-      "integrity": "sha512-C6lLL7EJPY44kBvA80gq4uMsVFw5x3oSKfuMl1cuZ2RkI5+UJqQXgn+6hlUew0y4ig7Ypt4CObAAIzU53Nfpuw==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-2.2.2.tgz",
+      "integrity": "sha512-f8KcQ1D80V7RnqVm+/lirO9zkOxjGxhaTC1IPrBGd3MEfNgmNG67tSUO9gTi2F3Blr2Az6g1vocaxzkVnWl9MA==",
       "dev": true,
       "funding": {
         "type": "github",
@@ -20060,15 +20049,15 @@
       "dev": true
     },
     "@cspell/cspell-bundled-dicts": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-6.27.0.tgz",
-      "integrity": "sha512-udRkEUz0QIAecCUECVac8IBCu7f5siCrxUZmsoZINgqLlSh0ppmn4/CiiA+sefj99rOq/vB4VEEQCnMShfl5qw==",
+      "version": "6.29.3",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-6.29.3.tgz",
+      "integrity": "sha512-M4KizYr/MgC1dkJ3Q1lgwh+VQLO60J0P/99GAVPExyT4pGufIekBLCuVypaMKveEgMlsL0LwaumQl+vOlWJnaQ==",
       "dev": true,
       "requires": {
         "@cspell/dict-ada": "^4.0.1",
         "@cspell/dict-aws": "^3.0.0",
         "@cspell/dict-bash": "^4.1.1",
-        "@cspell/dict-companies": "^3.0.8",
+        "@cspell/dict-companies": "^3.0.9",
         "@cspell/dict-cpp": "^4.0.3",
         "@cspell/dict-cryptocurrencies": "^3.0.1",
         "@cspell/dict-csharp": "^4.0.2",
@@ -20100,13 +20089,13 @@
         "@cspell/dict-php": "^3.0.4",
         "@cspell/dict-powershell": "^4.0.2",
         "@cspell/dict-public-licenses": "^2.0.1",
-        "@cspell/dict-python": "^4.0.1",
+        "@cspell/dict-python": "^4.0.2",
         "@cspell/dict-r": "^2.0.1",
         "@cspell/dict-ruby": "^4.0.2",
         "@cspell/dict-rust": "^4.0.1",
         "@cspell/dict-scala": "^4.0.1",
         "@cspell/dict-software-terms": "^3.1.5",
-        "@cspell/dict-sql": "^2.0.2",
+        "@cspell/dict-sql": "^2.1.0",
         "@cspell/dict-svelte": "^1.0.2",
         "@cspell/dict-swift": "^2.0.1",
         "@cspell/dict-typescript": "^3.1.1",
@@ -20114,21 +20103,21 @@
       }
     },
     "@cspell/cspell-pipe": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-6.27.0.tgz",
-      "integrity": "sha512-lS3kIew5+ETExORdPcJkEA03ylrEL9CHaJ1xE7SSezU3mqoUgbVW5/f2+PCIWPu1mVvUpWef2X1ODddiPPp9NQ==",
+      "version": "6.29.3",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-6.29.3.tgz",
+      "integrity": "sha512-6cmFkkat0CP411mY9vtE72piMh5RDBKc6K7g3O3JCAK1T01qa1WUUEhwFDOekwP1gE0HgC7SRDSy2/NU8zVTvQ==",
       "dev": true
     },
     "@cspell/cspell-service-bus": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-6.27.0.tgz",
-      "integrity": "sha512-GC3WseMeBE1xtIftBgfTOQxgAMHmLF5HhjHo2rVIfCKv3uyQXuNsGYmtqY7dm4GDrBx1vIYjOoT2xtEaSLoUPw==",
+      "version": "6.29.3",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-6.29.3.tgz",
+      "integrity": "sha512-rcxgmbTbUhiF872tw0S7xfv95V2z0kJZSyeXHH9ZRyLNdkk+JU306lWFF8q962+5uuYeGJK31fzJ6ckmnj3IhA==",
       "dev": true
     },
     "@cspell/cspell-types": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-6.27.0.tgz",
-      "integrity": "sha512-eHKpAhIUYIjssqF20IrihzNAPDTWJsFpBzg7UznX03Z4Y77JrGAgdRZ6h69uaIafQb7uotNYWnDazpVSkMpikQ==",
+      "version": "6.29.3",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-6.29.3.tgz",
+      "integrity": "sha512-JSl+P+WiJSrMclq6CklHrsfRuNG170HO/mo3giM/R4Zf4dscgnZL8xcOgFz765KKvTL4WJqYI7hWqLkBff3V+A==",
       "dev": true
     },
     "@cspell/dict-ada": {
@@ -20150,9 +20139,9 @@
       "dev": true
     },
     "@cspell/dict-companies": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-companies/-/dict-companies-3.0.8.tgz",
-      "integrity": "sha512-tQPpkxgog+7xGN3dA9p2Hd4O95+hFYfJuHeY9GgxNahBQyq3bv0REAc6xlqdtkIpfV2ga93B0l37mQr1p107Iw==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-companies/-/dict-companies-3.0.9.tgz",
+      "integrity": "sha512-wSkVIJjk33Sm3LhieNv9TsSvUSeP0R/h8xx06NqbMYF43w9J8hZiMHlbB3FzaSOHRpXT5eBIJBVTeFbceZdiqg==",
       "dev": true
     },
     "@cspell/dict-cpp": {
@@ -20210,9 +20199,9 @@
       "dev": true
     },
     "@cspell/dict-en_us": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.3.0.tgz",
-      "integrity": "sha512-lQ4r8tBiylNjmYwrWz4xUgBtVC0CciKpddMUVosdusHonFE0KjlvkZK6PFtROBupmRLMBBMjxvtpbq8SdFBqCw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.3.1.tgz",
+      "integrity": "sha512-akfx/Q+4J3rfawtGaqe1Yp+fNyCGJCKmTQT14LXxGLN7DEjGvOFzlYoS+DdD3aDwAJih79bEFGiG+Lqs0zOauA==",
       "dev": true
     },
     "@cspell/dict-en-common-misspellings": {
@@ -20336,15 +20325,15 @@
       "dev": true
     },
     "@cspell/dict-public-licenses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-public-licenses/-/dict-public-licenses-2.0.1.tgz",
-      "integrity": "sha512-NZNwzkL5BqKddepDxvX/Qbji378Mso1TdnV4RFAN8hJoo6dSR0fv2TTI/Y0i/YWBmfmQGyTpEztBXtAw4qgjiA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-public-licenses/-/dict-public-licenses-2.0.2.tgz",
+      "integrity": "sha512-baKkbs/WGEV2lCWZoL0KBPh3uiPcul5GSDwmXEBAsR5McEW52LF94/b7xWM0EmSAc/y8ODc5LnPYC7RDRLi6LQ==",
       "dev": true
     },
     "@cspell/dict-python": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-python/-/dict-python-4.0.1.tgz",
-      "integrity": "sha512-1wtUgyaTqRiQY0/fryk0oW22lcxNUnZ5DwteTzfatMdbgR0OHXTlHbI8vYxpHLWalSoch7EpLsnaymG+fOrt8g==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-python/-/dict-python-4.0.2.tgz",
+      "integrity": "sha512-w1jSWDR1CkO23cZFbSYgnD/ZqknDZSVCI1AOE6sSszOJR8shmBkV3lMBYd+vpLsWhmkLLBcZTXDkiqFLXDGowQ==",
       "dev": true
     },
     "@cspell/dict-r": {
@@ -20378,9 +20367,9 @@
       "dev": true
     },
     "@cspell/dict-sql": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-sql/-/dict-sql-2.0.2.tgz",
-      "integrity": "sha512-XxUoamMFU9OGcDHLY6+pTlQDsqq9wcY7Oc4C55hqmotxFeFaaqinoD1UIAm1yDngRP7fKK4mVPPFmJI6bmspHg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-sql/-/dict-sql-2.1.0.tgz",
+      "integrity": "sha512-Bb+TNWUrTNNABO0bmfcYXiTlSt0RD6sB2MIY+rNlaMyIwug43jUjeYmkLz2tPkn3+2uvySeFEOMVYhMVfcuDKg==",
       "dev": true
     },
     "@cspell/dict-svelte": {
@@ -20408,18 +20397,18 @@
       "dev": true
     },
     "@cspell/dynamic-import": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-6.27.0.tgz",
-      "integrity": "sha512-PrBAH0+6OERWeY57PUH+9WmxYtUBnBjTYmm+3Zpg3SUd/ToD0cNf83OJCrcDF7KNQYE9rjCPUfVdsOe3aJlIHw==",
+      "version": "6.29.3",
+      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-6.29.3.tgz",
+      "integrity": "sha512-M5C8pdFT2Vc14krsiF2IHGVPhnfo2fncrG7PtbKS4tF/UNb2/qsJmK+XKym4TUtlv8re61/XA8OPD6TzK/q0kw==",
       "dev": true,
       "requires": {
-        "import-meta-resolve": "^2.2.1"
+        "import-meta-resolve": "^2.2.2"
       }
     },
     "@cspell/strong-weak-map": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-6.27.0.tgz",
-      "integrity": "sha512-4hel0Dik7GTX8yVOjOXlumIOzYD8mWzDeyMEhEJb3qwDfsTPeeYo1EMTSgtS+oJXR6kQ09qBrF1lok44v6NOAQ==",
+      "version": "6.29.3",
+      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-6.29.3.tgz",
+      "integrity": "sha512-+dc3pUsZY2lrtmosDJt4UlOGZDWyzCFnBJyMJ3uYADr+mBBaY4SILDPsTMOBrUHM3qrdft/TUKyLX4XxalAjPw==",
       "dev": true
     },
     "@csstools/css-parser-algorithms": {
@@ -23708,19 +23697,19 @@
       "dev": true
     },
     "cspell": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/cspell/-/cspell-6.27.0.tgz",
-      "integrity": "sha512-BhDzXJIRFcpswOy32tgnoOw2OdSM91pQuUpRxfZvRxdM4HBxUrodDYJ5HbBz7D0vNBrXFidFX/157KNX4m1gmg==",
+      "version": "6.29.3",
+      "resolved": "https://registry.npmjs.org/cspell/-/cspell-6.29.3.tgz",
+      "integrity": "sha512-lhNpCEsze7/YzD4yMb4LnSbCg2Qt+qKOuW/pR47ysqylA6EeBIl8Ea+kBYpSs1GuUHNEu3WXDE23gevePkMkog==",
       "dev": true,
       "requires": {
-        "@cspell/cspell-pipe": "6.27.0",
-        "@cspell/dynamic-import": "6.27.0",
+        "@cspell/cspell-pipe": "6.29.3",
+        "@cspell/dynamic-import": "6.29.3",
         "chalk": "^4.1.2",
         "commander": "^10.0.0",
-        "cspell-gitignore": "6.27.0",
-        "cspell-glob": "6.27.0",
-        "cspell-io": "6.27.0",
-        "cspell-lib": "6.27.0",
+        "cspell-gitignore": "6.29.3",
+        "cspell-glob": "6.29.3",
+        "cspell-io": "6.29.3",
+        "cspell-lib": "6.29.3",
         "fast-glob": "^3.2.12",
         "fast-json-stable-stringify": "^2.1.0",
         "file-entry-cache": "^6.0.1",
@@ -23812,88 +23801,80 @@
         }
       }
     },
-    "cspell-cli": {
-      "version": "git+ssh://git@github.com/streetsidesoftware/cspell-cli.git#37dbd5d52b7fd05fb44b59af89e6b2b77e43b609",
-      "dev": true,
-      "from": "cspell-cli@github:streetsidesoftware/cspell-cli",
-      "requires": {
-        "cspell": "^6.27.0"
-      }
-    },
     "cspell-dictionary": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-6.27.0.tgz",
-      "integrity": "sha512-u2HZ6Yl0tIBzflJ9Rt5i15kP1KN41XtyKfqCCntugX3gYtfbQ1t/HvAPcq4g7EDZV2tzqSKGcNvzuJgHJyxxFw==",
+      "version": "6.29.3",
+      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-6.29.3.tgz",
+      "integrity": "sha512-701ypYHQlmJxhVuFV2vivaw1TVCKQwFpukrbFIKGtj/SPxwQd9F/idHiSAHHfIfttmPUBYCBmbSOYlFXrK5jQg==",
       "dev": true,
       "requires": {
-        "@cspell/cspell-pipe": "6.27.0",
-        "@cspell/cspell-types": "6.27.0",
-        "cspell-trie-lib": "6.27.0",
+        "@cspell/cspell-pipe": "6.29.3",
+        "@cspell/cspell-types": "6.29.3",
+        "cspell-trie-lib": "6.29.3",
         "fast-equals": "^4.0.3",
-        "gensequence": "^4.0.3"
+        "gensequence": "^5.0.2"
       }
     },
     "cspell-gitignore": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-6.27.0.tgz",
-      "integrity": "sha512-aXIuSMtm2pW8Z0y4SHBqvXwY4Hk3lz4b3PD50IU1gn2mjk8GioEYAnWlN/FANeOuMjOXiRfLaX0McvNErnZxdw==",
+      "version": "6.29.3",
+      "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-6.29.3.tgz",
+      "integrity": "sha512-pfKAsXY1LCcy+pNHjTOm5GhEDmbHsfJKBxwp5oYjaBxPDw2zOi2Zyw7qXJskT9B3SaU7FkwPt/kLmXwgUTjcKQ==",
       "dev": true,
       "requires": {
-        "cspell-glob": "6.27.0",
+        "cspell-glob": "6.29.3",
         "find-up": "^5.0.0"
       }
     },
     "cspell-glob": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-6.27.0.tgz",
-      "integrity": "sha512-YzS9SiNU5iFIdEMCeVOsGlCvffCM7M51io9ylkkY6138NLCnqWw/DSePzIAAsuLqh9nsJt8xiXrHPerKiPnN3g==",
+      "version": "6.29.3",
+      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-6.29.3.tgz",
+      "integrity": "sha512-qDo5A2W4/UPut8Uji1ilNDuqOIEkv2zI062rTXWQ1PuVVpXLPuRSAJcx0/6bFPfZCu5ecVZFCZZidS35EV5eWg==",
       "dev": true,
       "requires": {
         "micromatch": "^4.0.5"
       }
     },
     "cspell-grammar": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-6.27.0.tgz",
-      "integrity": "sha512-03SH0+bWazhkzUUK+t6ywUZvWuDcqj4J171oIdA3fvdG7nBpTqyFc1/vU1mReZK7CDde16BUaqCkWgf+El+N1w==",
+      "version": "6.29.3",
+      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-6.29.3.tgz",
+      "integrity": "sha512-ax5G7Z7Go1mO6fTbbL0w6XUcLUBuKFOFklRjXI3dNktfhfNp2/zsD82ypjfqJJdjyJF010N9xwELSWJqBtPc9w==",
       "dev": true,
       "requires": {
-        "@cspell/cspell-pipe": "6.27.0",
-        "@cspell/cspell-types": "6.27.0"
+        "@cspell/cspell-pipe": "6.29.3",
+        "@cspell/cspell-types": "6.29.3"
       }
     },
     "cspell-io": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-6.27.0.tgz",
-      "integrity": "sha512-WsvXjbbWwIQVembEtlNuC8cJrGtyUuk8GvZzL9bBpSofU2UXvFjaQ9bAZjIeHibGQrIIuOM0ra0CqOcLb5mShA==",
+      "version": "6.29.3",
+      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-6.29.3.tgz",
+      "integrity": "sha512-8+k+LQ8kT6UfNo+RbRaT7iG3wM3lfo10lP3CroQ7QKycshn1LmdF7vn21XUvI3KY03fmTpv1oEDaAbNS/PueOw==",
       "dev": true,
       "requires": {
-        "@cspell/cspell-service-bus": "6.27.0",
+        "@cspell/cspell-service-bus": "6.29.3",
         "node-fetch": "^2.6.9"
       }
     },
     "cspell-lib": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-6.27.0.tgz",
-      "integrity": "sha512-wwi3VCFiWaVFrV/ycm4yNBjjPY3pyhWud4lVJs51p2IkKqJbmR7hZ+bSIyw6d9MVzPKRD67eMaNBYXFGDaNHGQ==",
+      "version": "6.29.3",
+      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-6.29.3.tgz",
+      "integrity": "sha512-6LZMjfesW8lOG2aCy0knApY82SiM/McK8KX2uvMI+3VCALsrPdpyh6sgjxrPDm+AioRSW57CoOpRL+R4rZ/12Q==",
       "dev": true,
       "requires": {
-        "@cspell/cspell-bundled-dicts": "6.27.0",
-        "@cspell/cspell-pipe": "6.27.0",
-        "@cspell/cspell-types": "6.27.0",
-        "@cspell/strong-weak-map": "6.27.0",
+        "@cspell/cspell-bundled-dicts": "6.29.3",
+        "@cspell/cspell-pipe": "6.29.3",
+        "@cspell/cspell-types": "6.29.3",
+        "@cspell/strong-weak-map": "6.29.3",
         "clear-module": "^4.1.2",
         "comment-json": "^4.2.3",
         "configstore": "^5.0.1",
-        "cosmiconfig": "8.0.0",
-        "cspell-dictionary": "6.27.0",
-        "cspell-glob": "6.27.0",
-        "cspell-grammar": "6.27.0",
-        "cspell-io": "6.27.0",
-        "cspell-trie-lib": "6.27.0",
+        "cosmiconfig": "^8.1.0",
+        "cspell-dictionary": "6.29.3",
+        "cspell-glob": "6.29.3",
+        "cspell-grammar": "6.29.3",
+        "cspell-io": "6.29.3",
+        "cspell-trie-lib": "6.29.3",
         "fast-equals": "^4.0.3",
         "find-up": "^5.0.0",
-        "gensequence": "^4.0.3",
+        "gensequence": "^5.0.2",
         "import-fresh": "^3.3.0",
         "resolve-from": "^5.0.0",
         "resolve-global": "^1.0.0",
@@ -23908,9 +23889,9 @@
           "dev": true
         },
         "cosmiconfig": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.0.0.tgz",
-          "integrity": "sha512-da1EafcpH6b/TD8vDRaWV7xFINlHlF6zKsGwS1TsuVJTZRkquaS5HTMq7uq6h31619QjbsYl21gVDOm32KM1vQ==",
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.1.0.tgz",
+          "integrity": "sha512-0tLZ9URlPGU7JsKq0DQOQ3FoRsYX8xDZ7xMiATQfaiGMz7EHowNkbU9u1coAOmnh9p/1ySpm0RB3JNWRXM5GCg==",
           "dev": true,
           "requires": {
             "import-fresh": "^3.2.1",
@@ -23931,14 +23912,14 @@
       }
     },
     "cspell-trie-lib": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-6.27.0.tgz",
-      "integrity": "sha512-kelDXszZKzlWbk7hV3cTtWYd2Gs3MXqTNSL3udtN4Oow74ik+h1bWsOOmXKKjtKvRctx4omWC1JdriQXfhBMBA==",
+      "version": "6.29.3",
+      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-6.29.3.tgz",
+      "integrity": "sha512-9jJp+Dt0ZEuSRAiL4ZFS3bp26xUUr8BhRmnj/ZS58RPSEE3QJXzIQsiAzj8LKgHHVySzCAwrIvnEFS8oDQN/vA==",
       "dev": true,
       "requires": {
-        "@cspell/cspell-pipe": "6.27.0",
-        "@cspell/cspell-types": "6.27.0",
-        "gensequence": "^4.0.3"
+        "@cspell/cspell-pipe": "6.29.3",
+        "@cspell/cspell-types": "6.29.3",
+        "gensequence": "^5.0.2"
       }
     },
     "css-declaration-sorter": {
@@ -25746,9 +25727,9 @@
       "dev": true
     },
     "gensequence": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/gensequence/-/gensequence-4.0.3.tgz",
-      "integrity": "sha512-izr+MKqJKjexkvLiPGhW96elQX8TuUR/su/xzILxjqzU1RDz1n1ZbqwDUnNFaRcq0gFR3oQfNH2JOH4Je1x/QA==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/gensequence/-/gensequence-5.0.2.tgz",
+      "integrity": "sha512-JlKEZnFc6neaeSVlkzBGGgkIoIaSxMgvdamRoPN8r3ozm2r9dusqxeKqYQ7lhzmj2UhFQP8nkyfCaiLQxiLrDA==",
       "dev": true
     },
     "gensync": {
@@ -26366,9 +26347,9 @@
       }
     },
     "import-meta-resolve": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-2.2.1.tgz",
-      "integrity": "sha512-C6lLL7EJPY44kBvA80gq4uMsVFw5x3oSKfuMl1cuZ2RkI5+UJqQXgn+6hlUew0y4ig7Ypt4CObAAIzU53Nfpuw==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-2.2.2.tgz",
+      "integrity": "sha512-f8KcQ1D80V7RnqVm+/lirO9zkOxjGxhaTC1IPrBGd3MEfNgmNG67tSUO9gTi2F3Blr2Az6g1vocaxzkVnWl9MA==",
       "dev": true
     },
     "imurmurhash": {

--- a/web/package.json
+++ b/web/package.json
@@ -47,7 +47,7 @@
     "chrome-remote-interface": "^0.32.1",
     "compression-webpack-plugin": "^10.0.0",
     "copy-webpack-plugin": "^11.0.0",
-    "cspell-cli": "github:streetsidesoftware/cspell-cli",
+    "cspell": "^6.29.3",
     "css-loader": "^6.5.0",
     "css-minimizer-webpack-plugin": "^4.2.2",
     "eslint": "^8.28.0",


### PR DESCRIPTION
## Problem

@teclator told me that there were problems at the time to build the package in OBS because of adding the `cspell` dependency from Github. This made me realize that we can use it from npm instead.


## Solution

Change the dependency source.