### PR TITLE
Planned devices fallback

### DIFF
--- a/service/lib/dinstaller/storage/proposal.rb
+++ b/service/lib/dinstaller/storage/proposal.rb
@@ -109,7 +109,7 @@ module DInstaller
       def calculated_settings
         return nil unless proposal
 
-        to_dinstaller_settings(proposal.settings, devices: proposal.planned_devices)
+        to_dinstaller_settings(proposal.settings, devices: proposal.planned_devices || [])
       end
 
       # Calculates a new proposal

--- a/service/package/rubygem-d-installer.changes
+++ b/service/package/rubygem-d-installer.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Mar 22 16:05:14 UTC 2023 - Knut Anderssen <kanderssen@suse.com>
+
+- Added a fallback in order to prevent a proposal error when no
+  planned devices are available (gh#yast/d-installer#494).
+
+-------------------------------------------------------------------
 Wed Mar 22 15:20:45 UTC 2023 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Adjustments to prevent iSCSI-related delays during storage


### PR DESCRIPTION
## Problem

When there are no devices the proposal fails showing an the spinner forever.

## Solution

Ensure the devices given for calculating the proposal D-Installer settings is an array.

## Testing

- *Tested manually*
