### PR TITLE
Update ruby-dbus dependency

### DIFF
--- a/service/d-installer.gemspec
+++ b/service/d-installer.gemspec
@@ -48,5 +48,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "fast_gettext", "~> 2.2.0"
   spec.add_dependency "nokogiri", "~> 1.13.1"
   spec.add_dependency "rexml", "~> 3.2.5"
-  spec.add_dependency "ruby-dbus", "~> 0.19.0"
+  spec.add_dependency "ruby-dbus", "~> 0.20.0"
 end


### PR DESCRIPTION
Update ruby-dbus dependency to version 0.20.0.