### PR TITLE
Wifi page options

### DIFF
--- a/web/src/components/layout/Icon.jsx
+++ b/web/src/components/layout/Icon.jsx
@@ -57,6 +57,7 @@ import Terminal from "@icons/terminal.svg?component";
 import Translate from "@icons/translate.svg?component";
 import Warning from "@icons/warning.svg?component";
 import Wifi from "@icons/wifi.svg?component";
+import WifiFind from "@icons/wifi_find.svg?component";
 
 import Loading from "./three-dots-loader-icon.svg?component";
 
@@ -95,7 +96,8 @@ const icons = {
   terminal: Terminal,
   translate: Translate,
   warning: Warning,
-  wifi: Wifi
+  wifi: Wifi,
+  wifi_find: WifiFind
 };
 
 /**

--- a/web/src/components/network/ConnectionsTable.jsx
+++ b/web/src/components/network/ConnectionsTable.jsx
@@ -60,10 +60,12 @@ const RowActions = ({ actions, connection, ...props }) => {
  * @param {object} props
  * @param {Connection[]} props.connections - Connections to be shown
  * @param {function} props.onEdit - function to be called for editing a connection
+ * @param {function} props.onForget - function to be called for forgetting a connection
  */
 export default function ConnectionsTable ({
   connections,
-  onEdit
+  onEdit,
+  onForget
 }) {
   if (connections.length === 0) return null;
 
@@ -83,8 +85,15 @@ export default function ConnectionsTable ({
               title: "Edit",
               "aria-label": `Edit connection ${connection.name}`,
               onClick: () => onEdit(connection)
-            }
-          ];
+            },
+            typeof onForget === 'function' && {
+              title: "Forget",
+              "aria-label": `Forget connection ${connection.name}`,
+              className: "danger-action",
+              icon: <Icon name="delete" size="24" />,
+              onClick: () => onForget(connection)
+            },
+          ].filter(Boolean);
 
           return (
             <Tr key={connection.id}>

--- a/web/src/components/network/NetworkPage.jsx
+++ b/web/src/components/network/NetworkPage.jsx
@@ -21,10 +21,9 @@
 
 import React, { useEffect, useState } from "react";
 import { Button, Skeleton } from "@patternfly/react-core";
-
 import { useInstallerClient } from "~/context/installer";
 import { ConnectionTypes, NetworkEventTypes } from "~/client/network";
-import { Page, Section } from "~/components/core";
+import { Page, PageOptions, Section } from "~/components/core";
 import { ConnectionsTable, IpSettingsForm, WifiSelector } from "~/components/network";
 
 /**
@@ -76,7 +75,7 @@ const NoWifiConnections = ({ wifiScanSupported }) => {
     <div className="stack">
       <div className="bold">No WiFi connections found</div>
       <div>{message}</div>
-      <WifiScan supported={wifiScanSupported} buttonVariant="primary" />
+      <WifiScan supported={wifiScanSupported} actionVariant="primary" />
     </div>
   );
 };
@@ -151,9 +150,6 @@ export default function NetworkPage() {
     return (
       <>
         <ConnectionsTable connections={activeWifiConnections} onEdit={selectConnection} />
-        <div className="horizontally-centered">
-          <WifiScan supported={wifiScanSupported} />
-        </div>
       </>
     );
   };
@@ -176,6 +172,9 @@ export default function NetworkPage() {
 
       { /* TODO: improve the connections edition */ }
       { selectedConnection && <IpSettingsForm connection={selectedConnection} onClose={() => setSelectedConnection(null)} /> }
+      <PageOptions title="Network">
+        <WifiScan supported={wifiScanSupported} />
+      </PageOptions>
     </Page>
   );
 }

--- a/web/src/components/network/NetworkPage.jsx
+++ b/web/src/components/network/NetworkPage.jsx
@@ -21,6 +21,7 @@
 
 import React, { useEffect, useState } from "react";
 import { Button, Skeleton } from "@patternfly/react-core";
+import { Icon } from "~/components/layout";
 import { useInstallerClient } from "~/context/installer";
 import { ConnectionTypes, NetworkEventTypes } from "~/client/network";
 import { Page, PageOptions, Section } from "~/components/core";
