### PR TITLE
Report progress of DASD formatting to the D-Bus interface

### DIFF
--- a/doc/dbus_api.md
+++ b/doc/dbus_api.md
@@ -623,7 +623,11 @@ ExitCode readable u
 
 ##### Signals
 
-* `Finished(u exit_code)`: the Job is not longer running and the exit code has been set to its final value.
+* `Finished(u exit_code)`: the Job is not longer running and the exit code has been set to its final
+  value.
+* `PropertiesChanged()`: in parallel to the mentioned `Finished` signal, the standard
+  `PropertiesChanged` signal from `org.freedesktop.DBus.Properties` is also triggered at the end of
+  the job execution to reflect the corresponding changes in the properties.
 
 #### `org.opensuse.DInstaller.Storage1.DASD.Format` Interface
 

--- a/doc/dbus_api.md
+++ b/doc/dbus_api.md
@@ -645,7 +645,7 @@ Summary readable a{s(uub)}
 
 ##### Signals
 
-* `SummaryUpdated(a{s(uub)} progress)`: the summary has been updated with new progress information for some of the DASDs.
+* `PropertiesChanged`, as standard from `org.freedesktop.DBus.Properties`.
 
 ## Users
 

--- a/doc/dbus_api.md
+++ b/doc/dbus_api.md
@@ -571,7 +571,7 @@ Arguments:
 
 * `in ao devices`: paths of the D-Bus objects representing the DASDs to format.
 * `out u result`: `0` if the format operation starts correctly and the job to track it is created. `1` if any of the given paths is invalid (ie. it does not correspond to a known DASD), `2` in case of any other error.
-* `out o job`: if the result is 0, path of the new job that can be used to track the formatting. Empty string in any other case.
+* `out o job`: if the result is 0, path of the new job that can be used to track the formatting. Contains the string `/` (no job) if the result is not zero.
 
 #### `org.opensuse.DInstaller.Storage1.DASD.Device` Interface
 

--- a/service/lib/dinstaller/dbus/interfaces/dasd.rb
+++ b/service/lib/dinstaller/dbus/interfaces/dasd.rb
@@ -121,7 +121,7 @@ module DInstaller
         # Succeeds (returns 0) if all the devices where successfully formatted.
         #
         # @param paths [Array<String>]
-        # @return [Integer]
+        # @return [Array(Integer,::DBus::ObjectPath)]
         def dasd_format(paths)
           dasds = find_dasds(paths)
           return [1, "/"] if dasds.nil?

--- a/service/lib/dinstaller/dbus/interfaces/dasd.rb
+++ b/service/lib/dinstaller/dbus/interfaces/dasd.rb
@@ -124,13 +124,13 @@ module DInstaller
         # @return [Integer]
         def dasd_format(paths)
           dasds = find_dasds(paths)
-          return [1, ""] if dasds.nil?
+          return [1, "/"] if dasds.nil?
 
           job = nil
           progress = proc { |statuses| job.update_format(statuses) }
           finish = proc { |result| job.finish_format(result) }
           initial_statuses = dasd_backend.format(dasds, on_progress: progress, on_finish: finish)
-          return [2, ""] unless initial_statuses
+          return [2, "/"] unless initial_statuses
 
           job = jobs_tree.add_dasds_format(initial_statuses, dasds_tree)
           [0, job.path]

