### PR TITLE
Fix iSCSI discover

### DIFF
--- a/web/src/components/storage/iscsi/DiscoverForm.jsx
+++ b/web/src/components/storage/iscsi/DiscoverForm.jsx
@@ -41,7 +41,7 @@ const defaultData = {
 };
 
 export default function DiscoverForm({ onSubmit: onSubmitProp, onCancel }) {
-  const [savedData, setSavedData] = useLocalStorage("dinstaller-iscsi-discovery", {});
+  const [savedData, setSavedData] = useLocalStorage("dinstaller-iscsi-discovery", defaultData);
   const [data, setData] = useState(defaultData);
   const [isLoading, setIsLoading] = useState(false);
   const [isFailed, setIsFailed] = useState(false);


### PR DESCRIPTION
## Problem

iSCSI discover form uses local storage, but it fails when threre is nothing stored yet.


## Solution

Initialized local storage with default data.


## Testing

- Tested manually