@@ -41,7 +42,13 @@ const WifiScan = ({ supported, actionVariant = "link" }) => {
 
   return (
     <>
-      <Button variant={actionVariant} onClick={() => setWifiSelectorOpen(true)}>Connect to a Wi-Fi network</Button>
+      <Button
+        variant={actionVariant}
+        onClick={() => setWifiSelectorOpen(true)}
+        icon={<Icon name="wifi_find" size="24" />}
+      >
+        Connect to a Wi-Fi network
+      </Button>
       <WifiSelector isOpen={wifiSelectorOpen} onClose={() => setWifiSelectorOpen(false)} />
     </>
   );
@@ -139,6 +146,11 @@ export default function NetworkPage() {
     client.getConnection(id).then(setSelectedConnection);
   };
 
+  const forgetConnection = async ({ id }) => {
+    const connection = await client.getConnection(id);
+    client.deleteConnection(connection);
+  };
+
   const activeWiredConnections = connections.filter(c => c.type === ConnectionTypes.ETHERNET);
   const activeWifiConnections = connections.filter(c => c.type === ConnectionTypes.WIFI);
 
@@ -149,7 +161,7 @@ export default function NetworkPage() {
 
     return (
       <>
-        <ConnectionsTable connections={activeWifiConnections} onEdit={selectConnection} />
+        <ConnectionsTable connections={activeWifiConnections} onEdit={selectConnection} onForget={forgetConnection} />
       </>
     );
   };
@@ -172,9 +184,10 @@ export default function NetworkPage() {
 
       { /* TODO: improve the connections edition */ }
       { selectedConnection && <IpSettingsForm connection={selectedConnection} onClose={() => setSelectedConnection(null)} /> }
-      <PageOptions title="Network">
-        <WifiScan supported={wifiScanSupported} />
-      </PageOptions>
+      { wifiScanSupported &&
+        <PageOptions title="Network">
+          <WifiScan supported={wifiScanSupported} />
+        </PageOptions> }
     </Page>
   );
 }

--- a/web/src/components/network/NetworkPage.test.jsx
+++ b/web/src/components/network/NetworkPage.test.jsx
@@ -82,29 +82,6 @@ describe("NetworkPage", () => {
     within(section).getByText("192.168.69.200/24");
   });
 
-  describe("when WiFi scan is supported", () => {
-    beforeEach(() => {
-      settingsFn.mockReturnValue({ ...networkSettings, wifiScanSupported: true });
-    });
-
-    it("displays a link for scanning other WiFi networks", async () => {
-      installerRender(<NetworkPage />);
-
-      const heading = await screen.findByRole("heading", { name: "WiFi networks" });
-      const section = heading.closest("section");
-      const scanWifiButton = within(section).getByRole("button", { name: "Connect to a Wi-Fi network" });
-      expect(scanWifiButton.classList.contains("pf-m-link")).toBe(true);
-    });
-
-    it("opens the WiFi selector dialog when user clicks for scanning WiFi networks", async () => {
-      const { user } = installerRender(<NetworkPage />);
-      const link = await screen.findByRole("button", { name: "Connect to a Wi-Fi network" });
-      await user.click(link);
-      const wifiDialog = await screen.findByRole("dialog");
-      within(wifiDialog).getByText("Connect to a Wi-Fi network");
-    });
-  });
-
   describe("when no wired connection is detected", () => {
     beforeEach(() => {
       activeConnectionsFn.mockReturnValue([wiFiConnection]);


### PR DESCRIPTION
In order to unify the interface of the current Network Page with others like Users or Storage we must move the option to connect a WiFi network to the sidebar at least when there is already an active WiFi connection.

There are also some small issues like the alignment and the look of the button which should be fixed to be consistent with the rest of interfaces.

## Testing

- *Adapted unit test*
- *Tested manually*


## Screenshots

![Screenshot from 2023-03-20 10-25-58](https://user-images.githubusercontent.com/7056681/226313839-3f985c8e-f9f6-4a79-8254-dd153537abb3.png)
![Screenshot from 2023-03-20 10-26-05](https://user-images.githubusercontent.com/7056681/226313843-fe63c858-0af9-40f8-b92f-b934377dd7b1.png)
![Screenshot from 2023-03-20 10-26-12](https://user-images.githubusercontent.com/7056681/226313846-7f5b7dcf-b85b-46ab-8354-ab7c9359110e.png)
![Screenshot from 2023-03-20 10-26-37](https://user-images.githubusercontent.com/7056681/226313847-b0daff6f-4c02-4f49-8517-f079511fa5ea.png)