--- a/service/lib/dinstaller/dbus/storage/dasds_format_job.rb
+++ b/service/lib/dinstaller/dbus/storage/dasds_format_job.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2023] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "dbus"
+require "dinstaller/dbus/base_object"
+
+module DInstaller
+  module DBus
+    module Storage
+      # Class representing the process of formatting a set of DASDs
+      class DasdsFormatJob < BaseObject
+        # Internal class to make easier to index the status information both by DASD id and by job
+        # path, although in fact both are fully stable during the whole execution of the installer.
+        #
+        # This class helps to refresh the relationship between the DASD and its path every time a
+        # status update is sent from the backend, although as already mentioned that wouldn't be
+        # needed with the current implementation of the DASDs tree, since it keeps that relationship
+        # stable.
+        class DasdFormatInfo
+          # @return [String] channel id of the DASD
+          attr_accessor :id
+
+          # @return [String] path of the DASD in the D-Bus tree
+          attr_accessor :path
+
+          # @return [Integer] total number of cylinders reported by the format operation
+          attr_accessor :cylinders
+
+          # @return [Integer] number of cylinders already processed by the format operation
+          attr_accessor :progress
+
+          # @return [Boolean] whether the disk is already fully formatted
+          attr_accessor :done
+
+          # Constructor
+          #
+          # @param status [Y2S390::FormatStatus]
+          # @param dasds_tree [DasdsTree]
+          def initialize(status, dasds_tree)
+            @id = status.dasd.id
+            @cylinders = status.cylinders
+            @progress = status.progress
+            @done = status.done?
+
+            dbus_dasd = dasds_tree.find { |d| d.id == @id }
+            if dbus_dasd
+              @path = dbus_dasd.path
+            else
+              logger.warning "DASD is not longer in the D-BUS tree: #{status.inspect}"
+            end
+          end
+
+          # Progress representation as expected by the D-Bus API (property Summary and signal
+          # SummaryUpdated)
+          def to_dbus
+            [cylinders, progress, done]
+          end
+        end
+
+        JOB_INTERFACE = "org.opensuse.DInstaller.Storage1.Job"
+        private_constant :JOB_INTERFACE
+
+        dbus_interface JOB_INTERFACE do
+          dbus_reader(:running, "b")
+          dbus_reader(:exit_code, "u")
+          dbus_signal(:Finished, "exit_code:u")
+        end
+
+        DASD_FORMAT_INTERFACE = "org.opensuse.DInstaller.Storage1.DASD.Format"
+        private_constant :DASD_FORMAT_INTERFACE
+
+        dbus_interface DASD_FORMAT_INTERFACE do
+          dbus_reader(:summary, "a{s(uub)}")
+          dbus_signal(:SummaryUpdated, "progress:a{s(uub)}")
+        end
+
+        # @return [Boolean]
+        attr_reader :running
+
+        # @return [Integer] zero if still running
+        attr_reader :exit_code
+
+        # @return [Array<Y2390::Dasd>]
+        attr_reader :dasds
+
+        # Constructor
+        #
+        # @param initial [Array<Y2S390::FormatStatus>] initial status report from the format process
+        # @param dasds_tree [DasdsTree] see #dasds_tree
+        # @param path [DBus::ObjectPath] path in which the Job object is exported
+        # @param logger [Logger, nil]
+        def initialize(initial, dasds_tree, path, logger: nil)
+          super(path, logger: logger)
+
+          @exit_code = 0
+          @running = true
+          @dasds_tree = dasds_tree
+          @infos = {}
+          update_info(initial)
+        end
+
+        # Current status, in the format described by the D-Bus API
+        def summary
+          result = {}
+          @infos.each_value { |i| result[i.path] = i.to_dbus if i.path }
+          result
+        end
+
+        # Marks the job as finished
+        #
+        # @note A Finished signal is always emitted.
+        #
+        # @param exit_code [Integer]
+        def finish_format(exit_code)
+          @running = false
+          @exit_code = exit_code
+          Finished(exit_code)
+        end
+
+        # Updates the internal status information
+        #
+        # @note A SummaryUpdated signal is always emitted
+        #
+        # @param statuses [Array<Y2S390::FormatStatus] latest status update from the format process
+        def update_format(statuses)
+          SummaryUpdated(update_info(statuses))
+        end
+
+      private
+
+        # @return [DasdsTree] D-Bus representation of the DASDs
+        attr_reader :dasds_tree
+
+        # @param statuses [Array<Y2S390::FormatStatus] latest status update from the format process
+        # @return [{String => DasdFormatInfo}] status info of the DASDs, indexed by D-Bus path
+        def update_info(statuses)
+          result = {}
+          statuses.each do |status|
+            info = DasdFormatInfo.new(status, dasds_tree)
+            @infos[info.id] = info
+            result[info.path] = info.to_dbus if info.path
+          end
+          result
+        end
+      end
+    end
+  end
+end

