### PR TITLE
[web] Add DASD UI - first version

### DIFF
--- a/doc/dbus_api.md
+++ b/doc/dbus_api.md
@@ -593,6 +593,7 @@ DeviceName    readable s
 Formatted     readable b
 Diag          readable b
 Type          readable s
+Status        readable s
 AccessType    readable s
 PartitionInfo readable s
 ~~~
@@ -608,6 +609,7 @@ string `AccessType` could be replaced by a boolean `ReadOnly`).
 * `Formatted`: whether the device is formatted.
 * `Diag`: Whether the DIAG access method is used (or will be used when the device is enabled).
 * `Type`: The DASD type (eg. EKCD or FBA).
+* `Status`: Device status according to lsdasd (eg. "offline", "active", "active(ro)")
 * `AccessType`: Empty string if unknown. Either "rw" or "ro" otherwise.
 * `PartitionInfo`: Partition names (and sometimes their type) separated by commas.
   Eg. "_/dev/dasda1 (Linux native), /dev/dasda2 (Linux native)_". Empty if the information is unknown.

--- a/service/lib/dinstaller/dbus/storage/dasd.rb
+++ b/service/lib/dinstaller/dbus/storage/dasd.rb
@@ -162,7 +162,6 @@ module DInstaller
           dbus_reader(:diag, "b")
           dbus_reader(:status, "s")
           dbus_reader(:type, "s")
-          dbus_reader(:device_type, "s")
           dbus_reader(:access_type, "s")
           dbus_reader(:partition_info, "s")
         end

--- a/service/lib/dinstaller/dbus/storage/dasds_format_job.rb
+++ b/service/lib/dinstaller/dbus/storage/dasds_format_job.rb
@@ -132,7 +132,7 @@ module DInstaller
           @running = false
           @exit_code = exit_code
           Finished(exit_code)
-          dbus_properties_changed(JOB_INTERFACE, interfaces_and_properties.slice(JOB_INTERFACE), [])
+          dbus_properties_changed(JOB_INTERFACE, interfaces_and_properties[JOB_INTERFACE], [])
         end
 
         # Updates the internal status information

--- a/service/lib/dinstaller/dbus/storage/manager.rb
+++ b/service/lib/dinstaller/dbus/storage/manager.rb
@@ -65,7 +65,7 @@ module DInstaller
           return unless Yast::Arch.s390
 
           singleton_class.include DBus::Interfaces::Dasd
-          register_dasd_callbacks
+          register_and_extend_dasd_callbacks
         end
 
         STORAGE_INTERFACE = "org.opensuse.DInstaller.Storage1"
@@ -267,6 +267,14 @@ module DInstaller
         def register_software_callbacks
           backend.software.on_product_selected do |_product|
             backend.proposal.reset
+          end
+        end
+
+        def register_and_extend_dasd_callbacks
+          register_dasd_callbacks
+
+          dasd_backend.on_refresh do |_|
+            deprecate_system
           end
         end
 

--- a/service/package/rubygem-d-installer.changes
+++ b/service/package/rubygem-d-installer.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Mar 24 14:53:14 UTC 2023 - Knut Alejandro Anderssen González <kanderssen@suse.com>
+
+- Adjustments to allow obtaining the DASD format progress and set
+  the system as deprecated after making DASD changes.
+- gh#d-installer#501.
+
+-------------------------------------------------------------------
 Fri Mar 24 10:39:18 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Version 0.8.2

--- a/service/test/dinstaller/dbus/storage/dasd_test.rb
+++ b/service/test/dinstaller/dbus/storage/dasd_test.rb
@@ -29,7 +29,8 @@ describe DInstaller::DBus::Storage::Dasd do
   let(:y2s390_dasd2) do
     instance_double(
       "Y2S390::Dasd", id: "0.0.002", offline?: true, device_name: nil, formatted?: false,
-      diag_wanted: false, type: nil, access_type: nil, partition_info: ""
+      diag_wanted: false, type: nil, access_type: nil, partition_info: "", status: :unknown,
+      device_type: ""
     )
   end
   let(:path) { "/org/opensuse/DInstaller/Storage1/dasds/1" }

--- a/web/cspell.json
+++ b/web/cspell.json
@@ -23,6 +23,7 @@
         "btrfs",
         "ccmp",
         "dasd",
+        "dasds",
         "dbus",
         "dinstaller",
         "filecontent",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -12,6 +12,7 @@
         "@patternfly/react-core": "^4.261.0",
         "@patternfly/react-table": "^4.111.33",
         "core-js": "^3.21.1",
+        "fast-sort": "^3.2.1",
         "ipaddr.js": "^2.0.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -9070,6 +9071,11 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
+    },
+    "node_modules/fast-sort": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/fast-sort/-/fast-sort-3.2.1.tgz",
+      "integrity": "sha512-ECGwVH57yCv3C8v+4BQkQf65bNR4nFetxfGRRLYmzFEAK3oZBr7zCakBjOY/AptmmoU3ffMPJLLN1rdKdMHoUA=="
     },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.16",
