### PR TITLE
setup sh: factor out setup-service.sh to be used by CLI and CI tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,56 +86,30 @@ to have a closer look, then clone and configure the project as explained in the 
 
 You can run D-Installer from its sources by cloning and configuring the project:
 
-~~~
+```console
 $ git clone https://github.com/yast/d-installer
 $ cd d-installer
 $ ./setup.sh
-~~~
-
-Start the d-installer service
-~~~
-cd service; sudo bundle exec bin/d-installer
-~~~
+```
 
 Then point your browser to http://localhost:9090/cockpit/@localhost/d-installer/index.html and that's all.
 
-Note that the [setup.sh](./setup.sh) script installs the required dependencies to build and run the project and it also configures the D-Installer services and cockpit. Alternatively, just go through the following instructions if you want to configure it manually:
-
-* Install dependencies:
-
-~~~
-$ sudo zypper in gcc gcc-c++ make openssl-devel ruby-devel augeas-devel npm cockpit
-~~~
-
-* Setup the D-Installer services:
-
-~~~
-$ sudo cp service/share/dbus.conf /usr/share/dbus-1/d-installer.conf
-$ cd service
-$ bundle config set --local path 'vendor/bundle';
-$ bundle install
-$ cd -
-~~~
-
-* Setup the web UI:
-
-~~~
-$ sudo ln -s `pwd`/web/dist /usr/share/cockpit/d-installer
-$ sudo systemctl start cockpit
-$ cd web
-$ make devel-install
-$ cd -
-~~~
+The [setup.sh](./setup.sh) script installs the required dependencies
+to build and run the project and it also configures the D-Installer services
+and cockpit. It uses `sudo` to install packages and files to system locations.
+The script is well commented so we refer you to it instead of repeating its
+steps here.
 
 * Start the services:
     * beware that D-Installer must run as root (like YaST does) to do
       hardware probing, partition the disks, install the software and so on.
     * Note that `setup.sh` sets up D-Bus activation so starting manually is
       only needed when you prefer to see the log output upfront.