--- a/service/lib/dinstaller/dbus/storage/dasds_format_job.rb
+++ b/service/lib/dinstaller/dbus/storage/dasds_format_job.rb
@@ -126,13 +126,14 @@ module DInstaller
 
         # Marks the job as finished
         #
-        # @note A Finished signal is always emitted.
+        # @note A Finished and a PropertiesChanged signals are always emitted.
         #
         # @param exit_code [Integer]
         def finish_format(exit_code)
           @running = false
           @exit_code = exit_code
           Finished(exit_code)
+          dbus_properties_changed(JOB_INTERFACE, interfaces_and_properties.slice(JOB_INTERFACE), [])
         end
 
         # Updates the internal status information

--- a/service/lib/dinstaller/dbus/storage/dasds_tree.rb
+++ b/service/lib/dinstaller/dbus/storage/dasds_tree.rb
@@ -44,7 +44,7 @@ module DInstaller
 
         # Fills the D-Bus tree with the given DASDs
         #
-        # Any previous DASD if unexported and the new ones are exported
+        # Any previous DASD is unexported and the new ones are exported
         #
         # @param dasds [Array<DBus::Storage::Dasd>]
         def populate(dasds)
@@ -67,6 +67,11 @@ module DInstaller
         # @return [Array<DBus::Storage::Dasd>]
         def find_paths(paths)
           dbus_dasds.find_all { |d| paths.include?(d.path) }
+        end
+
+        # @return [Array<DBus::Storage::Dasd>]
+        def find(*args, &block)
+          dbus_dasds.find(*args, &block)
         end
 
       private
@@ -102,7 +107,7 @@ module DInstaller
 
         # Exports or updates the information of a given DASD object
         #
-        # @return [DBus::Storage::Dasd>]
+        # @return [DBus::Storage::Dasd]
         def publish(dasd)
           dbus_dasd = dbus_dasds.find { |d| d.id == dasd.id }
 

--- a/service/lib/dinstaller/dbus/storage/jobs_tree.rb
+++ b/service/lib/dinstaller/dbus/storage/jobs_tree.rb
@@ -47,6 +47,7 @@ module DInstaller
         # @param initial [Array<Y2S390::FormatStatus] initial status information for all the
         #   involved DASDs
         # @param dasds_tree [DasdsTree] up-to-date representations of the DASDs in the D-Bus tree
+        # @return [DasdsFormatJob]
         def add_dasds_format(initial, dasds_tree)
           job = DBus::Storage::DasdsFormatJob.new(
             initial, dasds_tree, next_path, logger: logger

--- a/service/lib/dinstaller/dbus/storage/jobs_tree.rb
+++ b/service/lib/dinstaller/dbus/storage/jobs_tree.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2023] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "dinstaller/dbus/with_path_generator"
+require "dinstaller/dbus/storage/dasds_format_job"
+
+module DInstaller
+  module DBus
+    module Storage
+      # Class representing the storage jobs (D-Bus objects representing long-running processes)
+      # exported on D-Bus
+      class JobsTree
+        include WithPathGenerator
+
+        ROOT_PATH = "/org/opensuse/DInstaller/Storage1/jobs"
+        path_generator ROOT_PATH
+
+        # Constructor
+        #
+        # @param service [::DBus::Service]
+        # @param logger [Logger, nil]
+        def initialize(service, logger: nil)
+          @service = service
+          @logger = logger
+        end
+
+        # Registers a new job to format a set of DASDs
+        #
+        # @param initial [Array<Y2S390::FormatStatus] initial status information for all the
+        #   involved DASDs
+        # @param dasds_tree [DasdsTree] up-to-date representations of the DASDs in the D-Bus tree
+        def add_dasds_format(initial, dasds_tree)
+          job = DBus::Storage::DasdsFormatJob.new(
+            initial, dasds_tree, next_path, logger: logger
+          )
+          service.export(job)
+          job
+        end
+
+      private
+
+        # @return [::DBus::Service]
+        attr_reader :service
+
+        # @return [Logger]
+        attr_reader :logger
+      end
+    end
+  end
+end