@@ -25462,6 +25468,11 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
+    },
+    "fast-sort": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/fast-sort/-/fast-sort-3.2.1.tgz",
+      "integrity": "sha512-ECGwVH57yCv3C8v+4BQkQf65bNR4nFetxfGRRLYmzFEAK3oZBr7zCakBjOY/AptmmoU3ffMPJLLN1rdKdMHoUA=="
     },
     "fastest-levenshtein": {
       "version": "1.0.16",

--- a/web/package.json
+++ b/web/package.json
@@ -99,6 +99,7 @@
     "@patternfly/react-core": "^4.261.0",
     "@patternfly/react-table": "^4.111.33",
     "core-js": "^3.21.1",
+    "fast-sort": "^3.2.1",
     "ipaddr.js": "^2.0.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/web/package/cockpit-d-installer.changes
+++ b/web/package/cockpit-d-installer.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Fri Mar 24 14:51:55 UTC 2023 - Knut Alejandro Anderssen González <kanderssen@suse.com>
+
+- Add UI for configuring DASD (gh#yast/d-installer#501).
+
+-------------------------------------------------------------------
 Fri Mar 24 12:50:06 UTC 2023 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Added a tip about iSCSI and DASD configuration to the storage

--- a/web/src/assets/styles/blocks.scss
+++ b/web/src/assets/styles/blocks.scss
@@ -189,3 +189,10 @@ section > .content {
   word-break: break-all;
   white-space: pre-wrap;
 }
+
+// Make progress more compact
+.dasd-format-progress {
+  .pf-c-progress {
+    --pf-c-progress--GridGap: var(--spacer-small);
+  }
+}

--- a/web/src/assets/styles/patternfly-overrides.scss
+++ b/web/src/assets/styles/patternfly-overrides.scss
@@ -122,7 +122,6 @@ section .pf-c-toolbar {
   --pf-c-toolbar--PaddingTop: 0;
 }
 
-// FIXME: these main.stack PF4/toolbar overrides are just for testing.
 .pf-c-toolbar {
   border-block-end: 1px solid var(--color-gray-light);
 }

--- a/web/src/assets/styles/patternfly-overrides.scss
+++ b/web/src/assets/styles/patternfly-overrides.scss
@@ -121,3 +121,12 @@ section .pf-c-toolbar {
   --pf-c-toolbar--PaddingBottom: 0;
   --pf-c-toolbar--PaddingTop: 0;
 }
+
+// FIXME: these main.stack PF4/toolbar overrides are just for testing.
+.pf-c-toolbar {
+  border-block-end: 1px solid var(--color-gray-light);
+}
+
+.pf-c-text-input-group__utilities .pf-c-button {
+  padding: 0;
+}

--- a/web/src/client/storage.js
+++ b/web/src/client/storage.js
@@ -23,14 +23,21 @@
 
 import DBusClient from "./dbus";
 import { WithStatus, WithProgress, WithValidation } from "./mixins";
+import { hex } from "~/utils";
 
 const STORAGE_IFACE = "org.opensuse.DInstaller.Storage1";
 const PROPOSAL_CALCULATOR_IFACE = "org.opensuse.DInstaller.Storage1.Proposal.Calculator";
 const ISCSI_NODE_IFACE = "org.opensuse.DInstaller.Storage1.ISCSI.Node";
 const ISCSI_NODES_NAMESPACE = "/org/opensuse/DInstaller/Storage1/iscsi_nodes";
 const ISCSI_INITIATOR_IFACE = "org.opensuse.DInstaller.Storage1.ISCSI.Initiator";
+const DASD_DEVICE_IFACE = "org.opensuse.DInstaller.Storage1.DASD.Device";
+const DASD_DEVICES_NAMESPACE = "/org/opensuse/DInstaller/Storage1/dasds";
+const DASD_MANAGER_IFACE = "org.opensuse.DInstaller.Storage1.DASD.Manager";
+const DASD_STATUS_IFACE = "org.opensuse.DInstaller.Storage1.DASD.Format";
 const PROPOSAL_IFACE = "org.opensuse.DInstaller.Storage1.Proposal";
 const STORAGE_OBJECT = "/org/opensuse/DInstaller/Storage1";
+const STORAGE_JOB_IFACE = "org.opensuse.DInstaller.Storage1.Job";
+const STORAGE_JOBS_NAMESPACE = "/org/opensuse/DInstaller/Storage1/jobs";
 
 /**
  * Removes properties with undefined value
@@ -235,6 +242,259 @@ class ProposalManager {
     } catch {
       return null;
     }
+  }
+}
+
+/**
+ * Class providing an API for managing Direct Access Storage Devices (DASDs)
+ */
+class DASDManager {
+  /**
+   * @param {string} service - D-Bus service name
+   * @param {string} address - D-Bus address
+   */
+  constructor(service, address) {
+    this.service = service;
+    this.address = address;
+    this.proxies = {};
+  }
+
+  /**
+   * @return {DBusClient} client
+   */
+  client() {
+    // return this.assigned_client;
+    if (!this._client) {
+      this._client = new DBusClient(this.service, this.address);
+    }
+
+    return this._client;
+  }
+
+  async isSupported() {
+    const proxy = await this.managerProxy();
+
+    return proxy !== undefined;
+  }
+
+  /**
+   * Build a job
+   *
+   * @returns {StorageJob}
+   *
+   * @typedef {object} StorageJob
+   * @property {string} path
+   * @property {boolean} running
+   * @property {number} exitCode
+   */
+  buildJob(job) {
+    return {
+      path: job.path,
+      running: job.Running,
+      exitCode: job.ExitCode
+    };
+  }
+
+  /**
+   * Triggers a DASD probing
+   */
+  async probe() {
+    const proxy = await this.managerProxy();
+    await proxy?.Probe();
+  }
+
+  /**
+   * Gets the list of DASD devices
+   *
+   * @returns {Promise<DASDDevice[]>}
+   */
+  async getDevices() {
+    // FIXME: should we do the probing here?
+    await this.probe();
+    const devices = await this.devicesProxy();
+    return Object.values(devices).map(this.buildDevice);
+  }
+
+  /**
+   * Requests the format action for given devices
+   *
+   * @param {DASDDevice[]} devices
+   */
+  async format(devices) {
+    const proxy = await this.managerProxy();
+    const devicesPath = devices.map(d => this.devicePath(d));
+    proxy.Format(devicesPath);
+  }
+
+  /**
+   * Set DIAG for given devices
+   *
+   * @param {DASDDevice[]} devices
+   * @param {boolean} value
+   */
+  async setDIAG(devices, value) {
+    const proxy = await this.managerProxy();
+    const devicesPath = devices.map(d => this.devicePath(d));
+    proxy.SetDiag(devicesPath, value);
+  }
+
+  /**
+   * Enables given DASD devices
+   *
+   * @param {DASDDevice[]} devices
+   */
+  async enableDevices(devices) {
+    const proxy = await this.managerProxy();
+    const devicesPath = devices.map(d => this.devicePath(d));
+    proxy.Enable(devicesPath);
+  }
+
+  /**
+   * Disables given DASD devices
+   *
+   * @param {DASDDevice[]} devices
+   */
+  async disableDevices(devices) {
+    const proxy = await this.managerProxy();
+    const devicesPath = devices.map(d => this.devicePath(d));
+    proxy.Disable(devicesPath);
+  }
+
+  /**
+   * @private
+   * Proxy for objects implementing org.opensuse.DInstaller.Storage1.Job iface
+   *
+   * @note The jobs are dynamically exported.
+   *
+   * @returns {Promise<object>}
+   */
+  async jobsProxy() {
+    if (!this.proxies.jobs)
+      this.proxies.jobs = await this.client().proxies(STORAGE_JOB_IFACE, STORAGE_JOBS_NAMESPACE);
+
+    return this.proxies.jobs;
+  }
+
+  async getJobs() {
+    const proxy = await this.jobsProxy();
+    return Object.values(proxy).filter(p => p.Running)
+      .map(this.buildJob);
+  }
+
+  async onJobAdded(handler) {
+    const proxy = await this.jobsProxy();
+    proxy.addEventListener("added", (_, proxy) => handler(this.buildJob(proxy)));
+  }
+
+  async onJobChanged(handler) {
+    const proxy = await this.jobsProxy();
+    proxy.addEventListener("changed", (_, proxy) => handler(this.buildJob(proxy)));
+  }
+
+  /**
+   * @private
+   * Proxy for objects implementing org.opensuse.DInstaller.Storage1.Job iface
+   *
+   * @note The jobs are dynamically exported.
+   *
+   * @returns {Promise<object>}
+   */
+  async formatProxy(jobPath) {
+    const proxy = await this.client().proxy(DASD_STATUS_IFACE, jobPath);
+    return proxy;
+  }
+
+  async onFormatProgress(jobPath, handler) {
+    const proxy = await this.formatProxy(jobPath);
+    proxy.addEventListener("changed", (_, proxy) => {
+      handler(proxy.Summary);
+    });
+  }
+
+  /**
+   * @private
+   * Proxy for objects implementing org.opensuse.DInstaller.Storage1.DASD.Device iface
+   *
+   * @note The DASD devices are dynamically exported.
+   *
+   * @returns {Promise<object>}
+   */
+  async devicesProxy() {
+    if (!this.proxies.devices)
+      this.proxies.devices = await this.client().proxies(DASD_DEVICE_IFACE, DASD_DEVICES_NAMESPACE);
+
+    return this.proxies.devices;
+  }
+
+  /**
+   * @private
+   * Proxy for org.opensuse.DInstaller.Storage1.DASD.Manager iface
+   *
+   * @returns {Promise<object>}
+   */
+  async managerProxy() {
+    if (!this.proxies.dasdManager)
+      this.proxies.dasdManager = await this.client().proxy(DASD_MANAGER_IFACE, STORAGE_OBJECT);
+
+    return this.proxies.dasdManager;
+  }
+
+  async deviceEventListener(signal, handler) {
+    const proxy = await this.devicesProxy();
+    const action = (_, proxy) => handler(this.buildDevice(proxy));
+
+    proxy.addEventListener(signal, action);
+    return () => proxy.removeEventListener(signal, action);
+  }
+
+  /**
+   * Build a list of DASD devices
+   *
+   * @returns {DASDDevice}
+   *
+   * @typedef {object} DASDDevice
+   * @property {string} id
+   * @property {number} hexId
+   * @property {string} accessType
+   * @property {string} channelId
+   * @property {boolean} diag
+   * @property {boolean} enabled
+   * @property {boolean} formatted
+   * @property {string} name
+   * @property {string} partitionInfo
+   * @property {string} status
+   * @property {string} type
+   * @property {string} device_type
+   */
+  buildDevice(device) {
+    const id = device.path.split("/").slice(-1)[0];
+    const enabled = device.Enabled;
+
+    return {
+      id,
+      accessType: enabled ? device.AccessType : "offline",
+      channelId: device.Id,
+      diag: device.Diag,
+      enabled,
+      formatted: device.Formatted,
+      hexId: hex(device.Id),
+      name: device.DeviceName,
+      partitionInfo: enabled ? device.PartitionInfo : "",
+      status: device.Status,
+      type: device.Type,
+      device_type: device.DeviceType
+    };
+  }
+
+  /**
+   * @private
+   * Builds the D-Bus path for the given DASD device
+   *
+   * @param {DASDDevice} device
+   * @returns {string}
+   */
+  devicePath(device) {
+    return DASD_DEVICES_NAMESPACE + "/" + device.id;
   }
 }
 
@@ -506,6 +766,7 @@ class StorageBaseClient {
     this.client = new DBusClient(StorageBaseClient.SERVICE, address);
     this.proposal = new ProposalManager(this.client);
     this.iscsi = new ISCSIManager(StorageBaseClient.SERVICE, address);
+    this.dasd = new DASDManager(StorageBaseClient.SERVICE, address);
     this.proxies = {
       storage: this.client.proxy(STORAGE_IFACE)
     };

--- a/web/src/client/storage.js
+++ b/web/src/client/storage.js
@@ -464,7 +464,6 @@ class DASDManager {
    * @property {string} partitionInfo
    * @property {string} status
    * @property {string} type
-   * @property {string} device_type
    */
   buildDevice(device) {
     const id = device.path.split("/").slice(-1)[0];
@@ -481,8 +480,7 @@ class DASDManager {
       name: device.DeviceName,
       partitionInfo: enabled ? device.PartitionInfo : "",
       status: device.Status,
-      type: device.Type,
-      device_type: device.DeviceType
+      type: device.Type
     };
   }
 

--- a/web/src/client/storage.js
+++ b/web/src/client/storage.js
@@ -271,6 +271,8 @@ class DASDManager {
     return this._client;
   }
 
+  // FIXME: use info from ObjectManager instead.
+  //   https://github.com/yast/d-installer/pull/501#discussion_r1147707515
   async isSupported() {
     const proxy = await this.managerProxy();
 

--- a/web/src/components/storage/DASDFormatProgress.jsx
+++ b/web/src/components/storage/DASDFormatProgress.jsx
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) [2022-2023] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React, { useEffect, useState } from "react";
+import { Progress, Skeleton } from '@patternfly/react-core';
+import { If, Popup } from "~/components/core";
+import { useInstallerClient } from "~/context/installer";
+
+export default function DASDFormatProgress({ job, devices, isOpen = true }) {
+  const { storage: client } = useInstallerClient();
+  const [progress, setProgress] = useState(undefined);
+
+  useEffect(() => {
+    client.dasd.onFormatProgress(job.path, p => setProgress(p));
+  }, [client.dasd, job.path]);
+
+  const ProgressContent = ({ progress }) => {
+    return (
+      <div className="stack dasd-format-progress">
+        { Object.entries(progress).map(([path, [total, step, done]]) => {
+          const device = devices.find(d => d.id === path.split("/").slice(-1)[0]);
+
+          return (
+            <Progress
+              key={path}
+              size="sm"
+              max={total}
+              value={step}
+              title={`${device.channelId} - ${device.name}`}
+              measureLocation="none"
+              variant={done ? "success" : undefined}
+            />
+          );
+        })}
+      </div>
+    );
+  };
+
+  const WaitingProgress = () => (
+    <div className="stack">
+      <div>Waiting for progress report</div>
+      <Skeleton height="10px" />
+      <Skeleton height="10px" />
+    </div>
+  );
+
+  return (
+    <Popup
+      title="Formatting DASD devices"
+      isOpen={isOpen}
+      disableFocusTrap
+    >
+
+      <If
+        condition={progress}
+        then={<ProgressContent progress={progress} />}
+        else={<WaitingProgress />}
+      />
+    </Popup>
+  );
+}

--- a/web/src/components/storage/DASDFormatProgress.jsx
+++ b/web/src/components/storage/DASDFormatProgress.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2022-2023] SUSE LLC
+ * Copyright (c) [2023] SUSE LLC
  *
  * All Rights Reserved.
  *

--- a/web/src/components/storage/DASDPage.jsx
+++ b/web/src/components/storage/DASDPage.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2022-2023] SUSE LLC
+ * Copyright (c) [2023] SUSE LLC
  *
  * All Rights Reserved.
  *

--- a/web/src/components/storage/DASDPage.jsx
+++ b/web/src/components/storage/DASDPage.jsx
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) [2022-2023] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React, { useEffect, useReducer } from "react";
+import { useNavigate } from "react-router-dom";
+import { Button } from "@patternfly/react-core";
+import { MainActions } from "~/components/layout";
+import { If, Page } from "~/components/core";
+import { DASDFormatProgress, DASDTable } from "~/components/storage";
+import { useCancellablePromise } from "~/utils";
+import { useInstallerClient } from "~/context/installer";
+
+const reducer = (state, action) => {
+  const { type, payload } = action;
+
+  switch (type) {
+    case "SET_DEVICES": {
+      return { ...state, devices: payload.devices };
+    }
+
+    case "ADD_DEVICE": {
+      const { device } = payload;
+      if (state.devices.find(d => d.id === device.id)) return state;
+
+      return { ...state, devices: [...state.devices, device] };
+    }
+
+    case "UPDATE_DEVICE": {
+      const { device } = payload;
+      const index = state.devices.findIndex(d => d.id === device.id);
+      const devices = [...state.devices];
+      index !== -1 ? devices[index] = device : devices.push(device);
+
+      const selectedDevicesIds = state.selectedDevices.map(d => d.id);
+      const selectedDevices = devices.filter(d => selectedDevicesIds.includes(d.id));
+
+      return { ...state, devices, selectedDevices };
+    }
+
+    case "REMOVE_DEVICE": {
+      const { device } = payload;
+
+      return { ...state, devices: state.devices.filter(d => d.id !== device.id) };
+    }
+
+    case "SET_MIN_CHANNEL": {
+      return { ...state, minChannel: payload.minChannel, selectedDevices: [] };
+    }
+
+    case "SET_MAX_CHANNEL": {
+      return { ...state, maxChannel: payload.maxChannel, selectedDevices: [] };
+    }
+
+    case "SELECT_DEVICE": {
+      const { device } = payload;
+
+      return { ...state, selectedDevices: [...state.selectedDevices, device] };
+    }
+
+    case "UNSELECT_DEVICE": {
+      const { device } = payload;
+
+      return { ...state, selectedDevices: state.selectedDevices.filter(d => d.id !== device.id) };
+    }
+
+    case "SELECT_ALL_DEVICES": {
+      return { ...state, selectedDevices: payload.devices };
+    }
+
+    case "UNSELECT_ALL_DEVICES": {
+      return { ...state, selectedDevices: [] };
+    }
+
+    case "START_FORMAT_JOB": {
+      const { data: formatJob } = payload;
+
+      if (!formatJob.running) return state;
+      const newState = { ...state, formatJob };
+
+      return newState;
+    }
+
+    case "UPDATE_FORMAT_JOB": {
+      const { data: formatJob } = payload;
+
+      if (formatJob.path !== state.formatJob.path) return state;
+
+      return { ...state, formatJob };
+    }
+
+    case "START_LOADING": {
+      return { ...state, isLoading: true };
+    }
+
+    case "STOP_LOADING": {
+      return { ...state, isLoading: false };
+    }
+
+    default: {
+      return state;
+    }
+  }
+};
+
+const initialState = {
+  devices: [],
+  selectedDevices: [],
+  minChannel: "",
+  maxChannel: "",
+  isLoading: true,
+  formatJob: {},
+};
+
+export default function DASDPage() {
+  const { storage: client } = useInstallerClient();
+  const navigate = useNavigate();
+  const { cancellablePromise } = useCancellablePromise();
+  const [state, dispatch] = useReducer(reducer, initialState);
+
+  useEffect(() => {
+    const loadDevices = async () => {
+      dispatch({ type: "START_LOADING" });
+      const devices = await cancellablePromise(client.dasd.getDevices());
+      dispatch({ type: "SET_DEVICES", payload: { devices } });
+      dispatch({ type: "STOP_LOADING" });
+    };
+
+    const loadJobs = async () => {
+      const jobs = await cancellablePromise(client.dasd.getJobs());
+      if (jobs.length > 0) {
+        dispatch({ type: "START_FORMAT_JOB", payload: { data: jobs[0] } });
+      }
+    };
+
+    loadDevices().catch(console.error);
+    loadJobs().catch(console.error);
+  }, [client.dasd, cancellablePromise]);
+
+  useEffect(() => {
+    const subscriptions = [];
+
+    const subscribe = async () => {
+      const action = (type, device) => dispatch({ type, payload: { device } });
+
+      subscriptions.push(
+        await client.dasd.deviceEventListener("added", d => action("ADD_DEVICE", d)),
+        await client.dasd.deviceEventListener("removed", d => action("REMOVE_DEVICE", d)),
+        await client.dasd.deviceEventListener("changed", d => action("UPDATE_DEVICE", d))
+      );
+
+      await client.dasd.onJobAdded((data) => dispatch({ type: "START_FORMAT_JOB", payload: { data } }));
+      await client.dasd.onJobChanged((data) => dispatch({ type: "UPDATE_FORMAT_JOB", payload: { data } }));
+    };
+
+    const unsubscribe = () => {
+      subscriptions.forEach(fn => fn());
+    };
+
+    subscribe();
+    return unsubscribe;
+  }, [client.dasd]);
+
+  return (
+    <Page title="Storage DASD" icon="hard_drive">
+      <MainActions>
+        <Button isLarge variant="secondary" onClick={() => navigate("/storage")}>Back</Button>
+      </MainActions>
+
+      <DASDTable state={state} dispatch={dispatch} />
+
+      <If
+        condition={state.formatJob.running}
+        then={<DASDFormatProgress job={state.formatJob} devices={state.devices} />}
+      />
+    </Page>
+  );
+}

--- a/web/src/components/storage/DASDTable.jsx
+++ b/web/src/components/storage/DASDTable.jsx
@@ -1,0 +1,259 @@
+/*
+ * Copyright (c) [2022-2023] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+import React, { useState } from "react";
+import {
+  Button,
+  Dropdown, DropdownToggle, DropdownItem, DropdownSeparator,
+  TextInputGroup, TextInputGroupMain, TextInputGroupUtilities,
+  Toolbar, ToolbarContent, ToolbarGroup, ToolbarItem
+} from '@patternfly/react-core';
+import { TableComposable, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
+import { sort } from 'fast-sort';
+
+import { Icon } from "~/components/layout";
+import { If, SectionSkeleton } from "~/components/core";
+import { hex } from "~/utils";
+import { useInstallerClient } from "~/context/installer";
+
+// FIXME: please, note that this file still requiring refinements until reach a
+//   reasonable stable version
+const columnData = (device, column) => {
+  let data = device[column.id];
+
+  switch (column.id) {
+    case 'formatted':
+    case 'diag':
+      if (!device.enabled)
+        data = "";
+      break;
+    case 'partitionInfo':
+      data = data.split(",").map(d => <div key={d}>{d}</div>);
+      break;
+  }
+
+  if (typeof data === "boolean") {
+    return data ? "Yes" : "No";
+  }
+
+  return data;
+};
+
+const columns = [
+  { id: "channelId", sortId: "hexId", label: "Channel ID" },
+  { id: "status", label: "Status" },
+  { id: "name", label: "Device" },
+  { id: "type", label: "Type" },
+  { id: "diag", label: "Diag" },
+  { id: "formatted", label: "Formatted" },
+  { id: "partitionInfo", label: "Partition Info" }
+];
+
+const Actions = ({ devices, isDisabled }) => {
+  const { storage: client } = useInstallerClient();
+  const [isOpen, setIsOpen] = useState(false);
+
+  const onToggle = (status) => setIsOpen(status);
+  const onSelect = () => setIsOpen(false);
+
+  const activate = () => client.dasd.enableDevices(devices);
+  const deactivate = () => client.dasd.disableDevices(devices);
+  const setDiagOn = () => client.dasd.setDIAG(devices, true);
+  const setDiagOff = () => client.dasd.setDIAG(devices, false);
+  const format = () => {
+    const offline = devices.filter(d => !d.enabled);
+
+    if (offline.length > 0) {
+      return false;
+    }
+
+    return client.dasd.format(devices);
+  };
+
+  const Action = ({ children, ...props }) => (
+    <DropdownItem component="button" {...props}>{children}</DropdownItem>
+  );
+
+  return (
+    <Dropdown
+      isOpen={isOpen}
+      onSelect={onSelect}
+      dropdownItems={[
+        <Action key="activate" onClick={activate}>Activate</Action>,
+        <Action key="deactivate" onClick={deactivate}>Deactivate</Action>,
+        <DropdownSeparator key="first-separator" />,
+        <Action key="set_diag_on" onClick={setDiagOn}>Set DIAG On</Action>,
+        <Action key="set_diag_off" onClick={setDiagOff}>Set DIAG Off</Action>,
+        <DropdownSeparator key="second-separator" />,
+        <Action key="format" onClick={format}>Format</Action>
+      ]}
+      toggle={
+        <DropdownToggle toggleVariant="primary" isDisabled={isDisabled} onToggle={onToggle}>
+          Perform an action
+        </DropdownToggle>
+      }
+    />
+  );
+};
+
+const filterDevices = (devices, from, to) => {
+  const allChannels = devices.map(d => d.hexId);
+  const min = hex(from) || Math.min(...allChannels);
+  const max = hex(to) || Math.max(...allChannels);
+
+  return devices.filter(d => d.hexId >= min && d.hexId <= max);
+};
+
+export default function DASDTable({ state, dispatch }) {
+  const [sortingColumn, setSortingColumn] = useState(columns[0]);
+  const [sortDirection, setSortDirection] = useState('asc');
+
+  const sortColumnIndex = () => columns.findIndex(c => c.id === sortingColumn.id);
+  const filteredDevices = filterDevices(state.devices, state.minChannel, state.maxChannel);
+  const selectedDevicesIds = state.selectedDevices.map(d => d.id);
+
+  // Selecting
+  const selectAll = (isSelecting = true) => {
+    const type = isSelecting ? "SELECT_ALL_DEVICES" : "UNSELECT_ALL_DEVICES";
+    dispatch({ type, payload: { devices: filteredDevices } });
+  };
+
+  const selectDevice = (device, isSelecting = true) => {
+    const type = isSelecting ? "SELECT_DEVICE" : "UNSELECT_DEVICE";
+    dispatch({ type, payload: { device } });
+  };
+
+  // Sorting
+  // See https://github.com/snovakovic/fast-sort
+  const sortBy = sortingColumn.sortBy || sortingColumn.id;
+  const sortedDevices = sort(filteredDevices)[sortDirection](d => d[sortBy]);
+
+  // FIXME: this can be improved and even extracted to be used with other tables.
+  const getSortParams = (columnIndex) => {
+    return {
+      sortBy: { index: sortColumnIndex(), direction: sortDirection },
+      onSort: (_event, index, direction) => {
+        setSortingColumn(columns[index]);
+        setSortDirection(direction);
+      },
+      columnIndex
+    };
+  };
+
+  // Filtering
+  const onMinChannelFilterChange = (_event, value) => {
+    dispatch({ type: "SET_MIN_CHANNEL", payload: { minChannel: value } });
+  };
+
+  const onMaxChannelFilterChange = (_event, value) => {
+    dispatch({ type: "SET_MAX_CHANNEL", payload: { maxChannel: value } });
+  };
+
+  const removeMinChannelFilter = () => {
+    dispatch({ type: "SET_MIN_CHANNEL", payload: { minChannel: "" } });
+  };
+
+  const removeMaxChannelFilter = () => {
+    dispatch({ type: "SET_MAX_CHANNEL", payload: { maxChannel: "" } });
+  };
+
+  return (
+    <>
+      <Toolbar>
+        <ToolbarContent>
+          <ToolbarGroup>
+            <ToolbarItem>
+              <TextInputGroup>
+                <TextInputGroupMain
+                  value={state.minChannel}
+                  type="text"
+                  aria-label="Filter by min channel"
+                  placeholder="Filter by min channel"
+                  onChange={onMinChannelFilterChange}
+                />
+                { state.minChannel !== "" &&
+                  <TextInputGroupUtilities>
+                    <Button
+                      variant="plain"
+                      aria-label="Remove min channel filter"
+                      onClick={removeMinChannelFilter}
+                    >
+                      <Icon name="backspace" size="24" />
+                    </Button>
+                  </TextInputGroupUtilities> }
+              </TextInputGroup>
+            </ToolbarItem>
+            <ToolbarItem>
+              <TextInputGroup>
+                <TextInputGroupMain
+                  value={state.maxChannel}
+                  type="text"
+                  aria-label="Filter by max channel"
+                  placeholder="Filter by max channel"
+                  onChange={onMaxChannelFilterChange}
+                />
+                { state.maxChannel !== "" &&
+                  <TextInputGroupUtilities>
+                    <Button
+                      variant="plain"
+                      aria-label="Remove max channel filter"
+                      onClick={removeMaxChannelFilter}
+                    >
+                      <Icon name="backspace" size="24" />
+                    </Button>
+                  </TextInputGroupUtilities> }
+              </TextInputGroup>
+            </ToolbarItem>
+
+            <ToolbarItem variant="separator" />
+
+            <ToolbarItem>
+              <Actions devices={state.selectedDevices} isDisabled={state.selectedDevices.length === 0} />
+            </ToolbarItem>
+          </ToolbarGroup>
+        </ToolbarContent>
+      </Toolbar>
+
+      <If
+        condition={state.isLoading}
+        then={<SectionSkeleton />}
+        else={
+          <TableComposable variant="compact">
+            <Thead>
+              <Tr>
+                <Th select={{ onSelect: (_event, isSelecting) => selectAll(isSelecting), isSelected: filteredDevices.length === state.selectedDevices.length }} />
+                { columns.map((column, index) => <Th key={column.id} sort={getSortParams(index)}>{column.label}</Th>) }
+              </Tr>
+            </Thead>
+            <Tbody>
+              { sortedDevices.map((device, rowIndex) => (
+                <Tr key={device.id}>
+                  <Td select={{ rowIndex, onSelect: (_event, isSelecting) => selectDevice(device, isSelecting), isSelected: selectedDevicesIds.includes(device.id), disable: false }} />
+                  { columns.map(column => <Td key={column.id} dataLabel={column.label}>{columnData(device, column)}</Td>) }
+                </Tr>
+              ))}
+            </Tbody>
+          </TableComposable>
+        }
+      />
+    </>
+  );
+}

--- a/web/src/components/storage/DASDTable.jsx
+++ b/web/src/components/storage/DASDTable.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2022-2023] SUSE LLC
+ * Copyright (c) [2023] SUSE LLC
  *
  * All Rights Reserved.
  *

--- a/web/src/components/storage/ProposalPage.jsx
+++ b/web/src/components/storage/ProposalPage.jsx
@@ -19,7 +19,7 @@
  * find current contact information at www.suse.com.
  */
 
-import React, { useCallback, useReducer, useEffect } from "react";
+import React, { useCallback, useReducer, useEffect, useState } from "react";
 import { Alert } from "@patternfly/react-core";
 import { Link } from "react-router-dom";
 
@@ -122,10 +122,28 @@ export default function ProposalPage() {
     );
   };
 
