### PR TITLE
Invalid storage device handling

### DIFF
--- a/.yupdate.pre
+++ b/.yupdate.pre
@@ -17,6 +17,10 @@
 #   run the yupdate script several times
 #
 
+if [ "$YUPDATE_SKIP_FRONTEND" == "1" ]; then
+  exit 0
+fi
+
 # the needed packages for compiling the d-installer cockpit module
 PACKAGES=(appstream-glib-devel make npm)
 

--- a/Rakefile
+++ b/Rakefile
@@ -93,41 +93,45 @@ SERVICES_DIR = "/usr/share/dbus-1/d-installer-services"
 if File.exist?("/.packages.initrd") || `mount`.match?(/^[\w]+ on \/ type overlay/)
   Rake::Task["install"].clear
   task :install do
-    destdir = ENV["DESTDIR"] || "/"
+    if ENV["YUPDATE_SKIP_BACKEND"] != "1"
+      destdir = ENV["DESTDIR"] || "/"
 
-    puts "Installing the DBus service..."
-    Dir.chdir("service") do
-      sh "gem build d-installer.gemspec"
-      sh "gem install --local --force --no-format-exec --no-doc --build-root #{destdir.shellescape} d-installer-*.gem"
+      puts "Installing the DBus service..."
+      Dir.chdir("service") do
+        sh "gem build d-installer.gemspec"
+        sh "gem install --local --force --no-format-exec --no-doc --build-root #{destdir.shellescape} d-installer-*.gem"
 
-      # update the DBus configuration files
-      FileUtils.mkdir_p(SERVICES_DIR)
-      sh "cp share/org.opensuse.DInstaller*.service #{SERVICES_DIR}"
-      sh "cp share/dbus.conf /usr/share/dbus-1/d-installer.conf"
+        # update the DBus configuration files
+        FileUtils.mkdir_p(SERVICES_DIR)
+        sh "cp share/org.opensuse.DInstaller*.service #{SERVICES_DIR}"
+        sh "cp share/dbus.conf /usr/share/dbus-1/d-installer.conf"
 
-      # update the systemd service file
-      source_file = "share/systemd.service"
-      target_file = "/usr/lib/systemd/system/d-installer.service"
+        # update the systemd service file
+        source_file = "share/systemd.service"
+        target_file = "/usr/lib/systemd/system/d-installer.service"
 
-      unless FileUtils.identical?(source_file, target_file)
-        FileUtils.cp(source_file, target_file)
-        sh "systemctl daemon-reload"
+        unless FileUtils.identical?(source_file, target_file)
+          FileUtils.cp(source_file, target_file)
+          sh "systemctl daemon-reload"
+        end
       end
     end
 
-    puts "Installing the Web frontend..."
-    Dir.chdir("web") do
-      node_env = ENV["NODE_ENV"] || "production"
-      sh "NODE_ENV=#{node_env.shellescape} make install"
+    if ENV["YUPDATE_SKIP_FRONTEND"] != "1"
+      puts "Installing the Web frontend..."
+      Dir.chdir("web") do
+        node_env = ENV["NODE_ENV"] || "production"
+        sh "NODE_ENV=#{node_env.shellescape} make install"
 
-      # clean up the extra files when switching the development/production mode
-      if node_env == "production"
-        # remove the uncompressed and development files
-        FileUtils.rm_f(Dir.glob("/usr/share/cockpit/d-installer/index.{css,html,js}"))
-        FileUtils.rm_f(Dir.glob("/usr/share/cockpit/d-installer/*.map"))
-      else
-        # remove the compressed files
-        FileUtils.rm_f(Dir.glob("/usr/share/cockpit/d-installer/*.gz"))
+        # clean up the extra files when switching the development/production mode
+        if node_env == "production"
+          # remove the uncompressed and development files
+          FileUtils.rm_f(Dir.glob("/usr/share/cockpit/d-installer/index.{css,html,js}"))
+          FileUtils.rm_f(Dir.glob("/usr/share/cockpit/d-installer/*.map"))
+        else
+          # remove the compressed files
+          FileUtils.rm_f(Dir.glob("/usr/share/cockpit/d-installer/*.gz"))
+        end
       end
     end
   end

--- a/doc/yupdate.md
+++ b/doc/yupdate.md
@@ -52,7 +52,7 @@ You can modify the update process with these environment variables:
   when you use the webpack development server for running the web frontend.
   In that case updating the web frontend does not make sense because it is
   running in a different server. This saves some time and disk/RAM space.
-- `YUPDATE_SKIP_BACKEND=1` - Skip updating the DBus service backend. This is the
+- `YUPDATE_SKIP_BACKEND=1` - Skip updating the D-Bus service backend. This is the
   opposite case for the previous option.
 
 ## Notes

--- a/doc/yupdate.md
+++ b/doc/yupdate.md
@@ -48,6 +48,12 @@ You can modify the update process with these environment variables:
   mode. The files will not be minimized and additional `*.map` files will be
   generated. This helps with debugging in the browser, you can get the locations
   in the original source files.