--- a/service/lib/dinstaller/storage/dasd/format_operation.rb
+++ b/service/lib/dinstaller/storage/dasd/format_operation.rb
@@ -27,37 +27,33 @@ module DInstaller
   module Storage
     module DASD
       # Operation to format the given set of DASDs
-      #
-      # TODO: we plan to change the approach to DASD formatting, so this class will change
-      # very soon.
       class FormatOperation
         # Constructor
         #
         # @param dasds [Array<Y2S390:Dasd>] devices to format
-        def initialize(dasds)
+        def initialize(dasds, on_progress = [], on_finish = [])
           @process = Y2S390::FormatProcess.new(dasds)
+          @on_progress = on_progress
+          @on_finish = on_finish
         end
 
-        # Formats all the given DASDs
+        # Starts a format process on the given DASDs
         #
-        # NOTE: this algorithm is pretty much copied from Y2S390::Dialogs::FormatDialog
+        # NOTE: Does a device need to be reactivated after formating it? The code at
+        # DasdActions::Activate seems to imply that, but the code at DasdActions::Format contains a
+        # comment stating otherwise. Let's do nothing for the time being.
         #
-        # @return [Boolean] true if the operation succeeds for all the DASDs
+        # @return [Array<Y2S390::FormatStatus>, nil] Initial status for all DASDs, nil if the format
+        #   process couldn't be started.
         def run
-          # NOTE: Does a device need to be reactivated after formating it?
-          #       The code at DasdActions::Activate seems to imply that
-          #       But the code at DasdActions::Format contains a comment stating otherwise
-          return false unless start?
+          return nil unless start?
 
           process.initialize_summary
-          while process.running?
-            process.update_summary
-            # TODO: trigger a callback to notify the process status information
-            sleep(0.2)
+          Thread.new do
+            wait # Ensure we finish first
+            monitor_process
           end
-          # TODO: maybe trigger a callback to notify the final status?
-
-          process.status.to_i.zero?
+          process.summary.values
         end
 
       private
@@ -67,13 +63,34 @@ module DInstaller
         # @return [Y2S390::FormatProcess]
         attr_reader :process
 
+        WAIT_TIME = 0.3
+        private_constant :WAIT_TIME
+
+        def wait
+          sleep(WAIT_TIME)
+        end
+
         # Starts the formatting process
         #
         # @return [Boolean] true if the process was succesfully started
         def start?
           process.start
-          sleep(0.2)
+          wait
           process.running?
+        end
+
+        def monitor_process
+          while process.running?
+            update_status
+            wait
+          end
+          update_status
+          @on_finish.each { |p| p.call(process.status) }
+        end
+
+        def update_status
+          process.update_summary
+          @on_progress.each { |p| p.call(process.updated.values) }
         end
       end
     end

--- a/service/lib/dinstaller/storage/dasd/format_operation.rb
+++ b/service/lib/dinstaller/storage/dasd/format_operation.rb
@@ -63,7 +63,9 @@ module DInstaller
         # @return [Y2S390::FormatProcess]
         attr_reader :process
 
-        WAIT_TIME = 0.3
+        # Seconds between queries (including the first one) to the dasdformat command... and thus,
+        # between subsequent progress updates.
+        WAIT_TIME = 1
         private_constant :WAIT_TIME
 
         def wait

--- a/service/lib/dinstaller/storage/dasd/format_operation.rb
+++ b/service/lib/dinstaller/storage/dasd/format_operation.rb
@@ -31,6 +31,9 @@ module DInstaller
         # Constructor
         #
         # @param dasds [Array<Y2S390:Dasd>] devices to format
+        # @param on_progress [Array<Proc>] callbacks to be called when the status of the operation
+        #   is refreshed
+        # @param on_finish [Array<Proc>] callbacks to be called when the operation ends
         def initialize(dasds, on_progress = [], on_finish = [])
           @process = Y2S390::FormatProcess.new(dasds)
           @on_progress = on_progress
@@ -50,7 +53,9 @@ module DInstaller
 
           process.initialize_summary
           Thread.new do
