### PR TITLE
Improved Playwright test

### DIFF
--- a/playwright/tests/take_screenshots.spec.ts
+++ b/playwright/tests/take_screenshots.spec.ts
@@ -25,26 +25,32 @@ test.describe("The Installer", () => {
     // set screenshot size to 768x1024
     page.setViewportSize({ width: 768, height: 1024 });
 
+    // check for multiple texts in parallel, avoid waiting for timeouts
+    let action = await Promise.any([
+      page.getByText("Product selection").waitFor().then(() => "set_product"),
+      page.getByText("None authentication method").waitFor().then(() => "set_password"),
+      page.getByText("Root authentication set").waitFor().then(() => "done"),
+    ]);
+
     // optional product selection
-    await test.step("Select the product", async () => {
-      // optional product selection
-      try {
-        await page.getByText("Product selection").waitFor({ timeout: 5000 });
+    if (action === "set_product") {
+      await test.step("Select the product", async () => {
         // select openSUSE Tumbleweed
         await page.getByText("openSUSE Tumbleweed").click();
         await page.screenshot({ path: "screenshots/product-selection.png" });
         await page.getByRole("button", { name: "Select" }).click();
-      }
-      catch (error) {
-        // do not ignore other errors
-        if (error.constructor.name !== "TimeoutError") throw(error);
-      }
-    });
+      });
 
-    // the the root password must be set
-    await test.step("Set the root password", async () => {
-      try {
-        await page.getByText("None authentication method").waitFor({ timeout: 10000 });
+      // update the action for the next step
+      action = await Promise.any([
+        page.getByText("None authentication method").waitFor().then(() => "set_password"),
+        page.getByText("Root authentication set").waitFor().then(() => "done"),
+      ]);
+    }
+
+    if (action === "set_password") {
+      // the the root password must be set
+      await test.step("Set the root password", async () => {
         await page.locator("a[href='#/users']").click();
         await page.locator("#actions-for-root-password").click();
         await page.getByRole("menuitem", { name: "Set" }).click();
@@ -52,12 +58,8 @@ test.describe("The Installer", () => {
         await page.locator("#passwordConfirmation").fill("linux");
         await page.locator('button[type="submit"]').click();
         await page.getByText("Back").click();
-        }
-      catch (error) {
-        // do not ignore other errors
-        if (error.constructor.name !== "TimeoutError") throw(error);
-      }
-    });
+      });
+    }
 
     // ensure the software proposal is ready, use longer timeout,
     // refreshing the repositories takes some time

--- a/playwright/tests/take_screenshots.spec.ts
+++ b/playwright/tests/take_screenshots.spec.ts
@@ -25,15 +25,22 @@ test.describe("The Installer", () => {
     // set screenshot size to 768x1024
     page.setViewportSize({ width: 768, height: 1024 });
 
+    // optional actions done on the page
+    const actions = Object.freeze({
+      setProduct: Symbol("product"),
+      setPassword: Symbol("password"),
+      done: Symbol("done")
+    });
+
     // check for multiple texts in parallel, avoid waiting for timeouts
     let action = await Promise.any([
-      page.getByText("Product selection").waitFor().then(() => "set_product"),
-      page.getByText("None authentication method").waitFor().then(() => "set_password"),
-      page.getByText("Root authentication set").waitFor().then(() => "done"),
+      page.getByText("Product selection").waitFor().then(() => actions.setProduct),
+      page.getByText("None authentication method").waitFor().then(() => actions.setPassword),
+      page.getByText("Root authentication set").waitFor().then(() => actions.done),
     ]);
 
     // optional product selection
-    if (action === "set_product") {
+    if (action === actions.setProduct) {
       await test.step("Select the product", async () => {
         // select openSUSE Tumbleweed
         await page.getByText("openSUSE Tumbleweed").click();
@@ -43,12 +50,12 @@ test.describe("The Installer", () => {
 
       // update the action for the next step
       action = await Promise.any([
-        page.getByText("None authentication method").waitFor().then(() => "set_password"),
-        page.getByText("Root authentication set").waitFor().then(() => "done"),
+        page.getByText("None authentication method").waitFor().then(() => actions.setPassword),
+        page.getByText("Root authentication set").waitFor().then(() => actions.done),
       ]);
     }
 
-    if (action === "set_password") {
+    if (action === actions.setPassword) {
       // the the root password must be set
       await test.step("Set the root password", async () => {
         await page.locator("a[href='#/users']").click();


### PR DESCRIPTION
## Problem

The Playwright screenshoting test is generic and handles some optional steps. For example the [product selection dialog](https://github.com/yast/d-installer/blob/master/doc/images/screenshots/product-selection.png) is skipped when there is only one product defined.

But the current implementation relies on timeout when the dialog is not displayed, that makes the test run unnecessary longer.

## Solution

- Avoid timeouts by running waits in parallel using [Promise.any](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/any) - it returns the first `Promise` which succeeds, we can check for multiple objects on the page in parallel
- Also avoids handling the timeout errors, makes the code cleaner


## Testing

- Tested manually, taking screenshots still works :smile: 