+- `YUPDATE_SKIP_FRONTEND=1` - Skip updating the web frontend. Use this option
+  when you use the webpack development server for running the web frontend.
+  In that case updating the web frontend does not make sense because it is
+  running in a different server. This saves some time and disk/RAM space.
+- `YUPDATE_SKIP_BACKEND=1` - Skip updating the DBus service backend. This is the
+  opposite case for the previous option.
 
 ## Notes
 

--- a/doc/yupdate.md
+++ b/doc/yupdate.md
@@ -52,8 +52,9 @@ You can modify the update process with these environment variables:
   when you use the webpack development server for running the web frontend.
   In that case updating the web frontend does not make sense because it is
   running in a different server. This saves some time and disk/RAM space.
-- `YUPDATE_SKIP_BACKEND=1` - Skip updating the D-Bus service backend. This is the
-  opposite case for the previous option.
+- `YUPDATE_SKIP_BACKEND=1` - Skip updating the D-Bus service backend. This is
+  similar to the previous option, use it when you do want to keep the D-Bus
+  service unchanged.
 
 ## Notes
 

--- a/service/lib/dinstaller/dbus/with_service_status.rb
+++ b/service/lib/dinstaller/dbus/with_service_status.rb
@@ -38,10 +38,9 @@ module DInstaller
       # @return [Object] the result of the given block
       def busy_while(&block)
         service_status.busy
-        result = block.call
+        block.call
+      ensure
         service_status.idle
-
-        result
       end
     end
   end

--- a/service/package/rubygem-d-installer.changes
+++ b/service/package/rubygem-d-installer.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Mar 21 16:44:27 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
+
+- Fixed exception handling so service always goes back to the
+  "idle" state when finishing a block (related to bsc#1209523)
+
+-------------------------------------------------------------------
 Thu Mar 16 16:13:21 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 0.8

--- a/service/test/dinstaller/dbus/with_service_status_test.rb
+++ b/service/test/dinstaller/dbus/with_service_status_test.rb
@@ -48,5 +48,17 @@ describe WithServiceStatusTest do
       result = subject.busy_while { "test" }
       expect(result).to eq("test")
     end
+
+    context "the passed block raises an exception" do
+      it "sets the idle status and passes the exception up" do
+        expect(subject.service_status).to receive(:busy)
+        expect(subject.service_status).to receive(:idle)
+
+        class TestException < RuntimeError; end
+
+        expect { subject.busy_while { raise TestException } }.to raise_error(TestException)
+      end
+    end
+
   end
 end

--- a/web/package/cockpit-d-installer.changes
+++ b/web/package/cockpit-d-installer.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Mar 21 16:41:06 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
+
+- Do not crash when setting an invalid target device using the
+  command line interface (bsc#1209523)
+
+-------------------------------------------------------------------
 Mon Mar 20 15:13:28 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Upgrade Webpack to version 5.76.2 (CVE-2023-28154, bsc#1209494).

--- a/web/src/components/storage/ProposalSummary.jsx
+++ b/web/src/components/storage/ProposalSummary.jsx
@@ -35,6 +35,14 @@ export default function ProposalSummary({ proposal }) {
   const [candidateDevice] = result.candidateDevices;
   const device = proposal.availableDevices.find(d => d.id === candidateDevice);
 
+  if (device === undefined) {
+    return (
+      <Text>
+        Required device <Em>{candidateDevice}</Em> not found
+      </Text>
+    );
+  }
+
   return (
     <Text>
       Install using device <Em>{device.label}</Em> and deleting all its content


### PR DESCRIPTION
## Problem

- https://trello.com/c/b0WId4rI
- https://bugzilla.suse.com/show_bug.cgi?id=1209523
- Setting an invalid D-Installer target disk via command line causes a crash

## Solution

- Fixed a `nil` problem in https://github.com/yast/yast-storage-ng/pull/1324
- Handle the `undefined` value in the web frontend
- Fixed exception handling in `busy_while` method to always go back to the "idle" state when finishing the block

## Improved `yupdate` support

- Allow optionally skipping update of the DBus backend or the web fronend
- Set environment variable `YUPDATE_SKIP_FRONTEND=1` or `YUPDATE_SKIP_BACKEND=1`  to skip the frontend or backend update
- `YUPDATE_SKIP_FRONTEND=1` can be used when you use the webpack development   server for running the web frontend, in that case updating the web frontend does not make sense, it just takes long time and consumes additional
  disk/RAM space
- `YUPDATE_SKIP_BACKEND=1` was added mainly as a complement just in case somebody needs to handle the opposite case
 
## Testing

- Added a new unit test
- Tested manually

## Screenshots

![dinstaller_invalid_device](https://user-images.githubusercontent.com/907998/226666854-53f03c4b-1a25-4f85-86d7-4b6adbb1fbc6.png)


