### PR TITLE
Bus startup race

### DIFF
--- a/service/Gemfile.lock
+++ b/service/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    d-installer (0.8)
+    d-installer (0.8.1)
       cfa (~> 1.0.2)
       cfa_grub2 (~> 2.0.0)
       cheetah (~> 1.0.0)
@@ -9,7 +9,7 @@ PATH
       fast_gettext (~> 2.2.0)
       nokogiri (~> 1.13.1)
       rexml (~> 3.2.5)
-      ruby-dbus (~> 0.19.0)
+      ruby-dbus (~> 0.20.0)
 
 GEM
   remote: https://rubygems.org/
@@ -49,7 +49,7 @@ GEM
       rspec-support (~> 3.11.0)
     rspec-support (3.11.0)
     ruby-augeas (0.5.0)
-    ruby-dbus (0.19.0)
+    ruby-dbus (0.20.0)
       rexml
     simplecov (0.21.2)
       docile (~> 1.1)

--- a/service/share/systemd.service
+++ b/service/share/systemd.service
@@ -4,7 +4,7 @@ Requires=cockpit.socket
 After=network-online.target
 
 [Service]
-Type=simple
+Type=forking
 ExecStart=/usr/bin/d-installer --daemon
 PIDFile=/run/d-installer/bus.pid
 User=root

--- a/setup-service.sh
+++ b/setup-service.sh
@@ -32,6 +32,13 @@ sudosed() {
   sed -e "$1" "$2" | $SUDO tee "$3" > /dev/null
 }
 
+# - Install the service dependencies
+(
+  cd $MYDIR/service
+  bundle config set --local path 'vendor/bundle'
+  bundle install
+)
+
 # - D-Bus configuration
 $SUDO cp -v $MYDIR/service/share/dbus.conf /usr/share/dbus-1/d-installer.conf
 
@@ -54,11 +61,3 @@ $SUDO cp -v $MYDIR/service/share/dbus.conf /usr/share/dbus-1/d-installer.conf
 
 # - Make sure NetworkManager is running
 $SUDO systemctl start NetworkManager
-
-# - Install the service dependencies
-(
-  cd $MYDIR/service
-  bundle config set --local path 'vendor/bundle'
-  bundle install
-)
-


### PR DESCRIPTION
## Problem

In an autoinstallation script (TODO link), you start the service using `systemctl`, then try to use it but it fails even though systemd says it went fine. And it eventually (within 1 second) works but we were too fast.

- *Links to other related pull requests*

## Solution

Fix the systemd service declaration so that systemd knows when we are ready and waits before proceeding:

[`Type=forking`](https://www.freedesktop.org/software/systemd/man/systemd.service.html#Type=)

## Testing

- Tested manually with
```sh
systemctl stop d-installer.service
time systemctl start d-installer.service; dinstaller config show
```

## Screenshots

no