### PR TITLE
Remove redundant (and problematic) requires

### DIFF
--- a/service/lib/dinstaller/dbus/interfaces/dasd.rb
+++ b/service/lib/dinstaller/dbus/interfaces/dasd.rb
@@ -20,8 +20,6 @@
 # find current contact information at www.suse.com.
 
 require "dbus"
-require "dinstaller/storage/dasd/manager"
-require "dinstaller/dbus/storage/dasds_tree"
 
 module DInstaller
   module DBus


### PR DESCRIPTION
Follow-up of #464.

This probably slipped in as a side effect of some wrong merge/rebase or similar operation. Those requires should be only at `self.included` below in the same file.