+  const DASDLink = () => {
+    const [show, setShow] = useState(false);
+
+    useEffect(() => {
+      client.dasd.isSupported().then(setShow);
+    }, []);
+
+    if (!show) return null;
+
+    return (
+      <Link to="/storage/dasd">
+        <Icon name="settings" size="24" />
+        Configure DASD
+      </Link>
+    );
+  };
+
   return (
     <Page title="Storage" icon="hard_drive" actionLabel="Back" actionVariant="secondary">
       <PageContent />
       <PageOptions title="Storage">
+        <DASDLink />
         <Link to="/storage/iscsi">
           <Icon name="settings" size="24" />
           Configure iSCSI

--- a/web/src/components/storage/index.js
+++ b/web/src/components/storage/index.js
@@ -28,4 +28,7 @@ export { default as ProposalSettingsForm } from "./ProposalSettingsForm";
 export { default as DeviceSelector } from "./DeviceSelector";
 export { default as ProposalActions } from "./ProposalActions";
 export { default as ProposalSummary } from "./ProposalSummary";
+export { default as DASDPage } from "./DASDPage";
+export { default as DASDTable } from "./DASDTable";
+export { default as DASDFormatProgress } from "./DASDFormatProgress";
 export { default as ISCSIPage } from "./ISCSIPage";

--- a/web/src/index.js
+++ b/web/src/index.js
@@ -37,7 +37,7 @@ import Main from "~/Main";
 import DevServerWrapper from "~/DevServerWrapper";
 import { Overview } from "~/components/overview";
 import { ProductSelectionPage } from "~/components/software";
-import { ProposalPage as StoragePage, ISCSIPage } from "~/components/storage";
+import { ProposalPage as StoragePage, DASDPage, ISCSIPage } from "~/components/storage";
 import { UsersPage } from "~/components/users";
 import { L10nPage } from "~/components/l10n";
 import { NetworkPage } from "~/components/network";
@@ -64,6 +64,7 @@ root.render(
                 <Route path="/l10n" element={<L10nPage />} />
                 <Route path="/storage" element={<StoragePage />} />
                 <Route path="/storage/iscsi" element={<ISCSIPage />} />
+                <Route path="/storage/dasd" element={<DASDPage />} />
                 <Route path="/network" element={<NetworkPage />} />
                 <Route path="/users" element={<UsersPage />} />
               </Route>

--- a/web/src/utils.js
+++ b/web/src/utils.js
@@ -162,10 +162,16 @@ const useLocalStorage = (storageKey, fallbackState) => {
   return [value, setValue];
 };
 
+const hex = (value) => {
+  const sanitizedValue = value.replaceAll(".", "");
+  return parseInt(sanitizedValue, 16);
+};
+
 export {
   noop,
   partition,
   classNames,
   useCancellablePromise,
-  useLocalStorage
+  useLocalStorage,
+  hex
 };


### PR DESCRIPTION
Now that there is a D-Bus API for DASD (see https://github.com/yast/d-installer/pull/464), the web client can offer a UI for managing these devices.

Reviewers, please note that it is a very rough first version that lacks of unit testing. However, it has been manually tested and it works acceptable enough.

---

[Screencast from 2023-03-24 14-52-39.webm](https://user-images.githubusercontent.com/7056681/227561177-691eaed5-ce96-4f84-9791-37d5de0f6245.webm)