-            wait # Ensure we finish first
+            # Just to be absolutely sure, sleep to ensure the #run method returns and its result is
+            # processed by the caller before we start calling callbacks
+            wait
             monitor_process
           end
           process.summary.values

--- a/service/lib/dinstaller/storage/dasd/manager.rb
+++ b/service/lib/dinstaller/storage/dasd/manager.rb
@@ -125,16 +125,14 @@ module DInstaller
 
         # Formats the given list of DASDs
         #
-        # Refresh callbacks are called at the end, see {#on_refresh}.
-        #
-        # TODO: we plan to change the approach to DASD formatting. See discussion at
-        # https://gist.github.com/ancorgs/390b064373995595a1b1dfb08d00507a
-        # So this method is subject to change in the short term.
-        #
         # @param devices [Array<Y2S390::Dasd>]
         # @return [Boolean] true if all the given devices were successfully formatted
-        def format(devices)
-          refresh_after(devices) { FormatOperation.new(devices).run }
+        def format(devices, on_progress: nil, on_finish: nil)
+          progress = []
+          finish = [proc { |_status| refresh(devices) }]
+          progress << on_progress if on_progress
+          finish << on_finish if on_finish
+          FormatOperation.new(devices, progress, finish).run
         end
 
       private

--- a/service/package/rubygem-d-installer.changes
+++ b/service/package/rubygem-d-installer.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Mar 21 16:28:26 UTC 2023 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Added D-Bus API for management of DASDs (gh#yast/d-installer#464,
+  gh#yast/d-installer#476)
+
+-------------------------------------------------------------------
 Tue Mar 21 11:42:51 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Update the products definitions (gh#yast/d-installer#485):

--- a/service/test/dinstaller/dbus/storage/dasds_tree_test.rb
+++ b/service/test/dinstaller/dbus/storage/dasds_tree_test.rb
@@ -80,6 +80,26 @@ describe DInstaller::DBus::Storage::DasdsTree do
     end
   end
 
+  describe "#find" do
+    let(:dbus_nodes) { [dbus_dasd1, dbus_dasd2, dbus_dasd3] }
+
+    let(:dbus_dasd1) do
+      instance_double(DInstaller::DBus::Storage::Dasd, id: "0.0.001", formatted: false)
+    end
+
+    let(:dbus_dasd2) do
+      instance_double(DInstaller::DBus::Storage::Dasd, id: "0.0.002", formatted: true)
+    end
+
+    let(:dbus_dasd3) do
+      instance_double(DInstaller::DBus::Storage::Dasd, id: "0.0.003", formatted: true)
+    end
+
+    it "returns the first DASD that matches the criteria" do
+      expect(subject.find(&:formatted)).to eq dbus_dasd2
+    end
+  end
+
   describe "#populate" do
     let(:dbus_nodes) { [dbus_dasd1, dbus_dasd2] }
 

--- a/service/test/dinstaller/dbus/storage/jobs_tree_test.rb
+++ b/service/test/dinstaller/dbus/storage/jobs_tree_test.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+# Copyright (c) [2023] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../../test_helper"
+require "dinstaller/dbus/storage/jobs_tree"
+require "dinstaller/dbus/storage/dasds_tree"
+require "dbus"
+
+describe DInstaller::DBus::Storage::JobsTree do
+  subject { described_class.new(service, logger: logger) }
+
+  let(:service) { instance_double(::DBus::Service) }
+  let(:dasds_root_node) { instance_double(::DBus::Node) }
+  let(:logger) { Logger.new($stdout, level: :warn) }
+
+  before do
+    allow(service).to receive(:get_node)
+      .with(DInstaller::DBus::Storage::DasdsTree::ROOT_PATH, anything).and_return(dasds_root_node)
+
+    allow(dasds_root_node).to receive(:descendant_objects).and_return(dasd_nodes)
+  end
+
+  describe "#add_dasds_format" do
+    let(:dbus_dasd1) do
+      instance_double(DInstaller::DBus::Storage::Dasd, id: "0.0.001", path: "/path/dasd1")
+    end
+    let(:dbus_dasd2) do
+      instance_double(DInstaller::DBus::Storage::Dasd, id: "0.0.002", path: "/path/dasd2")
+    end
+    let(:dasd_nodes) { [dbus_dasd1, dbus_dasd2] }
+    let(:dasds_tree) { DInstaller::DBus::Storage::DasdsTree.new(service, logger: logger) }
+
+    let(:dasd1) { double("Y2S390::Dasd", id: "0.0.001") }
+    let(:dasd2) { double("Y2S390::Dasd", id: "0.0.002") }
+    let(:initial_status) do
+      [
+        double("FormatStatus", dasd: dasd1, cylinders: 1000, progress: 0, done?: false),
+        double("FormatStatus", dasd: dasd2, cylinders: 2000, progress: 0, done?: false)
+      ]
+    end
+
+    it "exports a new D-Bus Job object" do
+      expect(service).to receive(:export) do |job|
+        expect(job.path).to match(/#{described_class::ROOT_PATH}\/[0-9]+/)
+
+        expect(job.summary).to eq(
+          { "/path/dasd1" => [1000, 0, false], "/path/dasd2" => [2000, 0, false] }
+        )
+      end
+
+      subject.add_dasds_format(initial_status, dasds_tree)
+    end
+  end
+end

--- a/service/test/dinstaller/dbus/storage/manager_test.rb
+++ b/service/test/dinstaller/dbus/storage/manager_test.rb
@@ -28,6 +28,7 @@ require "dinstaller/storage/proposal_settings"
 require "dinstaller/storage/volume"
 require "dinstaller/storage/iscsi/manager"
 require "dinstaller/storage/dasd/manager"
+require "dinstaller/dbus/storage/dasds_tree"
 require "y2storage"
 require "dbus"
 
@@ -504,6 +505,80 @@ describe DInstaller::DBus::Storage::Manager do
         end
       end
     end
+
+    describe "#dasd_format" do
+      before do
+        allow(DInstaller::DBus::Storage::DasdsTree).to receive(:new).and_return(dasds_tree)
+        allow(dasds_tree).to receive(:find_paths).and_return [dbus_dasd1, dbus_dasd2]
+      end
+
+      let(:dasds_tree) { instance_double(DInstaller::DBus::Storage::DasdsTree) }
+
+      let(:dasd1) { instance_double("Y2S390::Dasd") }
+      let(:path1) { "/org/opensuse/DInstaller/Storage1/dasds/1" }
+      let(:dbus_dasd1) { DInstaller::DBus::Storage::Dasd.new(dasd1, path1) }
+
+      let(:dasd2) { instance_double("Y2S390::Dasd") }
+      let(:path2) { "/org/opensuse/DInstaller/Storage1/dasds/2" }
+      let(:dbus_dasd2) { DInstaller::DBus::Storage::Dasd.new(dasd2, path2) }
+
+      let(:path3) { "/org/opensuse/DInstaller/Storage1/dasds/3" }
+
+      context "when some of the paths do not correspond to an exported DASD" do
+        let(:paths) { [path1, path2, path3] }
+
+        it "does not try to format" do
+          expect(dasd_backend).to_not receive(:format)
+          subject.dasd_format(paths)
+        end
+
+        it "returns 1 as code and empty string as path" do
+          result = subject.dasd_format(paths)
+          expect(result).to eq [1, ""]
+        end
+      end
+
+      context "when all the paths correspond to exported DASDs" do
+        let(:paths) { [path1, path2] }
+
+        it "tries to format all the DASDs" do
+          expect(dasd_backend).to receive(:format).with([dasd1, dasd2], any_args)
+          subject.dasd_format(paths)
+        end
+
+        context "and the action successes" do
+          before do
+            allow(dasd_backend).to receive(:format).and_return initial_status
+
+            allow(DInstaller::DBus::Storage::JobsTree).to receive(:new).and_return(jobs_tree)
+            allow(jobs_tree).to receive(:add_dasds_format).and_return format_job
+          end
+
+          let(:initial_status) { [double("FormatStatus"), double("FormatStatus")] }
+          let(:jobs_tree) { instance_double(DInstaller::DBus::Storage::JobsTree) }
+          let(:format_job) do
+            instance_double(DInstaller::DBus::Storage::DasdsFormatJob, path: job_path)
+          end
+          let(:job_path) { "/some/path" }
+
+          it "returns 0 and the path to the new Job object" do
+            result = subject.dasd_format(paths)
+            expect(result).to eq [0, job_path]
+          end
+        end
+
+        context "and the action fails" do
+          before do
+            allow(dasd_backend).to receive(:format).and_return nil
+          end
+
+          it "returns 2 as code an empty string as path" do
+            result = subject.dasd_format(paths)
+            expect(result).to eq [2, ""]
+          end
+        end
+      end
+    end
   end
 
   context "in a system that is not s390" do
@@ -513,6 +588,10 @@ describe DInstaller::DBus::Storage::Manager do
 
     it "does not respond to #dasd_enable" do
       expect { subject.dasd_enable }.to raise_error NoMethodError
+    end
+
+    it "does not respond to #dasd_format" do
+      expect { subject.dasd_format }.to raise_error NoMethodError
     end
   end
 end

--- a/service/test/dinstaller/dbus/storage/manager_test.rb
+++ b/service/test/dinstaller/dbus/storage/manager_test.rb
@@ -532,9 +532,9 @@ describe DInstaller::DBus::Storage::Manager do
           subject.dasd_format(paths)
         end
 
-        it "returns 1 as code and empty string as path" do
+        it "returns 1 as code and '/' as path" do
           result = subject.dasd_format(paths)
-          expect(result).to eq [1, ""]
+          expect(result).to eq [1, "/"]
         end
       end
 
@@ -572,9 +572,9 @@ describe DInstaller::DBus::Storage::Manager do
             allow(dasd_backend).to receive(:format).and_return nil
           end
 
-          it "returns 2 as code an empty string as path" do
+          it "returns 2 as code and '/' as path" do
             result = subject.dasd_format(paths)
-            expect(result).to eq [2, ""]
+            expect(result).to eq [2, "/"]
           end
         end
       end

--- a/service/test/dinstaller/storage/dasd/manager_test.rb
+++ b/service/test/dinstaller/storage/dasd/manager_test.rb
@@ -258,7 +258,7 @@ describe DInstaller::Storage::DASD::Manager do
       expect(progress_callback).to receive(:call).exactly(steps).times
       expect(finish_callback).to receive(:call).once.with(exit_code)
       subject.format(dasds, on_progress: progress_callback, on_finish: finish_callback)
-      sleep(2) # give background threads a chance to run
+      sleep(5) # give background threads a chance to run
     end
 
     it "updates the information of the DASDs when formatting finishes" do
@@ -266,7 +266,7 @@ describe DInstaller::Storage::DASD::Manager do
       expect(reader).to receive(:update_info).with(dasd2, extended: true)
       expect(reader).to receive(:update_info).with(dasd3, extended: true)
       subject.format(dasds)
-      sleep(2) # give background threads a chance to run
+      sleep(5) # give background threads a chance to run
     end
 
     context "when the process returns false to the first call to #running?" do
@@ -280,7 +280,7 @@ describe DInstaller::Storage::DASD::Manager do
         expect(progress_callback).to_not receive(:call)
         expect(finish_callback).to_not receive(:call)
         subject.format(dasds, on_progress: progress_callback, on_finish: finish_callback)
-        sleep(2) # give background threads a chance to run
+        sleep(5) # give background threads a chance to run
       end
     end
   end


### PR DESCRIPTION
## Problem

#464 implemented a D-Bus API for managing DASDs, but a way to track the progress of the formatting progress was still missing.

## Solution

This adds the concept of storage jobs, that are exported at `/org/opensuse/DInstaller/Storage1/jobs/[0-9]+`

Every time a formatting operation starts properly, the path of a new job is returned. That job can be used to track the formatting status of all the DASDs involved in the operation.

## Testing

- Added some minimal unit tests
- Manually tested in a real s390 with real formatting (thanks @teclator)

## Documentation

- Expanded `doc/dbus_api.md`