### PR TITLE
[web] Offer tip for iSCSI and DASD configuration in the UI

### DIFF
--- a/web/cspell.json
+++ b/web/cspell.json
@@ -22,6 +22,7 @@
         "autoconnect",
         "btrfs",
         "ccmp",
+        "dasd",
         "dbus",
         "dinstaller",
         "filecontent",

--- a/web/package/cockpit-d-installer.changes
+++ b/web/package/cockpit-d-installer.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Mar 24 12:50:06 UTC 2023 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Added a tip about iSCSI and DASD configuration to the storage
+  page (gh#yast/d-installer#500).
+
+-------------------------------------------------------------------
 Fri Mar 24 10:39:45 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 0.8.2

--- a/web/src/components/core/Sidebar.jsx
+++ b/web/src/components/core/Sidebar.jsx
@@ -23,11 +23,15 @@ import React, { useEffect, useRef, useState } from "react";
 import { Button, Text } from "@patternfly/react-core";
 import { Icon, PageActions } from "~/components/layout";
 
+// FIXME: look for a better way to allow opening the Sidebar from outside
+let openButtonRef = {};
+
 /**
  * D-Installer sidebar navigation
  */
-export default function Sidebar({ children }) {
+const Sidebar = ({ children }) => {
   const [isOpen, setIsOpen] = useState(false);
+  openButtonRef = useRef(null);
   const closeButtonRef = useRef(null);
 
   const open = () => setIsOpen(true);
@@ -83,6 +87,7 @@ export default function Sidebar({ children }) {
     <>
       <PageActions>
         <button
+          ref={openButtonRef}
           onClick={open}
           className="plain-control"
           aria-label="Show navigation and other options"
@@ -125,4 +130,10 @@ export default function Sidebar({ children }) {
       </nav>
     </>
   );
-}
+};
+
+Sidebar.OpenButton = ({ children }) => (
+  <Button variant="link" isInline onClick={() => openButtonRef.current.click()}>{children}</Button>
+);
+
+export default Sidebar;

--- a/web/src/components/storage/ProposalTargetSection.jsx
+++ b/web/src/components/storage/ProposalTargetSection.jsx
@@ -40,7 +40,7 @@ export default function ProposalTargetSection({ proposal, calculateProposal }) {
   // Temporary mini-component with temporary text for March prototype
   const SideBarTip = () => {
     return (
-      <div>If needed, use the <Sidebar.OpenButton>advanced options menu</Sidebar.OpenButton> to configure access to more disks using technologies like iSCSI or DASD (when available).</div>
+      <div>If needed, use the <Sidebar.OpenButton>advanced options menu</Sidebar.OpenButton> to configure access to more disks.</div>
     );
   };
 

--- a/web/src/components/storage/ProposalTargetSection.jsx
+++ b/web/src/components/storage/ProposalTargetSection.jsx
@@ -20,15 +20,12 @@
  */
 
 import React, { useState } from "react";
-import { useNavigate } from "react-router-dom";
-import { Button } from "@patternfly/react-core";
 
-import { If, Popup, Section } from "~/components/core";
+import { If, Popup, Section, Sidebar } from "~/components/core";
 import { ProposalSummary, ProposalTargetForm } from "~/components/storage";
 
 export default function ProposalTargetSection({ proposal, calculateProposal }) {
   const [isOpen, setIsOpen] = useState(false);
-  const navigate = useNavigate();
 
   const onTargetChange = ({ candidateDevices }) => {
     setIsOpen(false);
@@ -36,7 +33,6 @@ export default function ProposalTargetSection({ proposal, calculateProposal }) {
   };
 
   const openDeviceSelector = () => setIsOpen(true);
-  const navigateToISCSIPage = () => navigate("/storage/iscsi");
 
   const { availableDevices = [] } = proposal;
   const renderSelector = availableDevices.length > 0;
@@ -60,8 +56,7 @@ export default function ProposalTargetSection({ proposal, calculateProposal }) {
     return (
       <div className="stack">
         <div className="bold">No devices found</div>
-        <div>Please, configure iSCSI targets in order to find available devices for installation.</div>
-        <Button variant="primary" onClick={navigateToISCSIPage}>Configure iSCSI</Button>
+        <div>Please, <Sidebar.OpenButton>configure</Sidebar.OpenButton> storage devices in order to make them available for installation.</div>
       </div>
     );
   };

--- a/web/src/components/storage/ProposalTargetSection.jsx
+++ b/web/src/components/storage/ProposalTargetSection.jsx
@@ -37,6 +37,13 @@ export default function ProposalTargetSection({ proposal, calculateProposal }) {
   const { availableDevices = [] } = proposal;
   const renderSelector = availableDevices.length > 0;
 
+  // Temporary mini-component with temporary text for March prototype
+  const SideBarTip = () => {
+    return (
+      <div>If needed, use the <Sidebar.OpenButton>advanced options menu</Sidebar.OpenButton> to configure access to more disks using technologies like iSCSI or DASD (when available).</div>
+    );
+  };
+
   const Content = () => {
     return (
       <>
@@ -48,6 +55,7 @@ export default function ProposalTargetSection({ proposal, calculateProposal }) {
             <Popup.Cancel onClick={() => setIsOpen(false)} autoFocus />
           </Popup.Actions>
         </Popup>
+        <SideBarTip />
       </>
     );
   };
@@ -56,7 +64,7 @@ export default function ProposalTargetSection({ proposal, calculateProposal }) {
     return (
       <div className="stack">
         <div className="bold">No devices found</div>
-        <div>Please, <Sidebar.OpenButton>configure</Sidebar.OpenButton> storage devices in order to make them available for installation.</div>
+        <SideBarTip />
       </div>
     );
   };


### PR DESCRIPTION
## Problem

It was not always easy to find the options to configure iSCSI and DASD. This is how it looked if there are local devices (or if an iSCSI device was already configured).

![before-not-empty](https://user-images.githubusercontent.com/3638289/227522125-66ae72e3-b485-4f2d-b89c-b4443175240d.png)

If there where not available devices, it was a bit better:

![before-empty](https://user-images.githubusercontent.com/3638289/227522617-295d68ff-53d4-405d-affa-3968e7ded0e3.png)

But that solution didn't look much scalable (we could end up with 6 buttons or so when we keep adding technologies). And only iSCSI was mentioned - no reference to DASD, not even in a S390x system.

## Solution

First of all, this is a temporary fix. We will re-evaluate options later.

Anyway, now we always show a sentence, even if there are devices.

![after-not-empty](https://user-images.githubusercontent.com/3638289/227529951-1020349d-e6b2-4a36-be7b-7a19a0ee0231.png)

The link opens the sidebar.

![after-not-empty-open](https://user-images.githubusercontent.com/3638289/227523096-8f58c55d-f3f5-4500-a2cf-0b8ff9efadb4.png)
 
Last but not least, the very same message with the very same behavior is displayed also if there are no devices.

![after-empty](https://user-images.githubusercontent.com/3638289/227530006-cfbac35c-381b-47cf-985e-5e6341f30661.png)

Note not only the messages are temporary, also the implementation itself, as explained in this commit message:

> [web] Allow opening the Sidebar from outside
> 
> By using the Sidebar.OpenButton "subcomponent". It's using a ref by now, but
> it's needed to research if there is a better way to do it (exploring the
> useImperativeHanlde[1] hook or any other technique).
> 
> [1] https://react.dev/reference/react/useImperativeHandle

## Testing

Tested manually.