-~~~
+
+```console
 $ cd service
 $ sudo bundle exec bin/d-installer
-~~~
+```
 
 * Check that D-Installer services are working with a tool like
 [busctl](https://www.freedesktop.org/wiki/Software/dbus/) or

--- a/README.md
+++ b/README.md
@@ -115,13 +115,22 @@ $ sudo bundle exec bin/d-installer
 [busctl](https://www.freedesktop.org/wiki/Software/dbus/) or
 [D-Feet](https://wiki.gnome.org/Apps/DFeet) if you prefer a graphical one:
 
-~~~
-$ busctl call org.opensuse.DInstaller.Language /org/opensuse/DInstaller/Language1 \
-    org.opensuse.DInstaller.Language1 AvailableLanguages
 
-$ busctl call org.opensuse.DInstaller.Language /org/opensuse/DInstaller/Language1 \
-    org.freedesktop.DBus.Properties GetAll s org.opensuse.DInstaller.Language1
-~~~
+```console
+$ busctl --address=unix:path=/run/d-installer/bus \
+    call \
+    org.opensuse.DInstaller \
+   /org/opensuse/DInstaller/Manager1 \
+    org.opensuse.DInstaller.Manager1 \
+    CanInstall
+
+$ busctl --address=unix:path=/run/d-installer/bus \
+    call \
+    org.opensuse.DInstaller.Language \
+   /org/opensuse/DInstaller/Language1 \
+    org.freedesktop.DBus.Properties \
+    GetAll s org.opensuse.DInstaller.Language1
+```
 
 ## How to Contribute
 

--- a/setup-service.sh
+++ b/setup-service.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+
+# Using a git checkout in the current directory,
+# set up the service (backend) part of d-installer
+# so that it can be used by
+# - the web frontend (as set up by setup.sh)
+# - the CLI
+# or both
+
+# Exit on error; unset variables are an error
+set -eu
+
+MYDIR=$(realpath $(dirname $0))
+
+# Helper:
+# Ensure root privileges for the installation.
+# In a testing container, we are root but there is no sudo.
+if [ $(id --user) != 0 ]; then
+  SUDO=sudo
+  if [ $($SUDO id --user) != 0 ]; then
+    echo "We are not root and cannot sudo, cannot continue."
+    exit 1
+  fi
+else
+  SUDO=""
+fi
+
+# Helper:
+# Like "sed -e $1 < $2 > $3" but $3 is a system file owned by root
+sudosed() {
+  echo "$2 -> $3"
+  sed -e "$1" "$2" | $SUDO tee "$3" > /dev/null
+}
+
+# - D-Bus configuration
+$SUDO cp -v $MYDIR/service/share/dbus.conf /usr/share/dbus-1/d-installer.conf
+
+# - D-Bus activation configuration
+#   (this could be left out but then we would rely
+#    on the manual startup via bin/d-installer)
+(
+  cd $MYDIR/service/share
+  DBUSDIR=/usr/share/dbus-1/d-installer-services
+  mkdir -p $DBUSDIR
+  for SVC in org.opensuse.DInstaller*.service; do
+    sudosed "s@\(Exec\)=/usr/bin/@\1=$MYDIR/service/bin/@" $SVC $DBUSDIR/$SVC
+  done
+  sudosed "s@\(ExecStart\)=/usr/bin/@\1=$MYDIR/service/bin/@" \
+          systemd.service /usr/lib/systemd/system/d-installer.service
+  $SUDO systemctl daemon-reload
+)
+
+# - Install the service dependencies
+(
+  cd $MYDIR/service
+  bundle config set --local path 'vendor/bundle'
+  bundle install
+)
+

--- a/setup-service.sh
+++ b/setup-service.sh
@@ -48,7 +48,12 @@ $SUDO cp -v $MYDIR/service/share/dbus.conf /usr/share/dbus-1/d-installer.conf
   sudosed "s@\(ExecStart\)=/usr/bin/@\1=$MYDIR/service/bin/@" \
           systemd.service /usr/lib/systemd/system/d-installer.service
   $SUDO systemctl daemon-reload
+  # Start the separate dbus-daemon for D-Installer
+  $SUDO systemctl start d-installer.service
 )
+
+# - Make sure NetworkManager is running
+$SUDO systemctl start NetworkManager
 
 # - Install the service dependencies
 (

--- a/setup-service.sh
+++ b/setup-service.sh
@@ -41,7 +41,7 @@ $SUDO cp -v $MYDIR/service/share/dbus.conf /usr/share/dbus-1/d-installer.conf
 (
   cd $MYDIR/service/share
   DBUSDIR=/usr/share/dbus-1/d-installer-services
-  mkdir -p $DBUSDIR
+  $SUDO mkdir -p $DBUSDIR
   for SVC in org.opensuse.DInstaller*.service; do
     sudosed "s@\(Exec\)=/usr/bin/@\1=$MYDIR/service/bin/@" $SVC $DBUSDIR/$SVC
   done

--- a/setup.sh
+++ b/setup.sh
@@ -3,22 +3,42 @@
 # This script sets up the development environment without installing any
 # package. This script is supposed to run within a repository clone.
 
-sudo zypper --non-interactive install gcc gcc-c++ make openssl-devel ruby-devel \
+# Helper:
+# Ensure root privileges for the installation.
+# In a testing container, we are root but there is no sudo.
+if [ $(id --user) != 0 ]; then
+  SUDO=sudo
+  if [ $($SUDO id --user) != 0 ]; then
+    echo "We are not root and cannot sudo, cannot continue."
+    exit 1
+  fi
+else
+  SUDO=""
+fi
+
+# Install dependencies
+
+$SUDO zypper --non-interactive install gcc gcc-c++ make openssl-devel ruby-devel \
   'npm>=18' git augeas-devel cockpit jemalloc-devel || exit 1
 
-sudo systemctl start cockpit
-
+# Helper:
 # Like "sed -e $1 < $2 > $3" but $3 is a system file owned by root
 sudosed() {
   echo "$2 -> $3"
-  sed -e "$1" "$2" | sudo tee "$3" > /dev/null
+  sed -e "$1" "$2" | $SUDO tee "$3" > /dev/null
 }
 
-# set up the d-installer service
 MYDIR=$(realpath $(dirname $0))
-sudo cp -v $MYDIR/service/share/dbus.conf /usr/share/dbus-1/d-installer.conf
+
+# Backend setup
+
+# - D-Bus configuration
+$SUDO cp -v $MYDIR/service/share/dbus.conf /usr/share/dbus-1/d-installer.conf
+
+# - D-Bus activation configuration
+#   (this could be left out but then we would rely
+#    on the manual startup via bin/d-installer)
 (
-  # D-Bus service activation
   cd $MYDIR/service/share
   DBUSDIR=/usr/share/dbus-1/d-installer-services
   mkdir -p $DBUSDIR
@@ -27,18 +47,29 @@ sudo cp -v $MYDIR/service/share/dbus.conf /usr/share/dbus-1/d-installer.conf
   done
   sudosed "s@\(ExecStart\)=/usr/bin/@\1=$MYDIR/service/bin/@" \
           systemd.service /usr/lib/systemd/system/d-installer.service
-  sudo systemctl daemon-reload
+  $SUDO systemctl daemon-reload
 )
-cd service; bundle config set --local path 'vendor/bundle'; bundle install; cd -
+
+# - Install the service dependencies
+(
+  cd $MYDIR/service
+  bundle config set --local path 'vendor/bundle'
+  bundle install
+)
+
+
+# Web Frontend
+
+$SUDO systemctl start cockpit
 
 # set up the web UI
 cd web; make devel-install; cd -
-sudo ln -snf `pwd`/web/dist /usr/share/cockpit/d-installer
+$SUDO ln -snf `pwd`/web/dist /usr/share/cockpit/d-installer
 
 # Start the installer
 echo
 echo "D-Bus will start the services, see journalctl for their logs."
 echo "To start the services manually, logging to the terminal:"
-echo "  cd service; sudo bundle exec bin/d-installer"
+echo "  cd service; $SUDO bundle exec bin/d-installer"
 echo
 echo "Visit http://localhost:9090/cockpit/@localhost/d-installer/index.html"

--- a/setup.sh
+++ b/setup.sh
@@ -3,6 +3,8 @@
 # This script sets up the development environment without installing any
 # package. This script is supposed to run within a repository clone.
 
+MYDIR=$(realpath $(dirname $0))
+
 # Helper:
 # Ensure root privileges for the installation.
 # In a testing container, we are root but there is no sudo.
@@ -21,42 +23,9 @@ fi
 $SUDO zypper --non-interactive install gcc gcc-c++ make openssl-devel ruby-devel \
   'npm>=18' git augeas-devel cockpit jemalloc-devel || exit 1
 
-# Helper:
-# Like "sed -e $1 < $2 > $3" but $3 is a system file owned by root
-sudosed() {
-  echo "$2 -> $3"
-  sed -e "$1" "$2" | $SUDO tee "$3" > /dev/null
-}
-
-MYDIR=$(realpath $(dirname $0))
-
 # Backend setup
 
-# - D-Bus configuration
-$SUDO cp -v $MYDIR/service/share/dbus.conf /usr/share/dbus-1/d-installer.conf
-
-# - D-Bus activation configuration
-#   (this could be left out but then we would rely
-#    on the manual startup via bin/d-installer)
-(
-  cd $MYDIR/service/share
-  DBUSDIR=/usr/share/dbus-1/d-installer-services
-  mkdir -p $DBUSDIR
-  for SVC in org.opensuse.DInstaller*.service; do
-    sudosed "s@\(Exec\)=/usr/bin/@\1=$MYDIR/service/bin/@" $SVC $DBUSDIR/$SVC
-  done
-  sudosed "s@\(ExecStart\)=/usr/bin/@\1=$MYDIR/service/bin/@" \
-          systemd.service /usr/lib/systemd/system/d-installer.service
-  $SUDO systemctl daemon-reload
-)
-
-# - Install the service dependencies
-(
-  cd $MYDIR/service
-  bundle config set --local path 'vendor/bundle'
-  bundle install
-)
-
+$MYDIR/setup-service.sh
 
 # Web Frontend
 


### PR DESCRIPTION
## Problem

In the instructions for testing the CLI (https://github.com/yast/d-installer-cli/pull/40) we've found that we're repeating some steps that are already automated in our `setup.sh`

Also, the [CI integration-tests](https://github.com/yast/d-installer/blob/25462f57ab695d6910beb59ff0b21a7afaeda47e/.github/workflows/ci.yml) are repeating them.

And the README repeats it too, poorly.

## Solution

Split off  `setup-service.sh` so that it can be called instead of copied.

In the process, fix the automatic D-Bus activation that got broken when we moved to our own bus.

Removed the corresponding part of the Readme. Fixed the smoke test there.

## Testing

- [x] Tested manually in a Live CD VM
- [x] Tested manually in a CI testing container

## Screenshots

no
